### PR TITLE
fixed a file tree bug regarding missing root uids

### DIFF
--- a/src/web_interface/components/ajax_routes.py
+++ b/src/web_interface/components/ajax_routes.py
@@ -52,7 +52,7 @@ class AjaxRoutes(ComponentBase):
                 for child_uid in sc.get_specific_fields_of_db_entry(uid, {'files_included': 1})['files_included']
                 if whitelist is None or child_uid in whitelist
             ]
-            for node in sc.generate_file_tree_nodes_for_uid_list(child_uids, root_uid or uid, whitelist):
+            for node in sc.generate_file_tree_nodes_for_uid_list(child_uids, root_uid, whitelist):
                 root.add_child_node(node)
         return root
 

--- a/src/web_interface/templates/about.html
+++ b/src/web_interface/templates/about.html
@@ -57,6 +57,7 @@
         <h4>FACT 3.2-dev</h4>
         <ul>
             <li>Structural changes regarding the "virtual file path" (<b>Warning:</b> Changes in custom plugins may be necessary)</li>
+            <li>Bug fixes</li>
         </ul>
 
         <h4>FACT 3.1 (2020-05-28)</h4>

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -213,7 +213,7 @@
                                             'data' : {
                                                 'url' : function (node) {
                                                     return node.id === '#' ?
-                                                        "/ajax_root/{{ uid | safe }}/{{ root_uid | safe }}" : "/ajax_tree/" + node["data"]["uid"] + "/{{ root_uid|safe }}";
+                                                        "/ajax_root/{{ uid | safe }}/{{ root_uid | safe }}" : "/ajax_tree/" + node["data"]["uid"] + "/{{ root_uid | safe }}";
                                                 }
                                             }
                                         },


### PR DESCRIPTION
fixed a bug where the links in the file tree were incorrect for file objects on the analysis page without root UID