### PR TITLE
Experimental find failed analyses

### DIFF
--- a/src/helperFunctions/web_interface.py
+++ b/src/helperFunctions/web_interface.py
@@ -1,10 +1,12 @@
 import json
 import os
 import re
+from datetime import timedelta
 from typing import List
 
 from common_helper_files import get_binary_from_file
 from passlib.context import CryptContext
+from si_prefix import si_format
 
 from helperFunctions.fileSystem import get_template_dir
 from helperFunctions.uid import is_uid
@@ -78,3 +80,13 @@ def virtual_path_element_to_span(hid_element: str, uid_element, root_uid) -> str
 
 def split_virtual_path(virtual_path: str) -> List[str]:
     return [element for element in virtual_path.split('|') if element]
+
+
+def format_si_prefix(number: float, unit: str) -> str:
+    return '{number}{unit}'.format(number=si_format(number, precision=2), unit=unit)
+
+
+def format_time(seconds: float):
+    if seconds < 60:
+        return format_si_prefix(seconds, 's')
+    return str(timedelta(seconds=seconds))

--- a/src/install/frontend.py
+++ b/src/install/frontend.py
@@ -150,7 +150,9 @@ def main(radare, nginx):
         'Flask-API',
         'uwsgi',
         'bcrypt',
-        'python-dateutil')
+        'python-dateutil',
+        'si-prefix'
+    )
 
     # installing web/js-frameworks
     _install_and_patch_bootstrap()

--- a/src/test/integration/storage/test_db_interface_frontend.py
+++ b/src/test/integration/storage/test_db_interface_frontend.py
@@ -229,7 +229,7 @@ class TestStorageDbInterfaceFrontend(unittest.TestCase):
         assert missing_analyses == {}
 
         test_fw_1.processed_analysis['foobar'] = {'foo': 'bar'}
-        self.db_backend_interface.add_firmware(test_fw_1)
+        self.db_backend_interface.add_analysis(test_fw_1)
         missing_analyses = self.db_frontend_interface.find_missing_analyses()
         assert test_fw_1.uid in missing_analyses
         assert missing_analyses[test_fw_1.uid] == {test_fo.uid}

--- a/src/test/integration/storage/test_db_interface_frontend.py
+++ b/src/test/integration/storage/test_db_interface_frontend.py
@@ -202,3 +202,34 @@ class TestStorageDbInterfaceFrontend(unittest.TestCase):
         assert all(set(entry.keys()) == {'_id', 'virtual_file_path'} for entry in result)
         result_uids = [entry['_id'] for entry in result]
         assert all(uid in result_uids for uid in test_uid_list)
+
+    def test_find_missing_files(self):
+        test_fw_1 = create_test_firmware()
+        test_fw_1.files_included.add('uid1234')
+        self.db_backend_interface.add_firmware(test_fw_1)
+        missing_files = self.db_frontend_interface.find_missing_files()
+        assert test_fw_1.uid in missing_files
+        assert missing_files[test_fw_1.uid] == {'uid1234'}
+
+        test_fo = create_test_file_object()
+        test_fo.uid = 'uid1234'
+        self.db_backend_interface.add_file_object(test_fo)
+        missing_files = self.db_frontend_interface.find_missing_files()
+        assert missing_files == {}
+
+    def test_find_missing_analyses(self):
+        test_fw_1 = create_test_firmware()
+        test_fo = create_test_file_object()
+        test_fw_1.files_included.add(test_fo.uid)
+        test_fo.virtual_file_path = {test_fw_1.uid: ['|foo|bar|']}
+        self.db_backend_interface.add_firmware(test_fw_1)
+        self.db_backend_interface.add_file_object(test_fo)
+
+        missing_analyses = self.db_frontend_interface.find_missing_analyses()
+        assert missing_analyses == {}
+
+        test_fw_1.processed_analysis['foobar'] = {'foo': 'bar'}
+        self.db_backend_interface.add_firmware(test_fw_1)
+        missing_analyses = self.db_frontend_interface.find_missing_analyses()
+        assert test_fw_1.uid in missing_analyses
+        assert missing_analyses[test_fw_1.uid] == {test_fo.uid}

