### PR TITLE
Sd 979 inverse advanced fw search

### DIFF
--- a/src/test/acceptance/test_advanced_search.py
+++ b/src/test/acceptance/test_advanced_search.py
@@ -3,7 +3,7 @@ from urllib.parse import quote
 
 from storage.db_interface_backend import BackEndDbInterface
 from test.acceptance.base import TestAcceptanceBase
-from test.common_helper import create_test_firmware, create_test_file_object
+from test.common_helper import create_test_file_object, create_test_firmware
 
 
 class TestAcceptanceAdvancedSearch(TestAcceptanceBase):
@@ -22,6 +22,9 @@ class TestAcceptanceAdvancedSearch(TestAcceptanceBase):
         self.child_fo.processed_analysis['unpacker']['plugin_used'] = 'test'
         self.child_fo.processed_analysis['file_type']['mime'] = 'some_type'
         self.db_backend_interface.add_object(self.child_fo)
+        self.other_fw = create_test_firmware()
+        self.other_fw.uid = '1234abcd_123'
+        self.db_backend_interface.add_object(self.other_fw)
 
     def tearDown(self):
         self.db_backend_interface.shutdown()
@@ -52,6 +55,16 @@ class TestAcceptanceAdvancedSearch(TestAcceptanceBase):
         assert b'Please enter a valid search request' not in rv.data
         assert self.child_fo.uid.encode() not in rv.data
         assert self.parent_fw.uid.encode() in rv.data
+
+    def test_advanced_search_inverse_only_firmware(self):
+        response = self.test_client.post(
+            '/database/advanced_search', content_type='multipart/form-data', follow_redirects=True,
+            data={'advanced_search': json.dumps({'_id': self.child_fo.uid}), 'only_firmwares': 'True', 'inverted': 'True'}
+        ).data.decode()
+        assert 'Please enter a valid search request' not in response
+        assert self.child_fo.uid not in response
+        assert '<strong>UID:</strong> {}'.format(self.parent_fw.uid) not in response
+        assert '<strong>UID:</strong> {}'.format(self.other_fw.uid) in response
 
     def test_rest_recursive_firmware_search(self):
         query = quote(json.dumps({'file_name': self.child_fo.file_name}))

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -212,7 +212,7 @@ class DatabaseMock:  # pylint: disable=too-many-public-methods
     def create_analysis_structure():
         return ''
 
-    def generic_search(self, search_string, skip=0, limit=0, only_fo_parent_firmware=False):
+    def generic_search(self, search_string, skip=0, limit=0, only_fo_parent_firmware=False, inverted=False):
         result = []
         if isinstance(search_string, dict):
             search_string = json.dumps(search_string)

--- a/src/web_interface/components/database_routes.py
+++ b/src/web_interface/components/database_routes.py
@@ -104,7 +104,6 @@ class DatabaseRoutes(ComponentBase):
                     cached_query = connection.get_query_from_cache(query)
                     query = cached_query['search_query']
                     search_parameters['query_title'] = cached_query['query_title']
-        logging.warning(f"\nrequest args: {request.args}")  # tODO
         search_parameters['only_firmware'] = request.args.get('only_firmwares') == 'True' if request.args.get('only_firmwares') else only_firmware
         search_parameters['inverted'] = request.args.get('inverted') == 'True' if request.args.get('inverted') else inverted
         search_parameters['query'] = apply_filters_to_query(request, query)

--- a/src/web_interface/components/database_routes.py
+++ b/src/web_interface/components/database_routes.py
@@ -63,14 +63,16 @@ class DatabaseRoutes(ComponentBase):
             return query
 
     @roles_accepted(*PRIVILEGES['basic_search'])
-    def _app_show_browse_database(self, query: str = '{}', only_firmwares=False):
+    def _app_show_browse_database(self, query: str = '{}', only_firmwares=False, inverted=False):
         page, per_page = self._get_page_items()[0:2]
-        search_parameters = self._get_search_parameters(query, only_firmwares)
+        search_parameters = self._get_search_parameters(query, only_firmwares, inverted)
         try:
-            firmware_list = self._search_database(search_parameters['query'], skip=per_page * (page - 1), limit=per_page, only_firmwares=search_parameters['only_firmware'])
+            firmware_list = self._search_database(
+                search_parameters['query'], skip=per_page * (page - 1), limit=per_page,
+                only_firmwares=search_parameters['only_firmware'], inverted=search_parameters['inverted']
+            )
             if self._query_has_only_one_result(firmware_list, search_parameters['query']):
-                uid = firmware_list[0][0]
-                return redirect(url_for('analysis/<uid>', uid=uid))
+                return redirect(url_for('analysis/<uid>', uid=firmware_list[0][0]))
         except Exception as err:
             error_message = 'Could not query database: {} {}'.format(type(err), str(err))
             logging.error(error_message)
@@ -93,7 +95,7 @@ class DatabaseRoutes(ComponentBase):
                                current_vendor=str(request.args.get('vendor')),
                                search_parameters=search_parameters)
 
-    def _get_search_parameters(self, query, only_firmware):
+    def _get_search_parameters(self, query, only_firmware, inverted):
         search_parameters = dict()
         if request.args.get('query'):
             query = request.args.get('query')
@@ -102,10 +104,9 @@ class DatabaseRoutes(ComponentBase):
                     cached_query = connection.get_query_from_cache(query)
                     query = cached_query['search_query']
                     search_parameters['query_title'] = cached_query['query_title']
