### PR TITLE
Removed from config so that IDE toolchains work correctly

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --pep8 -v --cov=./
+addopts = --pep8 -v
 norecursedirs = */cwe_checker/internal/*
 pep8ignore =
     *.py E501


### PR DESCRIPTION
Note that I have added the option to the CI scripts. Only difference is in use on CL where you now have to add it manually.

Upside is, that debugger like in PyCharm, using same hooking library as coverage can now work without user having to first change pytest.ini.