--- a/src/test/unit/helperFunctions/test_web_interface.py
+++ b/src/test/unit/helperFunctions/test_web_interface.py
@@ -3,8 +3,8 @@ from flask_security.core import AnonymousUser, RoleMixin, UserMixin
 from werkzeug.local import LocalProxy
 
 from helperFunctions.web_interface import (
-    filter_out_illegal_characters, get_radare_endpoint, password_is_legal, split_virtual_path,
-    virtual_path_element_to_span
+    filter_out_illegal_characters, format_si_prefix, format_time, get_radare_endpoint, password_is_legal,
+    split_virtual_path, virtual_path_element_to_span
 )
 from test.common_helper import get_config_for_testing
 from web_interface.security.authentication import user_has_privilege
@@ -26,12 +26,12 @@ class RoleSuperuser(RoleMixin):
 
 
 class SuperuserUser(UserMixin):
-    id = 1
+    id = 1  # pylint: disable=invalid-name
     roles = [RoleSuperuser]
 
 
 class NormalUser(UserMixin):
-    id = 2
+    id = 2  # pylint: disable=invalid-name
     roles = []
 
 
@@ -81,3 +81,23 @@ def test_virtual_path_element_to_span(hid, uid, expected_output):
 ])
 def test_split_virtual_path(virtual_path, expected_output):
     assert split_virtual_path(virtual_path) == expected_output
+
+
+@pytest.mark.parametrize('number, unit, expected_output', [
+    (1, 'm', '1.00 m'),
+    (0.034, 'g', '34.00 mg'),
+    (0.0000123456789, 's', '12.35 µs'),
+    (1234.5, 'm', '1.23 km'),
+])
+def test_format_si_prefix(number, unit, expected_output):
+    assert format_si_prefix(number, unit) == expected_output
+
+
+@pytest.mark.parametrize('seconds, expected_output', [
+    (2, '2.00 s'),
+    (0.2, '200.00 ms'),
+    (120, '0:02:00'),
+    (100000, '1 day, 3:46:40'),
+])
+def test_format_time(seconds, expected_output):
+    assert format_time(seconds) == expected_output

--- a/src/test/unit/web_interface/base.py
+++ b/src/test/unit/web_interface/base.py
@@ -11,8 +11,8 @@ TMP_DIR = TemporaryDirectory(prefix="fact_test_")
 
 class WebInterfaceTest(unittest.TestCase):
 
-    def setUp(self):
-        self.mocked_interface = DatabaseMock()
+    def setUp(self, db_mock=DatabaseMock):  # pylint: disable=arguments-differ
+        self.mocked_interface = db_mock()
 
         self.enter_patch = unittest.mock.patch(target='helperFunctions.database.ConnectTo.__enter__', new=lambda _: self.mocked_interface)
         self.enter_patch.start()

--- a/src/test/unit/web_interface/test_app_missing_analyses.py
+++ b/src/test/unit/web_interface/test_app_missing_analyses.py
@@ -12,7 +12,7 @@ class MissingAnalysesDbMock(DatabaseMock):
         return self.result
 
 
-class TestAppAddComment(WebInterfaceTest):
+class TestAppMissingAnalyses(WebInterfaceTest):
     def setUp(self, db_mock=None):
         super().setUp(db_mock=MissingAnalysesDbMock)
 

