### PR TITLE
code preview hightlighting added

### DIFF
--- a/src/bootstrap/bootstrap_frontend.sh
+++ b/src/bootstrap/bootstrap_frontend.sh
@@ -56,11 +56,24 @@ wget -nc https://github.com/vakata/jstree/zipball/3.3.2
 unzip 3.3.2
 rm 3.3.2
 mv vakata* jstree
+# download highlight.js
+highlight_js_url=https://highlightjs.org/download/
+highlight_js_dir=highlight.js
+highlight_js_zip=highlight.js.zip
+if [ -d "${highlight_js_dir}" ]; then
+  rm -r ${highlight_js_dir}
+fi
+csrftoken=$(curl --silent -c - ${highlight_js_url} | grep csrftoken | awk {'print $7'})
+wget ${highlight_js_url} --header="Host: highlightjs.org" --header="User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0" --header="Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8" --header="Accept-Language: en-GB,en;q=0.5" --header="Accept-Encoding: gzip, deflate, br" --header="Referer: https://highlightjs.org/download/" --header="Content-Type: application/x-www-form-urlencoded" --header="Cookie: csrftoken=${csrftoken}" --header="DNT: 1" --header="Connection: keep-alive" --header="Upgrade-Insecure-Requests: 1" --post-data="apache.js=on&bash.js=on&coffeescript.js=on&cpp.js=on&cs.js=on&csrfmiddlewaretoken=${csrftoken}&css.js=on&diff.js=on&http.js=on&ini.js=on&java.js=on&javascript.js=on&json.js=on&makefile.js=on&markdown.js=on&nginx.js=on&objectivec.js=on&perl.js=on&php.js=on&python.js=on&ruby.js=on&shell.js=on&sql.js=on&xml.js=on" -O ${highlight_js_zip}
+unzip ${highlight_js_zip} -d ${highlight_js_dir}
+rm ${highlight_js_zip}
 # download angularJS
 wget -nc https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.min.js
 # download charts.js
 wget -nc https://github.com/chartjs/Chart.js/releases/download/v2.3.0/Chart.js
 cd ../../bootstrap
+
+
 
 
 echo "####################################"

--- a/src/web_interface/templates/about.html
+++ b/src/web_interface/templates/about.html
@@ -46,6 +46,7 @@
 		<li>Added software components statistics</li>
 		<li>Added REST endpoint for binary search (YARA)</li>
 		<li>Added unified mime-type-based analysis blacklist feature</li>
+		<li>Added syntax highlighting for code preview</li>
 	</ul>
 
 	<h4>FACT 2.5 (2018-08-01)</h4>

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -25,6 +25,11 @@
     <script src="{{ url_for('static', filename='jstree/dist/jstree.min.js') }}"></script>
     <link rel="stylesheet" href="{{ url_for('static', filename='jstree/dist/themes/default/style.min.css') }}" />
 
+
+	{# highlight.js import #}
+    <script src="{{ url_for('static', filename='highlight.js/highlight.pack.js') }}"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='highlight.js/styles/github.css') }}" />
+
 {% endblock %}
 
 {% block body %}
@@ -284,13 +289,21 @@
 		        </div>
 		        <script>
 		            var loading_gif = document.getElementById("preview-loading-gif");
+		            function init_preview() {
+		                hide_gif();
+		                highlight_code();
+		            };
 		            function hide_gif() {
 		                loading_gif.style.display = "none";
+		            };
+		            function highlight_code() {
+		                var block = $('div#preview-div pre')[0];
+                        hljs.highlightBlock(block);
 		            };
 		            function load_preview(){
 		                loading_gif.style.display = "block";
 		                document.getElementById("preview_button").onclick = function() {return false;};
-		                $("#preview-div").load("/ajax_get_binary/{{ firmware.processed_analysis["file_type"]["mime"].replace("/", "_") }}/{{ uid|safe }}", hide_gif);
+		                $("#preview-div").load("/ajax_get_binary/{{ firmware.processed_analysis["file_type"]["mime"].replace("/", "_") }}/{{ uid|safe }}", init_preview);
 		            };
 		            document.getElementById("preview_button").onclick = load_preview;
 		        </script>


### PR DESCRIPTION
Solves SD-54 Syntax Highlighting.

Supported languages are the "Common" options of
https://highlightjs.org/download/
If more languages should be supported, the download script may be adjusted.

At the moment, a pre-built package is downloaded faking a post request requiring a cookie.

The other option would be to download the github sources and build the package. That would require node and npm to be installed on the users system.