### PR TITLE
Rest firmware supports recursive search

### DIFF
--- a/src/helperFunctions/rest.py
+++ b/src/helperFunctions/rest.py
@@ -70,6 +70,20 @@ def get_query(request_parameter):
     return query if query else dict()
 
 
+def get_recursive(request_parameter):
+    try:
+        recursive = request_parameter.get('recursive')
+        recursive = json.loads(recursive if recursive else 'false')
+    except (AttributeError, KeyError):
+        return False
+    except json.JSONDecodeError:
+        raise ValueError('recursive must be true or false')
+
+    if recursive not in [True, False]:
+        raise ValueError('recursive must be true or false')
+    return recursive
+
+
 def get_update(request_parameter):
     try:
         update = request_parameter.get('update')

--- a/src/storage/db_interface_frontend.py
+++ b/src/storage/db_interface_frontend.py
@@ -261,7 +261,9 @@ class FrontEndDbInterface(MongoInterfaceCommon):
 
         return visualize_complete_tree(stripped_field_strings)
 
-    def rest_get_firmware_uids(self, offset, limit, query=None):
+    def rest_get_firmware_uids(self, offset, limit, query=None, recursive=False):
+        if recursive:
+            return self.generic_search(search_dict=query, skip=offset, limit=limit, only_fo_parent_firmware=True)
         return self.rest_get_object_uids(self.firmwares, offset, limit, query if query else dict())
 
     def rest_get_file_object_uids(self, offset, limit, query=None):

--- a/src/test/acceptance/test_advanced_search.py
+++ b/src/test/acceptance/test_advanced_search.py
@@ -1,6 +1,9 @@
-from test.common_helper import create_test_firmware, create_test_file_object
-from test.acceptance.base import TestAcceptanceBase
+import json
+from urllib.parse import quote
+
 from storage.db_interface_backend import BackEndDbInterface
+from test.acceptance.base import TestAcceptanceBase
+from test.common_helper import create_test_firmware, create_test_file_object
 
 
 class TestAcceptanceAdvancedSearch(TestAcceptanceBase):
@@ -9,14 +12,14 @@ class TestAcceptanceAdvancedSearch(TestAcceptanceBase):
         super().setUp()
         self.db_backend_interface = BackEndDbInterface(self.config)
         self.config['database'] = {}
-        self.config['database']['results_per_page'] = "10"
+        self.config['database']['results_per_page'] = '10'
         self.parent_fw = create_test_firmware()
         self.child_fo = create_test_file_object()
         uid = self.parent_fw.get_uid()
-        self.child_fo.virtual_file_path = {uid: ["|{}|/folder/{}".format(uid, self.child_fo.file_name)]}
+        self.child_fo.virtual_file_path = {uid: ['|{}|/folder/{}'.format(uid, self.child_fo.file_name)]}
         self.db_backend_interface.add_object(self.parent_fw)
-        self.child_fo.processed_analysis["unpacker"] = {}
-        self.child_fo.processed_analysis["unpacker"]["plugin_used"] = "test"
+        self.child_fo.processed_analysis['unpacker'] = {}
+        self.child_fo.processed_analysis['unpacker']['plugin_used'] = 'test'
         self.db_backend_interface.add_object(self.child_fo)
 
     def tearDown(self):
@@ -25,25 +28,31 @@ class TestAcceptanceAdvancedSearch(TestAcceptanceBase):
 
     def test_advanced_search_get(self):
         rv = self.test_client.get('/database/advanced_search')
-        assert b"<h2>Advanced Search</h2>" in rv.data
+        assert b'<h2>Advanced Search</h2>' in rv.data
 
     def test_advanced_search(self):
         rv = self.test_client.post('/database/advanced_search', content_type='multipart/form-data',
-                                   data={"advanced_search": "{}"}, follow_redirects=True)
-        assert b"Please enter a valid search request" not in rv.data
+                                   data={'advanced_search': '{}'}, follow_redirects=True)
+        assert b'Please enter a valid search request' not in rv.data
         assert self.parent_fw.get_uid().encode() in rv.data
         assert self.child_fo.get_uid().encode() not in rv.data
 
     def test_advanced_search_file_object(self):
-        rv = self.test_client.post('/database/advanced_search', content_type='multipart/form-data', follow_redirects=True,
-                                   data={"advanced_search": '{{"_id": "{}"}}'.format(self.child_fo.get_uid())})
-        assert b"Please enter a valid search request" not in rv.data
+        rv = self.test_client.post('/database/advanced_search', content_type='multipart/form-data',
+                                   data={'advanced_search': json.dumps({'_id': self.child_fo.get_uid()})}, follow_redirects=True)
+        assert b'Please enter a valid search request' not in rv.data
         assert self.parent_fw.get_uid().encode() not in rv.data
         assert self.child_fo.get_uid().encode() in rv.data
 
     def test_advanced_search_only_firmwares(self):