--- a/src/test/unit/web_interface/test_app_missing_analyses.py
+++ b/src/test/unit/web_interface/test_app_missing_analyses.py
@@ -1,0 +1,31 @@
+from test.common_helper import DatabaseMock
+from test.unit.web_interface.base import WebInterfaceTest
+
+
+class MissingAnalysesDbMock(DatabaseMock):
+    result = None
+
+    def find_missing_files(self):
+        return self.result
+
+    def find_missing_analyses(self):
+        return self.result
+
+
+class TestAppAddComment(WebInterfaceTest):
+    def setUp(self, db_mock=None):
+        super().setUp(db_mock=MissingAnalysesDbMock)
+
+    def test_app_no_missing_analyses(self):
+        MissingAnalysesDbMock.result = {}
+        content = self.test_client.get('/admin/missing_analyses').data.decode()
+        assert 'No missing files found' in content
+        assert 'No missing analyses found' in content
+
+    def test_app_missing_analyses(self):
+        MissingAnalysesDbMock.result = {'parent_uid': {'child_uid1', 'child_uid2'}}
+        content = self.test_client.get('/admin/missing_analyses').data.decode()
+        assert '2 Missing Analyses' in content
+        assert '2 Missing Files' in content
+        assert 'parent_uid' in content
+        assert 'child_uid1' in content and 'child_uid2' in content

--- a/src/web_interface/components/miscellaneous_routes.py
+++ b/src/web_interface/components/miscellaneous_routes.py
@@ -23,7 +23,7 @@ class MiscellaneousRoutes(ComponentBase):
         self._app.add_url_rule('/comment/<uid>', 'comment/<uid>', self._app_add_comment, methods=['GET', 'POST'])
         self._app.add_url_rule('/admin/delete_comment/<uid>/<timestamp>', '/admin/delete_comment/<uid>/<timestamp>', self._app_delete_comment)
         self._app.add_url_rule('/admin/delete/<uid>', '/admin/delete/<uid>', self._app_delete_firmware)
-        self._app.add_url_rule('/admin/find_missing_analyses', 'admin/find_missing_analyses', self._app_find_missing_analyses, methods=['GET'])
+        self._app.add_url_rule('/admin/missing_analyses', 'admin/missing_analyses', self._app_find_missing_analyses, methods=['GET'])
 
     @login_required
     @roles_accepted(*PRIVILEGES['status'])

--- a/src/web_interface/components/miscellaneous_routes.py
+++ b/src/web_interface/components/miscellaneous_routes.py
@@ -88,7 +88,7 @@ class MiscellaneousRoutes(ComponentBase):
                 for result in collection.find({}, {'_id': 1, 'files_included': 1}):
                     uids_in_db.add(result['_id'])
                     parent_to_included[result['_id']] = set(result['files_included'])
