### PR TITLE
Match script identifier over whole command line call to fix shutdown.…

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,5 +2,5 @@
 line_length=120
 default_section = THIRDPARTY
 known_first_party=analysis,compare,helperFunctions,install,intercom,objects,plugins,
-    scheduler,statistic,storage,test,unpacker,web_interface
+    scheduler,statistic,storage,test,unpacker,version,web_interface
 multi_line_output=6

--- a/src/helperFunctions/program_setup.py
+++ b/src/helperFunctions/program_setup.py
@@ -85,5 +85,5 @@ def _load_config(args):
 
 
 def was_started_by_start_fact():
-    parent = psutil.Process(os.getppid()).cmdline()[-1]
+    parent = ' '.join(psutil.Process(os.getppid()).cmdline())
     return 'start_fact.py' in parent or 'start_all_installed_fact_components' in parent


### PR DESCRIPTION
… Bugfix credit to @icytxw.

Now wrapper scripts can be started with command line parameters and it still works.

Should close #323.