### PR TITLE
pull latest docker container before build to avoid dependency issues

### DIFF
--- a/src/plugins/analysis/input_vectors/install.sh
+++ b/src/plugins/analysis/input_vectors/install.sh
@@ -7,6 +7,8 @@ echo "------------------------------------"
 echo " Installing input_vectors Plugin "
 echo "------------------------------------"
 
+docker pull fkiecad/radare-web-gui:latest
+
 echo "Building docker container"
 docker build -t input-vectors .
 


### PR DESCRIPTION
Got the following error:
```python
ERROR    root:input_vectors.py:51 Could not decode JSON output.
ERROR    root:input_vectors.py:52 Traceback (most recent call last):
                                    File "/home/r2/input_vectors/input_vectors_r2.py", line 8, in <module>
                                      import r2pipe
                                  ModuleNotFoundError: No module named 'r2pipe'
```
Turned out that the input vector plugin build a docker container on an old base version of fkiecad/radare-web-gui.