### PR TITLE
Moved flask_security dependend function to another module

### DIFF
--- a/src/helperFunctions/web_interface.py
+++ b/src/helperFunctions/web_interface.py
@@ -2,14 +2,11 @@ import colorsys
 import json
 import os
 import re
-
-from flask_security.core import AnonymousUser
-from common_helper_files import get_binary_from_file
 from itertools import chain
 
-from helperFunctions.fileSystem import get_template_dir
-from web_interface.security.privileges import PRIVILEGES
+from common_helper_files import get_binary_from_file
 
+from helperFunctions.fileSystem import get_template_dir
 
 SPECIAL_CHARACTERS = 'ÄäÀàÁáÂâÃãÅåǍǎĄąĂăÆæĀāÇçĆćĈĉČčĎđĐďðÈèÉéÊêËëĚěĘęĖėĒēĜĝĢģĞğĤĥÌìÍíÎîÏïıĪīĮįĴĵĶķĹĺĻļŁłĽľÑñŃńŇňŅņÖöÒòÓóÔôÕõŐőØøŒœŔŕŘřẞßŚśŜŝŞşŠšȘș' \
                      'ŤťŢţÞþȚțÜüÙùÚúÛûŰűŨũŲųŮůŪūŴŵÝýŸÿŶŷŹźŽžŻż'
@@ -79,11 +76,3 @@ class ConnectTo:
 def get_template_as_string(view_name):
     path = os.path.join(get_template_dir(), view_name)
     return get_binary_from_file(path).decode('utf-8')
-
-
-def _auth_is_disabled(user):
-    return isinstance(user._get_current_object(), AnonymousUser)
-
-
-def user_has_privilege(user, privilege='delete'):
-    return _auth_is_disabled(user) or any(user.has_role(role) for role in PRIVILEGES[privilege])

--- a/src/test/unit/helperFunctions/test_web_interface.py
+++ b/src/test/unit/helperFunctions/test_web_interface.py
@@ -4,7 +4,8 @@ import pytest
 from flask_security.core import AnonymousUser, UserMixin, RoleMixin
 from werkzeug.local import LocalProxy
 
-from helperFunctions.web_interface import filter_out_illegal_characters, user_has_privilege
+from helperFunctions.web_interface import filter_out_illegal_characters
+from web_interface.security.authentication import user_has_privilege
 
 
 @pytest.mark.parametrize('input_data, expected', [

--- a/src/web_interface/components/analysis_routes.py
+++ b/src/web_interface/components/analysis_routes.py
@@ -10,7 +10,8 @@ from flask_login.utils import current_user
 from helperFunctions.dataConversion import none_to_none
 from helperFunctions.fileSystem import get_src_dir
 from helperFunctions.mongo_task_conversion import check_for_errors, convert_analysis_task_to_fw_obj, create_re_analyze_task
-from helperFunctions.web_interface import ConnectTo, get_template_as_string, overwrite_default_plugins, user_has_privilege
+from helperFunctions.web_interface import ConnectTo, get_template_as_string, overwrite_default_plugins
+from web_interface.security.authentication import user_has_privilege
 from intercom.front_end_binding import InterComFrontEndBinding
 from objects.firmware import Firmware
 from storage.db_interface_admin import AdminDbInterface

--- a/src/web_interface/security/authentication.py
+++ b/src/web_interface/security/authentication.py
@@ -1,8 +1,10 @@
 import base64
 import os
 
-from flask_security import Security, SQLAlchemyUserDatastore, UserMixin, RoleMixin
+from flask_security import Security, SQLAlchemyUserDatastore, UserMixin, RoleMixin, AnonymousUser
 from flask_sqlalchemy import SQLAlchemy
+
+from web_interface.security.privileges import PRIVILEGES
 
 
 def add_flask_security_to_app(app, config):
@@ -58,3 +60,11 @@ def _add_configuration_to_app(app, config):
 def _build_api_key():
     raw_key = os.urandom(32)
     return base64.standard_b64encode(raw_key).decode()
+
+
+def _auth_is_disabled(user):
+    return isinstance(user._get_current_object(), AnonymousUser)
+
+
+def user_has_privilege(user, privilege='delete'):
+    return _auth_is_disabled(user) or any(user.has_role(role) for role in PRIVILEGES[privilege])


### PR DESCRIPTION
On backend-only installations, the import of ConnectTo causes an import error since flask_security is not installed. Thus the auth functions is moved out of place.