### PR TITLE
Update analysis without unpacking

### DIFF
--- a/src/intercom/back_end_binding.py
+++ b/src/intercom/back_end_binding.py
@@ -123,17 +123,9 @@ class InterComBackEndReAnalyzeTask(InterComListener):
         return task
 
 
-class InterComBackEndUpdateTask(InterComListener):
+class InterComBackEndUpdateTask(InterComBackEndReAnalyzeTask):
 
     CONNECTION_TYPE = "update_task"
-
-    def additional_setup(self, config=None):
-        self.fs_organizer = FS_Organizer(config=config)
-
-    def post_processing(self, task, task_id):
-        file_path = self.fs_organizer.generate_path(task)
-        task.set_file_path(file_path)
-        return task
 
 
 class InterComBackEndCompareTask(InterComListener):

--- a/src/intercom/back_end_binding.py
+++ b/src/intercom/back_end_binding.py
@@ -50,7 +50,7 @@ class InterComBackEndBinding(object):
         self._start_listener(InterComBackEndAnalysisTask, self.unpacking_service.add_task)
 
     def start_re_analyze_listener(self):
-        self._start_listener(InterComBackEndReAnalyzeTask, self.unpacking_service.add_task)
+        self._start_listener(InterComBackEndReAnalyzeTask, self.analysis_service.add_update_task)
 
     def start_compare_listener(self):
         self._start_listener(InterComBackEndCompareTask, self.compare_service.add_task)

--- a/src/intercom/back_end_binding.py
+++ b/src/intercom/back_end_binding.py
@@ -39,6 +39,7 @@ class InterComBackEndBinding(object):
         self.start_raw_download_listener()
         self.start_tar_repack_listener()
         self.start_binary_search_listener()
+        self.start_update_listener()
 
     def shutdown(self):
         self.stop_condition.value = 1
@@ -50,7 +51,10 @@ class InterComBackEndBinding(object):
         self._start_listener(InterComBackEndAnalysisTask, self.unpacking_service.add_task)
 
     def start_re_analyze_listener(self):
-        self._start_listener(InterComBackEndReAnalyzeTask, self.analysis_service.add_update_task)
+        self._start_listener(InterComBackEndReAnalyzeTask, self.unpacking_service.add_task)
+
+    def start_update_listener(self):
+        self._start_listener(InterComBackEndUpdateTask, self.analysis_service.add_update_task)
 
     def start_compare_listener(self):
         self._start_listener(InterComBackEndCompareTask, self.compare_service.add_task)
@@ -109,6 +113,19 @@ class InterComBackEndAnalysisTask(InterComListener):
 class InterComBackEndReAnalyzeTask(InterComListener):
 
     CONNECTION_TYPE = "re_analyze_task"
+
+    def additional_setup(self, config=None):
+        self.fs_organizer = FS_Organizer(config=config)
+
+    def post_processing(self, task, task_id):
+        file_path = self.fs_organizer.generate_path(task)
+        task.set_file_path(file_path)
+        return task
+
+
+class InterComBackEndUpdateTask(InterComListener):
+
+    CONNECTION_TYPE = "update_task"
 
     def additional_setup(self, config=None):
         self.fs_organizer = FS_Organizer(config=config)

--- a/src/intercom/common_mongo_binding.py
+++ b/src/intercom/common_mongo_binding.py
@@ -23,6 +23,7 @@ class InterComMongoInterface(MongoInterface):
         'analysis_task',
         'analysis_plugins',
         're_analyze_task',
+        'update_task',
         'compare_task',
         'file_delete_task',
         'raw_download_task', 'raw_download_task_resp',

--- a/src/intercom/front_end_binding.py
+++ b/src/intercom/front_end_binding.py
@@ -13,8 +13,11 @@ class InterComFrontEndBinding(InterComMongoInterface):
     def add_analysis_task(self, fw):
         self.connections['analysis_task']['fs'].put(pickle.dumps(fw), filename=fw.get_uid())
 
-    def add_re_analyze_task(self, fw):
-        self.connections['re_analyze_task']['fs'].put(pickle.dumps(fw), filename=fw.get_uid())
+    def add_re_analyze_task(self, fw, unpack=True):
+        if unpack:
+            self.connections['re_analyze_task']['fs'].put(pickle.dumps(fw), filename=fw.get_uid())
+        else:
+            self.connections['update_task']['fs'].put(pickle.dumps(fw), filename=fw.get_uid())
 
     def add_compare_task(self, compare_id, force=False):
         self.connections['compare_task']['fs'].put(pickle.dumps((compare_id, force)), filename=compare_id)

--- a/src/scheduler/Analysis.py
+++ b/src/scheduler/Analysis.py
@@ -53,6 +53,14 @@ class AnalysisScheduler(object):
         self.process_queue.close()
         logging.info('Analysis System offline')
 
