### PR TITLE
backend install: run autoconf (fixes install on ubuntu 18.04)

### DIFF
--- a/src/install/backend.py
+++ b/src/install/backend.py
@@ -124,7 +124,7 @@ def _install_unpacker(xenial):
                          'sharutils')
     apt_install_packages('unar')
     # firmware-mod-kit
-    install_github_project('rampageX/firmware-mod-kit', ['(cd src && sh configure && make)',
+    install_github_project('rampageX/firmware-mod-kit', ['(cd src && autoconf && sh configure && make)',
                                                          'cp src/yaffs2utils/unyaffs2 src/untrx src/tpl-tool/src/tpl-tool ../../bin/'])
 
 


### PR DESCRIPTION
Hello,

I have tried installing FACT on a clean ubuntu 18.04 VM. I encountered the following error:
```
checking arpa/inet.h presence... yes
configure: WARNING: arpa/inet.h: present but cannot be compiled
configure: WARNING: arpa/inet.h:     check for missing prerequisite headers?
configure: WARNING: arpa/inet.h: see the Autoconf documentation
configure: WARNING: arpa/inet.h:     section "Present But Cannot Be Compiled"
configure: WARNING: arpa/inet.h: proceeding with the compiler's result
configure: WARNING:     ## ----------------------------------------------------- ##
configure: WARNING:     ## Report this to http://firmware-mod-kit.googlecode.com ##
configure: WARNING:     ## ----------------------------------------------------- ##
checking for arpa/inet.h... no
```

Running `autoconf` before running `configure` during the installation of `rampageX/firmware-mod-kit` fixes the problem.

Cheers!