### PR TITLE
Locking unpacked files

### DIFF
--- a/src/intercom/back_end_binding.py
+++ b/src/intercom/back_end_binding.py
@@ -182,11 +182,14 @@ class InterComBackEndDeleteFile(InterComListener):
         if self._entry_was_removed_from_db(task['_id']):
             logging.info('remove file: {}'.format(task['_id']))
             self.fs_organizer.delete_file(task['_id'])
-        else:
-            logging.warning('file not removed, because database entry exists: {}'.format(task['_id']))
         return None
 
     def _entry_was_removed_from_db(self, uid):
         with ConnectTo(MongoInterfaceCommon, self.config) as db:
-            entry_is_in_database = db.existence_quick_check(uid)
-        return not entry_is_in_database
+            if db.existence_quick_check(uid):
+                logging.debug('file not removed, because database entry exists: {}'.format(uid))
+                return False
+            elif db.check_unpacking_lock(uid):
+                logging.debug('file not removed, because it is processed by unpacker: {}'.format(uid))
+                return False
+        return True

--- a/src/scheduler/Unpacking.py
+++ b/src/scheduler/Unpacking.py
@@ -25,9 +25,13 @@ class UnpackingScheduler(object):
         self.workers = []
         self.post_unpack = post_unpack
         self.db_interface = MongoInterfaceCommon(config) if not db_interface else db_interface
+        self.drop_cached_locks()
         self.start_unpack_workers()
         self.start_work_load_monitor()
         logging.info('Unpacker Module online')