+    def add_update_task(self, fo):
+        for included_file in self.db_backend_service.get_list_of_all_included_files(fo):
+            child = self.db_backend_service.get_object(included_file)
+            child.scheduled_analysis = fo.scheduled_analysis
+            shuffle(child.scheduled_analysis)
+            self.check_further_process_or_complete(child)
+        self.check_further_process_or_complete(fo)
+
     def add_task(self, fo):
         '''
         This function should be used to add a new firmware object to the scheduler

--- a/src/test/acceptance/rest/test_rest_download.py
+++ b/src/test/acceptance/rest/test_rest_download.py
@@ -31,14 +31,9 @@ class TestIntegrationRestDownloadFirmware(TestAcceptanceBase):
         self.assertIn('"file_name": "{}"'.format(self.test_fw.file_name).encode(), rv.data, "rest download response incorrect")
         self.assertIn('"SHA256": "{}"'.format(self.test_fw.sha256).encode(), rv.data, "rest download response incorrect")
 
-    def _rest_update_analysis_bad_analysis(self):
-        rv = self.test_client.put('/rest/firmware/{}?update={}'.format(self.test_fw.uid, urllib.parse.quote('["unknown_system"]')), follow_redirects=True)
-        self.assertIn('Unknown analysis system'.encode(), rv.data, "rest analysis update should break on request of non existing system")
-
     def test_run_from_upload_to_show_analysis(self):
         self.test_fw = create_test_firmware(device_class="test class", device_name="test device", vendor="test vendor")
         self.db_backend.add_firmware(self.test_fw)
 
         self._rest_search()
         self._rest_download()
-        self._rest_update_analysis_bad_analysis()

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -189,7 +189,7 @@ class DatabaseMock:
     def add_analysis_task(self, task):
         self.tasks.append(task)
 
-    def add_re_analyze_task(self, task):
+    def add_re_analyze_task(self, task, unpack=True):
         self.tasks.append(task)
 
     def add_compare_task(self, task, force=None):

--- a/src/test/integration/intercom/test_backend_scheduler.py
+++ b/src/test/integration/intercom/test_backend_scheduler.py
@@ -11,7 +11,7 @@ TMP_DIR = TemporaryDirectory(prefix='faf_test_')
 
 
 # This number must be changed, whenever a listener is added or removed
-NUMBER_OF_LISTENERS = 6
+NUMBER_OF_LISTENERS = 7
 
 
 class ServiceMock():

--- a/src/test/integration/intercom/test_backend_scheduler.py
+++ b/src/test/integration/intercom/test_backend_scheduler.py
@@ -49,6 +49,9 @@ class AnalysisServiceMock():
     def __init__(self, config=None):
         pass
 
+    def add_update_task(self, fo):
+        pass
+
     def get_plugin_dict(self):
         return {}
 

--- a/src/test/unit/web_interface/rest/test_rest_firmware.py
+++ b/src/test/unit/web_interface/rest/test_rest_firmware.py
@@ -109,3 +109,12 @@ def test_request_update_missing_parameter(test_app):
     result = decode_response(test_app.put('/rest/firmware/{}'.format(TEST_FW.uid)))
     assert result['status'] == 1
     assert 'missing parameter: update' in result['error_message']
+
+
+def test_request_with_unpacking(test_app):
+    scheduled_analysis = ['unpacker', 'optional_plugin']
+    requested_analysis = json.dumps(scheduled_analysis)
+    result = decode_response(test_app.put('/rest/firmware/{}?update={}'.format(TEST_FW.uid, quote(requested_analysis))))
+    assert result['status'] == 0
+    assert sorted(result['request']['update']) == sorted(scheduled_analysis)
+    assert 'unpacker' in result['request']['update']

--- a/src/web_interface/rest/rest_firmware.py
+++ b/src/web_interface/rest/rest_firmware.py
@@ -92,6 +92,11 @@ class RestFirmware(Resource):
             firmware = connection.get_firmware(uid)
         if not firmware:
             return error_message('No firmware with UID {} found'.format(uid), self.URL, dict(uid=uid))
+
+        unpack = 'unpacker' in update
+        while 'unpacker' in update:
+            update.remove('unpacker')
+
         firmware.scheduled_analysis = update
 
         with ConnectTo(InterComFrontEndBinding, self.config) as intercom:
@@ -99,6 +104,8 @@ class RestFirmware(Resource):
             for item in update:
                 if item not in supported_plugins:
                     return error_message('Unknown analysis system \'{}\''.format(item), self.URL, dict(uid=uid, update=update))
-            intercom.add_re_analyze_task(firmware)
+            intercom.add_re_analyze_task(firmware, unpack)
 
+        if unpack:
+            update.append('unpacker')
         return success_message({}, self.URL, dict(uid=uid, update=update))


### PR DESCRIPTION
Allows adding or updating an analysis to a firmware without running mandatory plugins or unpacker.
Feature is implemented as REST-only at the moment.
Implementation:
- added intercom listener to differentiate between updating w/, w/o unpacker
- REST endpoint checks if unpacker is requested, triggers intercom accordingly