### PR TITLE
changed delay in test

### DIFF
--- a/src/test/unit/scheduler/test_analysis_tag.py
+++ b/src/test/unit/scheduler/test_analysis_tag.py
@@ -45,7 +45,7 @@ def detached_scheduler(monkeypatch, analysis_service):
 def test_start_process(scheduler):
     assert scheduler.tagging_process.is_alive()
     scheduler.stop_condition.value = 1
-    sleep(float(scheduler.config['ExpertSettings']['block_delay']) * 2)
+    sleep(float(scheduler.config['ExpertSettings']['block_delay']) + 1)
     assert not scheduler.tagging_process.is_alive()
 
 


### PR DESCRIPTION
test_start_process from /test/unit/scheduler/test_analysis_tag.py failed randomly 
probably because the new ci is slower and the sleep/wait time needs to be adjusted