+
+    def drop_cached_locks(self):
+        self.db_interface.drop_unpacking_locks()
 
     def add_task(self, fo):
         '''

--- a/src/storage/db_interface_backend.py
+++ b/src/storage/db_interface_backend.py
@@ -21,6 +21,8 @@ class BackEndDbInterface(MongoInterfaceCommon):
             self.add_file_object(fo_fw)
         else:
             logging.error('invalid object type: {} -> {}'.format(type(fo_fw), fo_fw))
+            return
+        self.release_unpacking_lock(fo_fw.uid)
 
     def update_object(self, new_object=None, old_object=None):
         update_dictionary = {

--- a/src/storage/db_interface_common.py
+++ b/src/storage/db_interface_common.py
@@ -300,4 +300,7 @@ class MongoInterfaceCommon(MongoInterface):
         return self.locks.count({'uid': uid}) > 0
 
     def release_unpacking_lock(self, uid):
-        self.locks.delete_many({'uid': uid})
+        self.locks.delete_one({'uid': uid})
+
+    def drop_unpacking_locks(self):
+        self.main.drop_collection('locks')

--- a/src/storage/db_interface_common.py
+++ b/src/storage/db_interface_common.py
@@ -21,6 +21,7 @@ class MongoInterfaceCommon(MongoInterface):
         self.main = self.client[main_database]
         self.firmwares = self.main.firmwares
         self.file_objects = self.main.file_objects
+        self.locks = self.main.locks
         # sanitize stuff
         self.report_threshold = int(self.config['data_storage']['report_threshold'])
         sanitize_db = self.config['data_storage'].get('sanitize_database', 'faf_sanitize')
@@ -291,3 +292,12 @@ class MongoInterfaceCommon(MongoInterface):
         if zero_on_empty_query and query == {}:
             return 0
         return self.file_objects.count(query)
+
+    def set_unpacking_lock(self, uid):
+        self.locks.insert_one({'uid': uid})
+
+    def check_unpacking_lock(self, uid):
+        return self.locks.count({'uid': uid}) > 0
+
+    def release_unpacking_lock(self, uid):
+        self.locks.delete_many({'uid': uid})

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -75,6 +75,7 @@ class DatabaseMock:
 
     def __init__(self, config=None):
         self.tasks = []
+        self.locks = []
 
     def shutdown(self):
         pass
@@ -321,13 +322,16 @@ class DatabaseMock:
             return 'test_name'
 
     def set_unpacking_lock(self, uid):
-        pass
+        self.locks.append(uid)
 
     def check_unpacking_lock(self, uid):
-        return False
+        return uid in self.locks
 
     def release_unpacking_lock(self, uid):
-        pass
+        self.locks.remove(uid)
+
+    def drop_unpacking_locks(self):
+        self.locks = []
 
 
 def fake_exit(self, *args):

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -320,6 +320,15 @@ class DatabaseMock:
         if uid == 'deadbeef00000000000000000000000000000000000000000000000000000000_123':
             return 'test_name'
 
+    def set_unpacking_lock(self, uid):
+        pass
+
+    def check_unpacking_lock(self, uid):
+        return False
+
+    def release_unpacking_lock(self, uid):
+        pass
+
 
 def fake_exit(self, *args):
     pass

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -327,9 +327,6 @@ class DatabaseMock:
     def check_unpacking_lock(self, uid):
         return uid in self.locks
 
-    def release_unpacking_lock(self, uid):
-        self.locks.remove(uid)
-
     def drop_unpacking_locks(self):
         self.locks = []
 

--- a/src/test/integration/common.py
+++ b/src/test/integration/common.py
@@ -8,6 +8,9 @@ class MockFSOrganizer:
     def store_file(self, file_object):
         pass
 
+    def delete_file(self, uid):
+        pass
+
 
 class MockDbInterface:
     def __init__(self, config):

--- a/src/test/integration/intercom/test_intercom_delete_file.py
+++ b/src/test/integration/intercom/test_intercom_delete_file.py
@@ -1,0 +1,52 @@
+import pytest
+
+from helperFunctions.config import get_config_for_testing
+from intercom.back_end_binding import InterComBackEndDeleteFile
+from test.common_helper import DatabaseMock, fake_exit
+from test.integration.common import MockFSOrganizer
+
+LOGGING_OUTPUT = None
+
+
+def set_output(message):
+    global LOGGING_OUTPUT
+    LOGGING_OUTPUT = message
+
+
+@pytest.fixture(scope='function', autouse=True)
+def mocking_the_database(monkeypatch):
+    monkeypatch.setattr('helperFunctions.web_interface.ConnectTo.__enter__', lambda _: DatabaseMock())
+    monkeypatch.setattr('helperFunctions.web_interface.ConnectTo.__exit__', fake_exit)
+    monkeypatch.setattr('intercom.common_mongo_binding.InterComListener.__init__', lambda self, config: None)
+    monkeypatch.setattr('logging.info', set_output)
+    monkeypatch.setattr('logging.debug', set_output)
+
+
+@pytest.fixture(scope='function')
+def config():
+    return get_config_for_testing()
+
+
+@pytest.fixture(scope='function')
+def mock_listener(config):
+    listener = InterComBackEndDeleteFile(config)
+    listener.fs_organizer = MockFSOrganizer(None)
+    listener.config = config
+    return listener
+
+
+def test_delete_file_success(mock_listener):
+    mock_listener.post_processing(dict(_id='AnyID'), None)
+    assert LOGGING_OUTPUT == 'remove file: AnyID'
+
+
+def test_delete_file_entry_exists(mock_listener, monkeypatch):
+    monkeypatch.setattr('test.common_helper.DatabaseMock.existence_quick_check', lambda self, uid: True)
+    mock_listener.post_processing(dict(_id='AnyID'), None)
+    assert 'entry exists: AnyID' in LOGGING_OUTPUT
+
+
+def test_delete_file_is_locked(mock_listener, monkeypatch):
+    monkeypatch.setattr('test.common_helper.DatabaseMock.check_unpacking_lock', lambda self, uid: True)
+    mock_listener.post_processing(dict(_id='AnyID'), None)
+    assert 'processed by unpacker: AnyID' in LOGGING_OUTPUT

--- a/src/test/integration/scheduler/test_unpack_and_analyse.py
+++ b/src/test/integration/scheduler/test_unpack_and_analyse.py
@@ -24,7 +24,7 @@ class TestFileAddition(unittest.TestCase):
         self._tmp_queue = Queue()
 
         self._analysis_scheduler = AnalysisScheduler(config=self._config, pre_analysis=lambda *_: None, post_analysis=self._dummy_callback, db_interface=MockDbInterface(None))
-        self._unpack_scheduler = UnpackingScheduler(config=self._config, post_unpack=self._analysis_scheduler.add_task)
+        self._unpack_scheduler = UnpackingScheduler(config=self._config, post_unpack=self._analysis_scheduler.add_task, db_interface=self.mocked_interface)
 
     def tearDown(self):
         self._unpack_scheduler.shutdown()

--- a/src/test/integration/scheduler/test_unpack_only.py
+++ b/src/test/integration/scheduler/test_unpack_only.py
@@ -7,6 +7,7 @@ from helperFunctions.fileSystem import get_test_data_dir
 from objects.firmware import Firmware
 from scheduler.Unpacking import UnpackingScheduler
 from test.integration.common import initialize_config, MockFSOrganizer
+from test.common_helper import DatabaseMock
 
 
 class TestFileAddition(unittest.TestCase):
@@ -14,7 +15,7 @@ class TestFileAddition(unittest.TestCase):
     def setUp(self):
         self._config = initialize_config(tmp_dir=None)
         self._tmp_queue = Queue()
-        self._unpack_scheduler = UnpackingScheduler(config=self._config, post_unpack=self._dummy_callback)
+        self._unpack_scheduler = UnpackingScheduler(config=self._config, post_unpack=self._dummy_callback, db_interface=DatabaseMock())
 
     def tearDown(self):
         self._unpack_scheduler.shutdown()

--- a/src/test/unit/scheduler/test_unpack.py
+++ b/src/test/unit/scheduler/test_unpack.py
@@ -8,6 +8,7 @@ import unittest
 from helperFunctions.fileSystem import get_test_data_dir
 from objects.firmware import Firmware
 from scheduler.Unpacking import UnpackingScheduler
+from test.common_helper import DatabaseMock
 
 
 class TestUnpackScheduler(unittest.TestCase):
@@ -61,7 +62,7 @@ class TestUnpackScheduler(unittest.TestCase):
         self.assertEqual(self.sched.throttle_condition.value, 1, 'throttle not functional')
 
     def _start_scheduler(self):
-        self.sched = UnpackingScheduler(config=self.config, post_unpack=self._mock_callback, analysis_workload=self._mock_get_analysis_workload)
+        self.sched = UnpackingScheduler(config=self.config, post_unpack=self._mock_callback, analysis_workload=self._mock_get_analysis_workload, db_interface=DatabaseMock())
 
     def _mock_callback(self, fw):
         self.tmp_queue.put(fw)

--- a/src/test/unit/unpacker/test_unpacker.py
+++ b/src/test/unit/unpacker/test_unpacker.py
@@ -7,7 +7,7 @@ import unittest
 from helperFunctions.dataConversion import make_list_from_dict
 from helperFunctions.fileSystem import get_test_data_dir
 from objects.file import FileObject
-from test.common_helper import create_test_file_object
+from test.common_helper import create_test_file_object, DatabaseMock
 from unpacker.unpack import Unpacker
 
 
@@ -21,7 +21,7 @@ class TestUnpackerBase(unittest.TestCase):
         config.set('unpack', 'max_depth', '3')
         config.set('unpack', 'whitelist', 'text/plain, image/png')
         config.add_section('ExpertSettings')
-        self.unpacker = Unpacker(config=config)
+        self.unpacker = Unpacker(config=config, db_interface=DatabaseMock())
         self.tmp_dir = TemporaryDirectory(prefix='faf_tests_')
         self.test_fo = create_test_file_object()
 

--- a/src/test/unit/unpacker/test_unpacker.py
+++ b/src/test/unit/unpacker/test_unpacker.py
@@ -135,6 +135,12 @@ class TestUnpackerCore(TestUnpackerBase):
         self.assertIn('no data lost', container.processed_analysis['unpacker']['summary'])
         self.assertNotIn('data loss', container.processed_analysis['unpacker'])
 
+    def test_file_is_locked(self):
+        assert not self.unpacker.db_interface.check_unpacking_lock(self.test_fo.uid)
+        file_pathes = ['{}/get_files_test/testfile1'.format(get_test_data_dir())]
+        self.unpacker.generate_and_store_file_objects(file_pathes, get_test_data_dir(), self.test_fo)
+        assert self.unpacker.db_interface.check_unpacking_lock(self.test_fo.uid)
+
 
 class TestUnpackerCoreMain(TestUnpackerBase):
 

--- a/src/test/unit/unpacker/test_unpacker.py
+++ b/src/test/unit/unpacker/test_unpacker.py
@@ -137,8 +137,8 @@ class TestUnpackerCore(TestUnpackerBase):
 
     def test_file_is_locked(self):
         assert not self.unpacker.db_interface.check_unpacking_lock(self.test_fo.uid)
-        file_pathes = ['{}/get_files_test/testfile1'.format(get_test_data_dir())]
-        self.unpacker.generate_and_store_file_objects(file_pathes, get_test_data_dir(), self.test_fo)
+        file_paths = ['{}/get_files_test/testfile1'.format(get_test_data_dir())]
+        self.unpacker.generate_and_store_file_objects(file_paths, get_test_data_dir(), self.test_fo)
         assert self.unpacker.db_interface.check_unpacking_lock(self.test_fo.uid)
 
 

--- a/src/unpacker/unpack.py
+++ b/src/unpacker/unpack.py
@@ -19,9 +19,10 @@ class Unpacker(UnpackBase):
     VALID_COMPRESSED_FILE_TYPES = ['application/x-shockwave-flash', 'audio/mpeg', 'audio/ogg', 'image/png', 'image/jpeg', 'image/gif', 'video/mp4', 'video/ogg']
     HEADER_OVERHEAD = 256
 
-    def __init__(self, config=None, worker_id=None):
+    def __init__(self, config=None, worker_id=None, db_interface=None):
         super().__init__(config=config, worker_id=worker_id)
         self.file_storage_system = FS_Organizer(config=self.config)
+        self.db_interface = db_interface
 
     def unpack(self, current_fo):
         '''
