### PR TITLE
Fixed discovery problem of pytest with cwe_checker

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 addopts = --pep8 -v --cov=./
-pep8ignore = 
+norecursedirs = */cwe_checker/internal/*
+pep8ignore =
     *.py E501
     install.py E402
     src/plugins/* E402


### PR DESCRIPTION
cwe_checker internal tests require precompiled binaries to run. FACT should not deal with internal cwe_checker tests.