### PR TITLE
Add parameter and lots of tests

### DIFF
--- a/src/helperFunctions/rest.py
+++ b/src/helperFunctions/rest.py
@@ -67,6 +67,8 @@ def get_query(request_parameter):
         return dict()
     except json.JSONDecodeError:
         raise ValueError('Query must be a json document')
+    if not isinstance(query, dict):
+        raise ValueError('Query must be a json document')
     return query if query else dict()
 
 
@@ -97,3 +99,17 @@ def get_update(request_parameter):
     if not update:
         raise ValueError('Update has to be specified')
     return update
+
+
+def get_summary_flag(request_parameter):
+    try:
+        summary = request_parameter.get('summary')
+        summary = json.loads(summary if summary else 'false')
+    except (AttributeError, KeyError):
+        return False
+    except json.JSONDecodeError:
+        raise ValueError('summary must be true or false')
+
+    if summary not in [True, False]:
+        raise ValueError('summary must be true or false')
+    return summary

--- a/src/test/integration/web_interface/rest/test_rest_firmware.py
+++ b/src/test/integration/web_interface/rest/test_rest_firmware.py
@@ -130,3 +130,10 @@ class TestRestFirmware(RestTestBase):
         rv = self.test_client.put('/rest/firmware/{}?update=not_a_list'.format(test_firmware.uid), follow_redirects=True)
         assert b'"status": 1' in rv.data
         assert b'has to be a list' in rv.data
+
+    def test_rest_download_with_summary(self):
+        test_firmware = create_test_firmware(device_class='test class', device_name='test device', vendor='test vendor')
+        self.db_backend.add_firmware(test_firmware)
+
+        request_with_summary = self.test_client.get('/rest/firmware/{}?summary=true'.format(test_firmware.uid), follow_redirects=True)
+        assert test_firmware.processed_analysis['dummy']['summary'][0].encode() in request_with_summary.data

--- a/src/test/unit/helperFunctions/test_rest.py
+++ b/src/test/unit/helperFunctions/test_rest.py
@@ -1,5 +1,6 @@
-from helperFunctions.rest import success_message, error_message, get_current_gmt, convert_rest_request
 import pytest
+
+from helperFunctions.rest import success_message, error_message, get_current_gmt, convert_rest_request, get_recursive, get_summary_flag, get_update, get_query, get_paging
 
 
 def test_time_is_int():
@@ -60,3 +61,78 @@ def test_convert_rest_request_fails(data):
 @pytest.mark.parametrize('data', [b'{}', b'{"param": true}', b'{"a": 1, "b": {"c": 3}}'])
 def test_convert_rest_request_succeeds(data):
     assert isinstance(convert_rest_request(data), dict)
+
+
+def test_get_recursive():
+    assert not get_recursive(None)
+
+    with pytest.raises(ValueError):
+        get_recursive(dict(recursive='bad_string'))
+
+    with pytest.raises(ValueError):
+        get_recursive(dict(recursive='2'))
+
+    no_flag = get_recursive(dict())
+    assert not no_flag
+
+    false_result = get_recursive(dict(recursive='false'))
+    assert not false_result
+
+    good_result = get_recursive(dict(recursive='true'))
+    assert good_result
+
+
+def test_get_summary_flag():
+    assert not get_summary_flag(None)
+
+    with pytest.raises(ValueError):
+        get_summary_flag(dict(summary='bad_string'))
+
+    with pytest.raises(ValueError):
+        get_summary_flag(dict(summary='2'))
+
+    no_flag = get_summary_flag(dict())
+    assert not no_flag
+
+    false_result = get_summary_flag(dict(summary='false'))
+    assert not false_result
+
+    good_result = get_summary_flag(dict(summary='true'))
+    assert good_result
+
+
+@pytest.mark.parametrize('arguments', [None, dict(), dict(update='bad_string'), dict(update='[]'), dict(update='{}')])
+def test_get_update_bad(arguments):
+    with pytest.raises(ValueError):
+        get_update(arguments)
+
+
+def test_get_update_success():
+    assert get_update(dict(update='["any_plugin"]')) == ['any_plugin']
+
+
+@pytest.mark.parametrize('arguments', [dict(query='bad_string'), dict(query='[]')])
+def test_get_query_bad(arguments):
+    with pytest.raises(ValueError):
+        get_query(arguments)
+
+
+def test_get_query():
+    assert not get_query(None)
+
+    assert get_query(dict(query='{"a": "b"}')) == {'a': 'b'}
+
+
+@pytest.mark.parametrize('arguments', [(None, None), ('1', None), ('A', 'B')])
+def test_get_paging_bad_arguments(arguments):
+    offset, limit = arguments
+    paging, success = get_paging(dict(offset=offset, limit=limit))
+    assert not success
+
+
+def test_get_paging_success():
+    paging, success = get_paging(dict(offset=0, limit=1))
+    assert success and paging == (0, 1)
+
+    paging, success = get_paging(dict(offset='0', limit='1'))
+    assert success and paging == (0, 1)

--- a/src/test/unit/web_interface/rest/test_rest_firmware.py
+++ b/src/test/unit/web_interface/rest/test_rest_firmware.py
@@ -129,3 +129,8 @@ def test_request_with_bad_recursive_flag(test_app):
     query = json.dumps({'processed_analysis.file_type.full': {'$regex': 'arm', '$options': 'si'}})
     result = decode_response(test_app.get('/rest/firmware?recursive=true&query={}'.format(quote(query))))
     assert result['status'] == 0
+
+
+def test_request_with_summary_parameter(test_app):
+    result = decode_response(test_app.get('/rest/firmware/{}?summary=true'.format(TEST_FW.uid)))
+    assert 'firmware' in result


### PR DESCRIPTION
When adding `?summary=true` to a firmware request, the summaries are collected from all child objects.