### PR TITLE
Added check for enum34, update copyright strings

### DIFF
--- a/src/compile_yara_signatures.py
+++ b/src/compile_yara_signatures.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2018  Fraunhofer FKIE
+    Copyright (C) 2015-2020  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/install.py
+++ b/src/install.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     FACT Installer
-    Copyright (C) 2015-2018  Fraunhofer FKIE
+    Copyright (C) 2015-2020  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/install/pre_install.sh
+++ b/src/install/pre_install.sh
@@ -59,6 +59,12 @@ then
 fi
 sudo usermod -aG docker "$FACTUSER"
 
+if [ "$(pip3 freeze | grep enum34)" ]
+then
+        echo "Please uninstall the enum34 pypi package before continuing as it is not compatible with python >3.6 anymore"
+        exit 1
+fi
+
 sudo -EH pip3 install --upgrade pip
 sudo -EH pip3 install --upgrade virtualenv
 

--- a/src/start_fact_backend.py
+++ b/src/start_fact_backend.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2019  Fraunhofer FKIE
+    Copyright (C) 2015-2020  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/start_fact_db.py
+++ b/src/start_fact_db.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2019  Fraunhofer FKIE
+    Copyright (C) 2015-2020  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/update_statistic.py
+++ b/src/update_statistic.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2018  Fraunhofer FKIE
+    Copyright (C) 2015-2020  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/update_variety_data.py
+++ b/src/update_variety_data.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2018  Fraunhofer FKIE
+    Copyright (C) 2015-2020  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/version.py
+++ b/src/version.py
@@ -1,6 +1,6 @@
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2019  Fraunhofer FKIE
+    Copyright (C) 2015-2020  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/web_interface/templates/about.html
+++ b/src/web_interface/templates/about.html
@@ -49,7 +49,7 @@
 				<li>New plug-in to identify input vectors for executables (e.g. file, network, environment, stdin)</li>
 				<li>New software signatures added</li>
 				<li>Crypto hints plug-in added</li>
-				<li>Removed Base64 plug-in!</li>
+				<li>Removed Base64 plug-in</li>
 			</ul>
 		</li>
         <li>Dynamic generation of analysis summary</li>

--- a/src/web_interface/templates/about.html
+++ b/src/web_interface/templates/about.html
@@ -49,7 +49,7 @@
 				<li>New plug-in to identify input vectors for executables (e.g. file, network, environment, stdin)</li>
 				<li>New software signatures added</li>
 				<li>Crypto hints plug-in added</li>
-				<li><b>Warning:</b> Base64 is deprecated and is going to be removed in 3.2</li>
+				<li>Removed Base64 plug-in</li>
 			</ul>
 		</li>
         <li>Dynamic generation of analysis summary</li>

--- a/src/web_interface/templates/about.html
+++ b/src/web_interface/templates/about.html
@@ -49,7 +49,7 @@
 				<li>New plug-in to identify input vectors for executables (e.g. file, network, environment, stdin)</li>
 				<li>New software signatures added</li>
 				<li>Crypto hints plug-in added</li>
-				<li>Removed Base64 plug-in</li>
+				<li>Removed Base64 plug-in!</li>
 			</ul>
 		</li>
         <li>Dynamic generation of analysis summary</li>


### PR DESCRIPTION
### Issue:

The FACT installation may break on systems having the [enum34](https://pypi.org/project/enum34/) package installed.

### Error:

```
AttributeError: module 'enum' has no attribute 'IntFlag'
```


### Root cause analysis:

Since python 3.4 there's a standard library `enum` module, so we should uninstall enum34,
which is no longer compatible with the `enum` in the standard library since `enum.IntFlag` was added in [python 3.6](https://docs.python.org/3/library/enum.html).


### Solution 

```
pip3 uninstall -y enum34
```
However, automatic uninstalling may cause unexpected side effects for the affected users still using the package. As a result, this PR modifies the `pre_install.sh` script to exit preemptively if the package is found