@@ -106,6 +107,7 @@ class Unpacker(UnpackBase):
                 if current_file.get_uid() in extracted_files:  # the same file is extracted multiple times from one archive
                     extracted_files[current_file.get_uid()].virtual_file_path[parent.get_root_uid()].append(current_virtual_path)
                 else:
+                    self.db_interface.set_unpacking_lock(current_file.uid)
                     self.file_storage_system.store_file(current_file)
                     current_file.virtual_file_path = {parent.get_root_uid(): [current_virtual_path]}
                     current_file.parent_firmware_uids.add(parent.get_root_uid())


### PR DESCRIPTION
Problem of race condition has appeared since binary deletion was activated recently.
Whenever a firmware is deleted, issuing a cascade of file deletions, a new analysis can overlap with the files. Then a file can be extracted during analysis, deleted shortly after due to the firmware deletion, and analyzed later on at which point the file has been deleted.
This happens basically every time a re-do anlysis is issued, but can happen in other scenarios as well.

A locking of extracted files should prevent that from happening. That is:
1. Unpacker finds file
2. file is locked
3. file is stored on fs
4. file is analyzed
5. analysis is stored in database
6. lock is released

As of now, if a deletion request is issued in between steps 3 and 5, the file is remove as no database link exists to it. Once step 5 is processed, a new link in the database exists and the lock can be safely removed. As long as the lock is in place, any deletion attempt will be discarded.