-        for included_files in list(parent_to_included.values()):
+        for included_files in parent_to_included.values():
             included_files.difference_update(uids_in_db)
         return {
             'missing_files': [(parent, included) for parent, included in parent_to_included.items() if included],

--- a/src/web_interface/components/miscellaneous_routes.py
+++ b/src/web_interface/components/miscellaneous_routes.py
@@ -75,9 +75,9 @@ class MiscellaneousRoutes(ComponentBase):
 
     @roles_accepted(*PRIVILEGES['delete'])
     def _app_find_missing_analyses(self):
-        data = self._find_missing_files()
-        data.update(self._find_missing_analyses())
-        return render_template('find_missing_analyses.html', data=data)
+        template_data = self._find_missing_files()
+        template_data.update(self._find_missing_analyses())
+        return render_template('find_missing_analyses.html', data=template_data)
 
     def _find_missing_files(self):
         start = time()

--- a/src/web_interface/templates/base.html
+++ b/src/web_interface/templates/base.html
@@ -132,7 +132,8 @@
                                 <li class="dropdown {% if caption == active_page %}active{% endif  %}">
                                     <a class="dropdown-toggle" data-toggle="dropdown" href="#"><span class="glyphicon glyphicon-cog"></span>&nbsp;{{ caption }}<span class="caret"></span></a>
                                     <ul class="dropdown-menu">
-                                        <li><a href="/admin/manage_users">Manage Users</a></li>
+                                        <li><a href="/admin/manage_users"><span class="glyphicon glyphicon-user"></span> Manage Users</a></li>
+                                        <li><a href="/admin/find_missing_analyses"><span class="glyphicon glyphicon-search"></span> Find Missing Analyses</a></li>
                                     </ul>
                                 </li>
                             {% endif %}

--- a/src/web_interface/templates/base.html
+++ b/src/web_interface/templates/base.html
@@ -133,7 +133,7 @@
                                     <a class="dropdown-toggle" data-toggle="dropdown" href="#"><span class="glyphicon glyphicon-cog"></span>&nbsp;{{ caption }}<span class="caret"></span></a>
                                     <ul class="dropdown-menu">
                                         <li><a href="/admin/manage_users"><span class="glyphicon glyphicon-user"></span> Manage Users</a></li>
-                                        <li><a href="/admin/find_missing_analyses"><span class="glyphicon glyphicon-search"></span> Find Missing Analyses</a></li>
+                                        <li><a href="/admin/missing_analyses"><span class="glyphicon glyphicon-search"></span> Find Missing Analyses</a></li>
                                     </ul>
                                 </li>
                             {% endif %}

--- a/src/web_interface/templates/find_missing_analyses.html
+++ b/src/web_interface/templates/find_missing_analyses.html
@@ -8,19 +8,53 @@
 <div class="col-sm-offset-1 col-sm-10">
 
     <div class="row" style="margin-bottom: 16px">
-        <h2>{{ missing_count }} Missing Files</h2>
+        <h2>{{ data.missing_files_count | nice_number }} Missing Files</h2>
+        <h6>took {{ data.missing_files_duration }} to generate</h6>
         <table class="table table-bordered table-hover">
             <tr class="success">
-                <th>Parent UID</th><th>UID</th>
+                <th style="width: 50%">Parent Object UID</th>
+                <th>Missing File UID</th>
             </tr>
-            {% for parent_uid, uid_list in missing_db_entries | sort %}
-                <tr>
-                    <td>
-                        <a href='/analysis/{{ parent_uid }}'>{{ parent_uid }}</a>
-                    </td>
-                    <td>{{ uid_list | nice_list | safe }}</td>
-                </tr>
-            {% endfor %}
+            {% for parent_uid, uid_list in data.missing_files | sort -%}
+            <tr>
+                <td>
+                    <a href='/analysis/{{ parent_uid }}'>{{ parent_uid }}</a>
+                </td>
+                <td>
+                    <button data-toggle="collapse" data-target="#{{ parent_uid }}" class="list-group-item list-group-item-info">
+                        <span class="badge">{{ uid_list | length }}</span> show files
+                    </button>
+                    <div id="{{ parent_uid }}" class="collapse">
+                        <ul style="margin-top: 5px">
+                            {% for uid in uid_list -%}
+                            <li>{{ uid }}</li>
+                            {%- endfor %}
+                        </ul>
+                    </div>
+                </td>
+            </tr>
+            {%- endfor %}
+        </table>
+    </div>
+
+    <div class="row" style="margin-bottom: 16px">
+        <h2>{{ data.missing_analyses_count | nice_number }} Missing Analyses</h2>
+        <h6>took {{ data.missing_analyses_duration }} to generate</h6>
+        <table class="table table-bordered table-hover">
+            <tr class="success">
+                <th style="width: 50%">Parent Object UID</th>
+                <th>Files Missing Analyses</th>
+            </tr>
+            {% for parent_uid, uid_list in data.missing_analyses.items() | sort -%}
+            <tr>
+                <td>
+                    <a href='/analysis/{{ parent_uid }}'>{{ parent_uid }}</a>
+                </td>
+                <td>
+                    {{ uid_list | nice_uid_list | safe }}
+                </td>
+            </tr>
+            {%- endfor %}
         </table>
     </div>
 

--- a/src/web_interface/templates/find_missing_analyses.html
+++ b/src/web_interface/templates/find_missing_analyses.html
@@ -8,15 +8,15 @@
 <div class="col-sm-offset-1 col-sm-10">
 
     <div class="row" style="margin-bottom: 16px">
-        {% if data.missing_files_count -%}
-            <h2>{{ data.missing_files_count | nice_number }} Missing Files</h2>
-            <h6>took {{ data.missing_files_duration }} to generate</h6>
+        {% if missing_files.count -%}
+            <h2>{{ missing_files.count | nice_number }} Missing Files</h2>
+            <h6>took {{ missing_files.duration }} to generate</h6>
             <table class="table table-bordered table-hover">
                 <tr class="success">
                     <th style="width: 50%">Parent Object UID</th>
                     <th>Missing File UID</th>
                 </tr>
-                {% for parent_uid, uid_list in data.missing_files | sort -%}
+                {% for parent_uid, uid_list in missing_files.tuples | sort -%}
                 <tr>
                     <td>
                         <a href='/analysis/{{ parent_uid }}'>{{ parent_uid }}</a>
@@ -42,15 +42,15 @@
     </div>
 
     <div class="row" style="margin-bottom: 16px">
-        {% if data.missing_analyses_count -%}
-            <h2>{{ data.missing_analyses_count | nice_number }} Missing Analyses</h2>
-            <h6>took {{ data.missing_analyses_duration }} to generate</h6>
+        {% if missing_analyses.count -%}
+            <h2>{{ missing_analyses.count | nice_number }} Missing Analyses</h2>
+            <h6>took {{ missing_analyses.duration }} to generate</h6>
             <table class="table table-bordered table-hover">
                 <tr class="success">
-                    <th style="width: 50%">Parent Object UID</th>
+                    <th style="width: 50%">Parent Firmware UID</th>
                     <th>Files Missing Analyses</th>
                 </tr>
-                {% for parent_uid, uid_list in data.missing_analyses.items() | sort -%}
+                {% for parent_uid, uid_list in missing_analyses.tuples | sort -%}
                 <tr>
                     <td>
                         <a href='/analysis/{{ parent_uid }}'>{{ parent_uid }}</a>

--- a/src/web_interface/templates/find_missing_analyses.html
+++ b/src/web_interface/templates/find_missing_analyses.html
@@ -8,54 +8,62 @@
 <div class="col-sm-offset-1 col-sm-10">
 
     <div class="row" style="margin-bottom: 16px">
-        <h2>{{ data.missing_files_count | nice_number }} Missing Files</h2>
-        <h6>took {{ data.missing_files_duration }} to generate</h6>
-        <table class="table table-bordered table-hover">
-            <tr class="success">
-                <th style="width: 50%">Parent Object UID</th>
-                <th>Missing File UID</th>
-            </tr>
-            {% for parent_uid, uid_list in data.missing_files | sort -%}
-            <tr>
-                <td>
-                    <a href='/analysis/{{ parent_uid }}'>{{ parent_uid }}</a>
-                </td>
-                <td>
-                    <button data-toggle="collapse" data-target="#{{ parent_uid }}" class="list-group-item list-group-item-info">
-                        <span class="badge">{{ uid_list | length }}</span> show files
-                    </button>
-                    <div id="{{ parent_uid }}" class="collapse">
-                        <ul style="margin-top: 5px">
-                            {% for uid in uid_list -%}
-                            <li>{{ uid }}</li>
-                            {%- endfor %}
-                        </ul>
-                    </div>
-                </td>
-            </tr>
-            {%- endfor %}
-        </table>
+        {% if data.missing_files_count -%}
+            <h2>{{ data.missing_files_count | nice_number }} Missing Files</h2>
+            <h6>took {{ data.missing_files_duration }} to generate</h6>
+            <table class="table table-bordered table-hover">
+                <tr class="success">
+                    <th style="width: 50%">Parent Object UID</th>
+                    <th>Missing File UID</th>
+                </tr>
+                {% for parent_uid, uid_list in data.missing_files | sort -%}
+                <tr>
+                    <td>
+                        <a href='/analysis/{{ parent_uid }}'>{{ parent_uid }}</a>
+                    </td>
+                    <td>
+                        <button data-toggle="collapse" data-target="#{{ parent_uid }}" class="list-group-item list-group-item-info">
+                            <span class="badge">{{ uid_list | length }}</span> show files
+                        </button>
+                        <div id="{{ parent_uid }}" class="collapse">
+                            <ul style="margin-top: 5px">
+                                {% for uid in uid_list -%}
+                                <li>{{ uid }}</li>
+                                {%- endfor %}
+                            </ul>
+                        </div>
+                    </td>
+                </tr>
+                {%- endfor %}
+            </table>
+        {%- else %}
+            <h2>No missing files found <span class="glyphicon glyphicon-ok"></span></h2>
+        {%- endif %}
     </div>
 
     <div class="row" style="margin-bottom: 16px">
-        <h2>{{ data.missing_analyses_count | nice_number }} Missing Analyses</h2>
-        <h6>took {{ data.missing_analyses_duration }} to generate</h6>
-        <table class="table table-bordered table-hover">
-            <tr class="success">
-                <th style="width: 50%">Parent Object UID</th>
-                <th>Files Missing Analyses</th>
-            </tr>
-            {% for parent_uid, uid_list in data.missing_analyses.items() | sort -%}
-            <tr>
-                <td>
-                    <a href='/analysis/{{ parent_uid }}'>{{ parent_uid }}</a>
-                </td>
-                <td>
-                    {{ uid_list | nice_uid_list | safe }}
-                </td>
-            </tr>
-            {%- endfor %}
-        </table>
+        {% if data.missing_analyses_count -%}
+            <h2>{{ data.missing_analyses_count | nice_number }} Missing Analyses</h2>
+            <h6>took {{ data.missing_analyses_duration }} to generate</h6>
+            <table class="table table-bordered table-hover">
+                <tr class="success">
+                    <th style="width: 50%">Parent Object UID</th>
+                    <th>Files Missing Analyses</th>
+                </tr>
+                {% for parent_uid, uid_list in data.missing_analyses.items() | sort -%}
+                <tr>
+                    <td>
+                        <a href='/analysis/{{ parent_uid }}'>{{ parent_uid }}</a>
+                    </td>
+                    <td>
+                        {{ uid_list | nice_uid_list | safe }}
+                    </td>
+                </tr>
+                {%- endfor %}
+            </table>
+        {%- else %}
+            <h2>No missing analyses found <span class="glyphicon glyphicon-ok"></span></h2>
+        {%- endif %}
     </div>
 
 </div>

--- a/src/web_interface/templates/find_missing_analyses.html
+++ b/src/web_interface/templates/find_missing_analyses.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% set active_page = "Database" %}
+
+
+{% block body %}
+
+<div class="col-sm-offset-1 col-sm-10">
+
+    <div class="row" style="margin-bottom: 16px">
+        <h2>{{ missing_count }} Missing Files</h2>
+        <table class="table table-bordered table-hover">
+            <tr class="success">
+                <th>Parent UID</th><th>UID</th>
+            </tr>
+            {% for parent_uid, uid_list in missing_db_entries | sort %}
+                <tr>
+                    <td>
+                        <a href='/analysis/{{ parent_uid }}'>{{ parent_uid }}</a>
+                    </td>
+                    <td>{{ uid_list | nice_list | safe }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+    </div>
+
+</div>
+
+{% endblock %}


### PR DESCRIPTION
addresses #344
added new page `/admin/missing_analyses` that shows:
- missing files (files that are included in another file_object/firmware but are not found in the DB)
- missing analyses (analyses that are present in the firmware object but not in included file_objects)