### PR TITLE
Align version naming

### DIFF
--- a/src/test/acceptance/rest/test_rest_compare.py
+++ b/src/test/acceptance/rest/test_rest_compare.py
@@ -54,7 +54,7 @@ class TestRestCompareFirmware(TestAcceptanceBase):
             'device_name': 'test_device',
             'device_part': 'full',
             'device_class': 'test_class',
-            'firmware_version': '1.0',
+            'version': '1.0',
             'vendor': 'test_vendor',
             'release_date': '01.01.1970',
             'tags': '',

--- a/src/test/acceptance/test_compare_firmwares.py
+++ b/src/test/acceptance/test_compare_firmwares.py
@@ -45,7 +45,7 @@ class TestAcceptanceCompareFirmwares(TestAcceptanceBase):
                 'device_name': device_name,
                 'device_part': 'full',
                 'device_class': 'test_class',
-                'firmware_version': '1.0',
+                'version': '1.0',
                 'vendor': 'test_vendor',
                 'release_date': '01.01.1970',
                 'tags': '',

--- a/src/test/acceptance/test_misc.py
+++ b/src/test/acceptance/test_misc.py
@@ -43,25 +43,25 @@ class TestAcceptanceMisc(TestAcceptanceBase):
 
     def _upload_firmware_get(self):
         rv = self.test_client.get('/upload')
-        self.assertIn(b'<h2>Upload Firmware</h2>', rv.data, "upload page not displayed correctly")
+        self.assertIn(b'<h2>Upload Firmware</h2>', rv.data, 'upload page not displayed correctly')
 
     def _upload_firmware_put(self, path, device_name, uid):
         testfile_path = os.path.join(get_test_data_dir(), path)
-        with open(testfile_path, "rb") as fp:
+        with open(testfile_path, 'rb') as fp:
             data = {
                 'file': fp,
                 'device_name': device_name,
                 'device_part': 'full',
-                'device_class': "test_class",
-                'firmware_version': "1.0",
-                'vendor': "test_vendor",
-                'release_date': "2009-01-01",
+                'device_class': 'test_class',
+                'version': '1.0',
+                'vendor': 'test_vendor',
+                'release_date': '2009-01-01',
                 'tags': '',
                 'analysis_systems': []
             }
             rv = self.test_client.post('/upload', content_type='multipart/form-data', data=data, follow_redirects=True)
-        self.assertIn(b'Upload Successful', rv.data, "upload not successful")
-        self.assertIn(uid.encode(), rv.data, "uid not found on upload success page")
+        self.assertIn(b'Upload Successful', rv.data, 'upload not successful')
+        self.assertIn(uid.encode(), rv.data, 'uid not found on upload success page')
 
     def _show_stats(self):
         rv = self.test_client.get('/statistic')

--- a/src/test/acceptance/test_upload_analyze_delete_firmware.py
+++ b/src/test/acceptance/test_upload_analyze_delete_firmware.py
@@ -60,7 +60,7 @@ class TestAcceptanceAnalyzeFirmware(TestAcceptanceBase):
                 'device_part': 'test_part',
                 'device_name': 'test_device',
                 'device_class': 'test_class',
-                'firmware_version': '1.0',
+                'version': '1.0',
                 'vendor': 'test_vendor',
                 'release_date': '1970-01-01',
                 'tags': '',

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -363,7 +363,7 @@ def get_firmware_for_rest_upload_test():
         'device_name': 'test_device',
         'device_part': 'test_part',
         'device_class': 'test_class',
-        'firmware_version': '1.0',
+        'version': '1.0',
         'vendor': 'test_vendor',
         'release_date': '01.01.1970',
         'tags': '',

--- a/src/test/integration/web_interface/rest/test_rest_firmware.py
+++ b/src/test/integration/web_interface/rest/test_rest_firmware.py
@@ -63,7 +63,7 @@ class TestRestFirmware(RestTestBase):
                 'device_name': 'test_device',
                 'device_part': 'full',
                 'device_class': 'test_class',