-        if request.args.get('only_firmwares'):
-            search_parameters['only_firmware'] = request.args.get('only_firmwares') == 'True'
-        else:
-            search_parameters['only_firmware'] = only_firmware
+        logging.warning(f"\nrequest args: {request.args}")  # tODO
+        search_parameters['only_firmware'] = request.args.get('only_firmwares') == 'True' if request.args.get('only_firmwares') else only_firmware
+        search_parameters['inverted'] = request.args.get('inverted') == 'True' if request.args.get('inverted') else inverted
         search_parameters['query'] = apply_filters_to_query(request, query)
         if 'query_title' not in search_parameters.keys():
             search_parameters['query_title'] = search_parameters['query']
@@ -117,10 +118,10 @@ class DatabaseRoutes(ComponentBase):
     def _query_has_only_one_result(result_list, query):
         return len(result_list) == 1 and query != '{}'
 
-    def _search_database(self, query, skip=0, limit=0, only_firmwares=False):
+    def _search_database(self, query, skip=0, limit=0, only_firmwares=False, inverted=False):
         sorted_meta_list = list()
         with ConnectTo(FrontEndDbInterface, self._config) as connection:
-            result = connection.generic_search(query, skip, limit, only_fo_parent_firmware=only_firmwares)
+            result = connection.generic_search(query, skip, limit, only_fo_parent_firmware=only_firmwares, inverted=inverted)
             if not isinstance(result, list):
                 raise Exception(result)
             if query not in ('{}', {}):
@@ -165,9 +166,10 @@ class DatabaseRoutes(ComponentBase):
             try:
                 query = json.loads(request.form['advanced_search'])  # check for syntax errors
                 only_firmwares = request.form.get('only_firmwares') is not None
+                inverted = request.form.get('inverted') is not None
                 if not isinstance(query, dict):
                     raise Exception('Error: search query invalid (wrong type)')
-                return redirect(url_for('database/browse', query=json.dumps(query), only_firmwares=only_firmwares))
+                return redirect(url_for('database/browse', query=json.dumps(query), only_firmwares=only_firmwares, inverted=inverted))
             except Exception as err:
                 error = err
         return render_template('database/database_advanced_search.html', error=error, database_structure=database_structure)

--- a/src/web_interface/templates/database/database_advanced_search.html
+++ b/src/web_interface/templates/database/database_advanced_search.html
@@ -48,7 +48,7 @@
                                 </label>
                             </td>
                             <td style="padding: 5px;">
-                                <label class="checkbox-inline" id="inverted_label" style="padding: 0; margin: 0 0 0 20px;">
+                                <label class="checkbox-inline" id="inverted_label" style="padding: 0; margin: 0 0 0 20px; display: none;">
                                     <input type="checkbox" name="inverted" id="inverted" value="True">
                                     inverse (firmware without matching files)
                                 </label>

--- a/src/web_interface/templates/database/database_advanced_search.html
+++ b/src/web_interface/templates/database/database_advanced_search.html
@@ -2,13 +2,22 @@
 
 {% set active_page = "Database" %}
 
+
 {% block head %}
         {# angularJS import #}
         <script type="text/javascript" src="{{ url_for('static', filename='angular.min.js') }}"></script>
+        <script>
+            function hide_checkbox() {
+                if ($("#only_firmwares").is(':checked'))
+                    $("#inverted_label").show();
+                else
+                    $("#inverted_label").hide();
+            }
+        </script>
 {% endblock %}
 
-{% block body %}
 
+{% block body %}
 
 <div class="row">
 
@@ -34,8 +43,14 @@
                             </td>
                             <td style="padding: 5px;">
                                 <label class="checkbox-inline" style="padding: 0; margin: 0 0 0 20px;">
-                                    <input type="checkbox" name="only_firmwares" value="True">
+                                    <input type="checkbox" name="only_firmwares" id="only_firmwares" value="True" onchange="hide_checkbox()">
                                     show parent firmware instead of matching file
+                                </label>
+                            </td>
+                            <td style="padding: 5px;">
+                                <label class="checkbox-inline" id="inverted_label" style="padding: 0; margin: 0 0 0 20px;">
+                                    <input type="checkbox" name="inverted" id="inverted" value="True">
+                                    inverse (firmware without matching files)
                                 </label>
                             </td>
                         </tr>

--- a/src/web_interface/templates/database/database_browse.html
+++ b/src/web_interface/templates/database/database_browse.html
@@ -60,7 +60,8 @@
 	{% if search_parameters['query_title'] %}
     <div class="col-md-8 col-md-offset-2 col-lg-8 col-lg-offset-2">
 	        <button data-toggle="collapse" data-target="#search_query" class="list-group-item list-group-item-info">
-            	Show Search Query <span class="badge">{% if search_parameters['only_firmware'] %}Firmware{% else %}File{% endif %} Search</span>
+                {%- set search_target = "File" if not search_parameters['only_firmware'] else "Firmware" if not search_parameters['inverted'] else "Inverse Firmware" -%}
+            	Show Search Query <span class="badge">{{ search_target }} Search</span>
         	</button>
         <div id="search_query" class="collapse">
             <pre>{{ search_parameters['query_title'] }}</pre>


### PR DESCRIPTION
- added "inverse" option to advanced search (only firmware)
    - this enables previously impossible search queries (e.g. firmware without busybox)