### PR TITLE
264 fix shutting down fact bug

### DIFF
--- a/src/helperFunctions/program_setup.py
+++ b/src/helperFunctions/program_setup.py
@@ -1,6 +1,6 @@
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2018  Fraunhofer FKIE
+    Copyright (C) 2015-2019  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/helperFunctions/program_setup.py
+++ b/src/helperFunctions/program_setup.py
@@ -19,8 +19,10 @@
 import argparse
 import configparser
 import logging
+import os
 import sys
 
+import psutil
 from common_helper_files import create_dir_for_file
 
 from helperFunctions.config import get_config_dir
@@ -80,3 +82,8 @@ def _load_config(args):
     if args.log_level is not None:
         config['Logging']['logLevel'] = args.log_level
     return config
+
+
+def was_started_by_start_fact():
+    parent = psutil.Process(os.getppid()).cmdline()[-1]
+    return 'start_fact' in parent

--- a/src/plugins/compare/file_coverage/view/file_coverage.html
+++ b/src/plugins/compare/file_coverage/view/file_coverage.html
@@ -58,7 +58,7 @@
                             'data' : {
                               'url' : function (node) {
                                 return node.id === '#' ?
-                                    "/ajax_root/{{ firmware_uid|safe }}" : "/compare/ajax_tree/{{ result["_id"] }}/{{ firmware_uid }}/" + node["data"]["uid"];
+                                    "/ajax_root/{{ firmware_uid|safe }}/{{ firmware_uid|safe }}" : "/compare/ajax_tree/{{ result["_id"] }}/{{ firmware_uid }}/" + node["data"]["uid"];
                               }
                             }
                           },

--- a/src/start_fact.py
+++ b/src/start_fact.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2018  Fraunhofer FKIE
+    Copyright (C) 2015-2019  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/start_fact.py
+++ b/src/start_fact.py
@@ -58,9 +58,9 @@ def _start_component(component, args):
         return None
 
 
-def _terminate_process(process):
+def _terminate_process(process: Popen):
     if process is not None:
-        process.terminate()
+        os.kill(process.pid, signal.SIGUSR1)
         try:
             process.wait(timeout=60)
         except TimeoutExpired:
@@ -75,7 +75,6 @@ def shutdown(*_):
 
 
 signal.signal(signal.SIGINT, shutdown)
-signal.signal(signal.SIGTERM, shutdown)
 
 if __name__ == '__main__':
     process_list = []
@@ -88,7 +87,7 @@ if __name__ == '__main__':
     backend_process = _start_component('backend', args)
 
     while run:
-        sleep(5)
+        sleep(1)
         if args.testing:
             break
 
@@ -96,8 +95,6 @@ if __name__ == '__main__':
     _terminate_process(backend_process)
     logging.debug('shutdown frontend')
     _terminate_process(frontend_process)
-    logging.debug('wait for childprocesses to stop...')
-    sleep(60)
     logging.debug('shutdown db')
     _terminate_process(db_process)
 

--- a/src/start_fact_backend.py
+++ b/src/start_fact_backend.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2018  Fraunhofer FKIE
+    Copyright (C) 2015-2019  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/start_fact_backend.py
+++ b/src/start_fact_backend.py
@@ -37,7 +37,7 @@ PROGRAM_DESCRIPTION = 'Firmware Analysis and Compare Tool (FACT) Backend'
 
 def shutdown(signum, _):
     global run
-    logging.info(f'received {signum}. shutting down {PROGRAM_NAME}...')
+    logging.info('received {signum}. shutting down {name}...'.format(signum=signum, name=PROGRAM_NAME))
     run = False
 
 

--- a/src/start_fact_db.py
+++ b/src/start_fact_db.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2018  Fraunhofer FKIE
+    Copyright (C) 2015-2019  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/start_fact_db.py
+++ b/src/start_fact_db.py
@@ -24,7 +24,7 @@ from time import sleep
 
 from statistic.work_load import WorkLoadStatistic
 from storage.MongoMgr import MongoMgr
-from helperFunctions.program_setup import program_setup
+from helperFunctions.program_setup import program_setup, was_started_by_start_fact
 
 PROGRAM_NAME = 'FACT DB-Service'
 PROGRAM_DESCRIPTION = 'Firmware Analysis and Compare Tool (FACT) DB-Service'
@@ -36,11 +36,13 @@ def shutdown(*_):
     run = False
 
 
-signal.signal(signal.SIGINT, shutdown)
-signal.signal(signal.SIGTERM, shutdown)
-
-
 if __name__ == '__main__':
+    if was_started_by_start_fact():
+        signal.signal(signal.SIGUSR1, shutdown)
+        signal.signal(signal.SIGINT, lambda *_: None)
+    else:
+        signal.signal(signal.SIGINT, shutdown)
+
     args, config = program_setup(PROGRAM_NAME, PROGRAM_DESCRIPTION)
     mongo_server = MongoMgr(config=config)
     work_load_stat = WorkLoadStatistic(config=config, component='database')

--- a/src/start_fact_frontend.py
+++ b/src/start_fact_frontend.py
@@ -30,7 +30,7 @@ from common_helper_process import execute_shell_command
 
 from helperFunctions.config import get_config_dir
 from helperFunctions.fileSystem import get_src_dir
-from helperFunctions.program_setup import program_setup
+from helperFunctions.program_setup import program_setup, was_started_by_start_fact
 from statistic.work_load import WorkLoadStatistic
 
 PROGRAM_NAME = 'FACT Frontend'
@@ -51,10 +51,6 @@ def _shutdown_uwsgi_server(process):
         process.kill()
 
 
-signal.signal(signal.SIGINT, shutdown)
-signal.signal(signal.SIGTERM, shutdown)
-
-
 def start_uwsgi_server(config_path=None):
     config_parameter = ' --pyargv {}'.format(config_path) if config_path else ''
     command = 'uwsgi --ini  {}/uwsgi_config.ini{}'.format(get_config_dir(), config_parameter)
@@ -71,6 +67,12 @@ def stop_docker():
 
 
 if __name__ == '__main__':
+    if was_started_by_start_fact():
+        signal.signal(signal.SIGUSR1, shutdown)
+        signal.signal(signal.SIGINT, lambda *_: None)
+    else:
+        signal.signal(signal.SIGINT, shutdown)
+
     run = True
     args, config = program_setup(PROGRAM_NAME, PROGRAM_DESCRIPTION)
 

--- a/src/start_fact_frontend.py
+++ b/src/start_fact_frontend.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2018  Fraunhofer FKIE
+    Copyright (C) 2015-2019  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
- removed SIGTERM signal handlers (unnecessary)
- in case FACT was started using the start_fact script:
  - remove SIGINT signal handler and use handler for SIGUSER1 to propagate the shutdown
  - reset PGID in the start_backend script so that `complete_shutdown` doesn't kill the other scripts