-                'firmware_version': '1',
+                'version': '1',
                 'vendor': 'test_vendor',
                 'release_date': '01.01.1970',
                 'tags': '',
@@ -87,7 +87,7 @@ class TestRestFirmware(RestTestBase):
                 'requested_analysis_systems': ['dummy']
             }
         ), follow_redirects=True)
-        assert b'"error_message": "firmware_version not found"' in rv.data
+        assert b'"error_message": "version not found"' in rv.data
         assert b'"status": 1' in rv.data
 
     def test_rest_download_valid(self):

--- a/src/test/unit/helperFunctions/test_mongo_task_conversion.py
+++ b/src/test/unit/helperFunctions/test_mongo_task_conversion.py
@@ -1,13 +1,11 @@
 import unittest
+
 import pytest
 
 from helperFunctions.mongo_task_conversion import check_for_errors, \
-    get_uid_of_analysis_task, get_uploaded_file_binary,\
-    convert_analysis_task_to_fw_obj, convert_fw_obj_to_analysis_task, \
-    is_sanitized_entry, _get_tag_list
+    get_uid_of_analysis_task, get_uploaded_file_binary, \
+    convert_analysis_task_to_fw_obj, is_sanitized_entry, _get_tag_list
 from objects.firmware import Firmware
-from test.common_helper import create_test_firmware
-
 
 TEST_TASK = {
     'binary': b'this is a test',
@@ -15,7 +13,7 @@ TEST_TASK = {
     'device_name': 'test device',
     'device_part': 'kernel',
     'device_class': 'test class',
-    'firmware_version': '1.0',
+    'version': '1.0',
     'vendor': 'test vendor',
     'release_date': '01.01.1970',
     'requested_analysis_systems': ['file_type', 'dummy'],
@@ -63,24 +61,6 @@ class TestMongoTask(unittest.TestCase):
         self.assertEqual(len(fw_obj.scheduled_analysis), 2)
         self.assertIn('dummy', fw_obj.scheduled_analysis)
         self.assertIsInstance(fw_obj.tags, dict, 'tag type not correct')
-
-    def test_convert_fw_obj_to_analysis_task(self):
-        fw = create_test_firmware()
-        result = convert_fw_obj_to_analysis_task(fw)
-        self.assertEqual(result['binary'], fw.binary)
-        self.assertEqual(result['file_name'], fw.file_name)
-        self.assertEqual(result['device_class'], fw.device_class)
-        self.assertEqual(result['vendor'], fw.vendor)
-        self.assertEqual(result['firmware_version'], fw.version)
-        self.assertEqual(result['release_date'], fw.release_date)
-        self.assertEqual(result['requested_analysis_systems'], fw.scheduled_analysis)
-        self.assertEqual(result['uid'], fw.get_uid())
-        self.assertEqual(result['tags'], ','.join(fw.tags))
-
-    def test_convert_fw_analysis_task_both_directions(self):
-        fw = convert_analysis_task_to_fw_obj(TEST_TASK)
-        result = convert_fw_obj_to_analysis_task(fw)
-        self.assertEqual(result, TEST_TASK)
 
     def test_is_sanitized_entry(self):
         sanitized_example = 'crypto_material_summary_81abfc7a79c8c1ed85f6b9fc2c5d9a3edc4456c4aecb9f95b4d7a2bf9bf652da_76415'

--- a/src/test/unit/web_interface/rest/test_rest_firmware.py
+++ b/src/test/unit/web_interface/rest/test_rest_firmware.py
@@ -70,7 +70,7 @@ def test_submit_missing_item(test_app):
         'file_name': 'no_real_file',
         'device_name': 'no real device',
         'device_class': 'no real class',
-        'firmware_version': 'no.real.version',
+        'version': 'no.real.version',
         'release_date': '01.01.1970',
         'requested_analysis_systems': ['file_type']
     }  # vendor missing
@@ -85,7 +85,7 @@ def test_submit_success(test_app):
         'device_part': 'kernel',
         'device_name': 'no real device',
         'device_class': 'no real class',
-        'firmware_version': 'no.real.version',
+        'version': 'no.real.version',
         'release_date': '01.01.1970',
         'vendor': 'no real vendor',
         'tags': 'tag1,tag2',

--- a/src/test/unit/web_interface/test_app_re_analyze.py
+++ b/src/test/unit/web_interface/test_app_re_analyze.py
@@ -24,7 +24,7 @@ class TestAppReAnalyze(WebInterfaceTest):
             'device_part': '',
             'device_part_dropdown': TEST_FW.part,
             'device_class': TEST_FW.device_class,
-            'firmware_version': TEST_FW.version,
+            'version': TEST_FW.version,
             'vendor': TEST_FW.vendor,
             'release_date': TEST_FW.release_date,
             'tags': '',

--- a/src/test/unit/web_interface/test_app_upload.py
+++ b/src/test/unit/web_interface/test_app_upload.py
@@ -18,12 +18,12 @@ class TestAppUpload(WebInterfaceTest):
             'device_name': 'test_device',
             'device_part': 'kernel',
             'device_class': 'test_class',
-            'firmware_version': '',
+            'version': '',
             'vendor': 'test_vendor',
             'release_date': '01.01.1970',
             'tags': '',
             'analysis_systems': ['dummy']}, follow_redirects=True)