-        rv = self.test_client.post('/database/advanced_search', content_type='multipart/form-data', follow_redirects=True,
-                                   data={"advanced_search": '{{"_id": "{}"}}'.format(self.child_fo.get_uid()), "only_firmwares": "True"})
-        assert b"Please enter a valid search request" not in rv.data
+        rv = self.test_client.post('/database/advanced_search', content_type='multipart/form-data',
+                                   data={'advanced_search': json.dumps({'_id': self.child_fo.get_uid()}), 'only_firmwares': 'True'}, follow_redirects=True)
+        assert b'Please enter a valid search request' not in rv.data
         assert self.parent_fw.get_uid().encode() in rv.data
         assert self.child_fo.get_uid().encode() not in rv.data
+
+    def test_rest_recursive_firmware_search(self):
+        query = quote(json.dumps({'file_name': self.child_fo.file_name}))
+        response = self.test_client.get('/rest/firmware?recursive=true&query={}'.format(query)).data
+        assert b'error_message' not in response
+        assert self.parent_fw.uid.encode() in response

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -249,7 +249,7 @@ class DatabaseMock:
         else:
             raise Exception("UID not found: {}".format(uid))
 
-    def rest_get_firmware_uids(self, offset, limit, query=None):
+    def rest_get_firmware_uids(self, offset, limit, query=None, recursive=False):
         if (offset != 0) or (limit != 0):
             return []
         else:

--- a/src/test/unit/web_interface/rest/test_rest_firmware.py
+++ b/src/test/unit/web_interface/rest/test_rest_firmware.py
@@ -3,7 +3,7 @@ from base64 import standard_b64encode
 from urllib.parse import quote
 
 from test.common_helper import TEST_FW
-from .conftest import decode_response
+from test.unit.web_interface.rest.conftest import decode_response
 
 
 def test_successful_request(test_app):
@@ -109,3 +109,13 @@ def test_request_update_missing_parameter(test_app):
     result = decode_response(test_app.put('/rest/firmware/{}'.format(TEST_FW.uid)))
     assert result['status'] == 1
     assert 'missing parameter: update' in result['error_message']
+
+
+def test_request_with_bad_recursive_flag(test_app):
+    result = decode_response(test_app.get('/rest/firmware?recursive=true'))
+    assert result['status'] == 1
+    assert 'only permissible with non-empty query' in result['error_message']
+
+    query = json.dumps({'processed_analysis.file_type.full': {'$regex': 'arm', '$options': 'si'}})
+    result = decode_response(test_app.get('/rest/firmware?recursive=true&query={}'.format(quote(query))))
+    assert result['status'] == 0

--- a/src/web_interface/rest/rest_firmware.py
+++ b/src/web_interface/rest/rest_firmware.py
@@ -30,6 +30,8 @@ class RestFirmware(Resource):
                 query = get_query(request.args)
             except ValueError as value_error:
                 return error_message(str(value_error), self.URL, request_data=dict(query=request.args.get('query'), recursive=request.args.get('recursive')))
+            if recursive and not query:
+                return error_message('recursive search is only permissible with non-empty query', self.URL, request_data=dict(query=request.args.get('query'), recursive=request.args.get('recursive')))
 
             try:
                 with ConnectTo(FrontEndDbInterface, self.config) as connection:

--- a/src/web_interface/rest/rest_firmware.py
+++ b/src/web_interface/rest/rest_firmware.py
@@ -6,7 +6,7 @@ from flask_restful import Resource
 
 from helperFunctions.mongo_task_conversion import convert_analysis_task_to_fw_obj
 from helperFunctions.object_conversion import create_meta_dict
-from helperFunctions.rest import get_paging, get_query, success_message, error_message, convert_rest_request, get_update
+from helperFunctions.rest import get_paging, get_query, success_message, error_message, convert_rest_request, get_update, get_recursive
 from helperFunctions.web_interface import ConnectTo
 from intercom.front_end_binding import InterComFrontEndBinding
 from storage.db_interface_frontend import FrontEndDbInterface
@@ -26,17 +26,18 @@ class RestFirmware(Resource):
             offset, limit = paging
 
             try:
+                recursive = get_recursive(request.args)
                 query = get_query(request.args)
             except ValueError as value_error:
-                return error_message(str(value_error), self.URL, request_data=dict(query=request.args.get('query')))
+                return error_message(str(value_error), self.URL, request_data=dict(query=request.args.get('query'), recursive=request.args.get('recursive')))
 
             try:
                 with ConnectTo(FrontEndDbInterface, self.config) as connection:
-                    uids = connection.rest_get_firmware_uids(offset=offset, limit=limit, query=query)
+                    uids = connection.rest_get_firmware_uids(offset=offset, limit=limit, query=query, recursive=recursive)
 
-                return success_message(dict(uids=uids), self.URL, dict(offset=offset, limit=limit, query=query))
+                return success_message(dict(uids=uids), self.URL, dict(offset=offset, limit=limit, query=query, recursive=recursive))
             except Exception:
-                return error_message('Unknown exception on request', self.URL, dict(offset=offset, limit=limit, query=query))
+                return error_message('Unknown exception on request', self.URL, dict(offset=offset, limit=limit, query=query, recursive=recursive))
         else:
             with ConnectTo(FrontEndDbInterface, self.config) as connection:
                 firmware = connection.get_firmware(uid)


### PR DESCRIPTION
Implementation using the existing generic_search function.
Recursive search is not allowed for empty queries to prevent querying the complete database.