### PR TITLE
fixed issue with bad directory cleanup

### DIFF
--- a/src/storage/binary_service.py
+++ b/src/storage/binary_service.py
@@ -3,7 +3,7 @@ import logging
 from common_helper_files.fail_safe_file_operations import get_binary_from_file
 
 from storage.db_interface_common import MongoInterfaceCommon
-from unpacker.tar_repack import tarRepack
+from unpacker.tar_repack import TarRepack
 
 
 class BinaryService(object):
@@ -28,7 +28,7 @@ class BinaryService(object):
         if tmp is None:
             return None, None
         else:
-            repack_service = tarRepack(config=self.config)
+            repack_service = TarRepack(config=self.config)
             tar = repack_service.tar_repack(tmp['file_path'])
             name = "{}.tar.gz".format(tmp['file_name'])
             return (tar, name)

--- a/src/test/unit/unpacker/test_tar_repack.py
+++ b/src/test/unit/unpacker/test_tar_repack.py
@@ -4,7 +4,7 @@ import os
 import unittest
 
 from helperFunctions.fileSystem import get_test_data_dir
-from unpacker.tar_repack import tarRepack
+from unpacker.tar_repack import TarRepack
 from helperFunctions.config import get_config_for_testing
 
 
@@ -12,7 +12,7 @@ class Test_unpacker_tar_repack(unittest.TestCase):
 
     def setUp(self):
         self.config = get_config_for_testing()
-        self.repack_service = tarRepack(config=self.config)
+        self.repack_service = TarRepack(config=self.config)
 
     def tearDown(self):
         gc.collect()

--- a/src/unpacker/tar_repack.py
+++ b/src/unpacker/tar_repack.py
@@ -8,16 +8,31 @@ from common_helper_files import get_binary_from_file
 from unpacker.unpackBase import UnpackBase
 
 
-class tarRepack(UnpackBase):
+class TarRepack(UnpackBase):
 
     def tar_repack(self, file_path):
-        extraction_dir = TemporaryDirectory(prefix='FAF_tar_repack')
-        container_storage = TemporaryDirectory(prefix='FAF_tar_repack')
-        self.extract_files_from_file(file_path, extraction_dir.name)
-        out_file_path = os.path.join(container_storage.name, 'download.tar.gz')
-        output = Popen('tar -C {} -cvzf {} .'.format(extraction_dir.name, out_file_path), shell=True, stdout=PIPE).stdout.read().decode()
-        logging.debug('tar -cvzf:\n {}'.format(output))
-        tar = get_binary_from_file(out_file_path)
-        extraction_dir.cleanup()
-        container_storage.cleanup()
-        return tar
+        extraction_directory = TemporaryDirectory(prefix='FAF_tar_repack')
+        self.extract_files_from_file(file_path, extraction_directory.name)
+
+        archive_directory = TemporaryDirectory(prefix='FAF_tar_repack')
+        archive_path = os.path.join(archive_directory.name, 'download.tar.gz')
+        tar_binary = self._repack_extracted_files(extraction_directory, archive_path)
+
+        self._cleanup_directories(archive_directory, extraction_directory)
+
+        return tar_binary
+
+    @staticmethod
+    def _repack_extracted_files(extraction_dir, out_file_path):
+        with Popen('tar -C {} -cvzf {} .'.format(extraction_dir.name, out_file_path), shell=True, stdout=PIPE) as process:
+            output = process.stdout.read().decode()
+            logging.debug('tar -cvzf:\n {}'.format(output))
+
+        return get_binary_from_file(out_file_path)
+
+    def _cleanup_directories(self, archive_directory, extraction_directory):
+        self.change_owner_back_to_me(extraction_directory.name, permissions='u+rw')
+        extraction_directory.cleanup()
+
+        self.change_owner_back_to_me(archive_directory.name, permissions='u+rw')
+        archive_directory.cleanup()

--- a/src/unpacker/unpackBase.py
+++ b/src/unpacker/unpackBase.py
@@ -88,10 +88,10 @@ class UnpackBase(object):
 
     def change_owner_back_to_me(self, directory=None, permissions='u+r'):
         with Popen('sudo chown -R {}:{} {}'.format(getuid(), getgid(), directory), shell=True, stdout=PIPE, stderr=PIPE) as pl:
-            pl.communicate()[0].decode()
+            pl.communicate()
         self.grant_read_permission(directory, permissions)
 
     @staticmethod
     def grant_read_permission(directory, permissions):
         with Popen('chmod --recursive {} {}'.format(permissions, directory), shell=True, stdout=PIPE, stderr=PIPE) as pl:
-            pl.communicate()[0].decode()
+            pl.communicate()

--- a/src/unpacker/unpackBase.py
+++ b/src/unpacker/unpackBase.py
@@ -86,13 +86,12 @@ class UnpackBase(object):
         meta_data['analysis_date'] = time()
         return get_files_in_dir(tmp_dir), meta_data
 
-    def change_owner_back_to_me(self, directory=None):
-        uid = getuid()
-        gid = getgid()
-        with Popen('sudo chown -R {}:{} {}'.format(uid, gid, directory), shell=True, stdout=PIPE, stderr=PIPE) as pl:
+    def change_owner_back_to_me(self, directory=None, permissions='u+r'):
+        with Popen('sudo chown -R {}:{} {}'.format(getuid(), getgid(), directory), shell=True, stdout=PIPE, stderr=PIPE) as pl:
             pl.communicate()[0].decode()
-        self.grant_read_permission(directory)
+        self.grant_read_permission(directory, permissions)
 
-    def grant_read_permission(self, directory=None):
-        with Popen('chmod --recursive u+r {}'.format(directory), shell=True, stdout=PIPE, stderr=PIPE) as pl:
+    @staticmethod
+    def grant_read_permission(directory, permissions):
+        with Popen('chmod --recursive {} {}'.format(permissions, directory), shell=True, stdout=PIPE, stderr=PIPE) as pl:
             pl.communicate()[0].decode()


### PR DESCRIPTION
There were some problems with downloading tar.gz archives.
This stemmed from files being extracted as root-owned or missing write permissions.

The problem is fixed via an already existing function in the `unpackBase`.
Code was refactored though.