-        assert b'Please specify the firmware version' in rv.data
+        assert b'Please specify the version' in rv.data
         self.assertEqual(len(self.mocked_interface.tasks), 0, 'task added to intercom but should not')
 
     def test_app_upload_valid_firmware(self):
@@ -32,7 +32,7 @@ class TestAppUpload(WebInterfaceTest):
             'device_name': 'test_device',
             'device_part': 'complete',
             'device_class': 'test_class',
-            'firmware_version': '1.0',
+            'version': '1.0',
             'vendor': 'test_vendor',
             'release_date': '01.01.1970',
             'tags': 'tag1,tag2',

--- a/src/web_interface/rest/rest_firmware.py
+++ b/src/web_interface/rest/rest_firmware.py
@@ -81,7 +81,7 @@ class RestFirmware(Resource):
             return self._update_analysis(uid, update)
 
     def _process_data(self, data):
-        for field in ['device_name', 'device_class', 'device_part', 'file_name', 'firmware_version', 'vendor', 'release_date',
+        for field in ['device_name', 'device_class', 'device_part', 'file_name', 'version', 'vendor', 'release_date',
                       'requested_analysis_systems', 'binary']:
             if field not in data.keys():
                 return dict(error_message='{} not found'.format(field))

--- a/src/web_interface/templates/upload/re-analyze.html
+++ b/src/web_interface/templates/upload/re-analyze.html
@@ -133,7 +133,7 @@
                 </div>
 
                 {% set input_form_text = [
-                    ("Version", "firmware_version", firmware.version)
+                    ("Version", "version", firmware.version)
                 ] -%}
                 {% for label, id, data in input_form_text %}
                 <div class="form-group">

--- a/src/web_interface/templates/upload/upload.html
+++ b/src/web_interface/templates/upload/upload.html
@@ -155,7 +155,7 @@
 
 
                 {% set input_form_text = [
-                    ("Version", "firmware_version")
+                    ("Version", "version")
                 ] -%}
                 {% for label, id in input_form_text %}
                 <div class="form-group">


### PR DESCRIPTION
Fixing mismatched naming of firmware version, where in database and object `version` was used and upload used `firmware_version`.

Side effect: Removed unused function `convert_fw_obj_to_analysis_task` from task conversion helper.

Name was already changed in wiki.