### PR TITLE
temporary fix. downgrade modkit from latest commit

### DIFF
--- a/src/install/backend.py
+++ b/src/install/backend.py
@@ -124,7 +124,7 @@ def _install_unpacker(xenial):
                          'sharutils')
     apt_install_packages('unar')
     # firmware-mod-kit
-    install_github_project('rampageX/firmware-mod-kit', ['(cd src && autoconf && sh configure && make)',
+    install_github_project('rampageX/firmware-mod-kit', ['git checkout 5e74fe9dd', '(cd src && sh configure && make)',
                                                          'cp src/yaffs2utils/unyaffs2 src/untrx src/tpl-tool/src/tpl-tool ../../bin/'])
 
 


### PR DESCRIPTION
The fix in PR #208 does not seem to work reliably (see ![CI build](https://ci.die-weidenbachs.de/job/FACT_core_bionic/374/console)).
Thus to smooth out builds, temporarily checkout 'mod-kit from before latest commit