### PR TITLE
made temp dir path configurable

### DIFF
--- a/src/config/main.cfg
+++ b/src/config/main.cfg
@@ -25,6 +25,9 @@ password_salt = 5up3r5tr0n6_p455w0rd_5417
 variety_path = bin/variety.js
 structural_threshold = 40
 
+# Temporary Directory Path
+temp_dir_path = /tmp
+
 [Logging]
 logFile=/tmp/fact_main.log
 mongoDbLogFile=/tmp/fact_mongo.log

--- a/src/helperFunctions/config.py
+++ b/src/helperFunctions/config.py
@@ -1,6 +1,7 @@
 import configparser
 import os
 from configparser import ConfigParser, NoOptionError, NoSectionError
+from typing import Optional
 
 from helperFunctions.fileSystem import get_src_dir
 from helperFunctions.process import complete_shutdown
@@ -13,10 +14,10 @@ def load_config(config_file_name):
     '''
     config = configparser.ConfigParser()
     config_path = '{}/{}'.format(get_config_dir(), config_file_name)
-    if os.path.exists(config_path):
-        config.read(config_path)
-        return config
-    complete_shutdown('config file not found: {}'.format(config_path))
+    if not os.path.exists(config_path):
+        complete_shutdown('config file not found: {}'.format(config_path))
+    config.read(config_path)
+    return config
 
 
 def get_config_dir():
@@ -41,3 +42,7 @@ def read_list_from_config(config_file: ConfigParser, section: str, key: str, def
     if not config_entry:
         return default
     return [item.strip() for item in config_entry.split(',') if item]
+
+
+def get_temp_dir_path(config: Optional[ConfigParser] = None) -> str:
+    return config.get('data_storage', 'temp_dir_path', fallback='/tmp') if config else '/tmp'

--- a/src/helperFunctions/config.py
+++ b/src/helperFunctions/config.py
@@ -1,6 +1,7 @@
 import configparser
-import os
+import logging
 from configparser import ConfigParser, NoOptionError, NoSectionError
+from pathlib import Path
 from typing import Optional
 
 from helperFunctions.fileSystem import get_src_dir
@@ -14,7 +15,7 @@ def load_config(config_file_name):
     '''
     config = configparser.ConfigParser()
     config_path = '{}/{}'.format(get_config_dir(), config_file_name)
-    if not os.path.exists(config_path):
+    if not Path(config_path).exists():
         complete_shutdown('config file not found: {}'.format(config_path))
     config.read(config_path)
     return config
@@ -45,4 +46,11 @@ def read_list_from_config(config_file: ConfigParser, section: str, key: str, def
 
 
 def get_temp_dir_path(config: Optional[ConfigParser] = None) -> str:
-    return config.get('data_storage', 'temp_dir_path', fallback='/tmp') if config else '/tmp'
+    temp_dir_path = config.get('data_storage', 'temp_dir_path', fallback='/tmp') if config else '/tmp'
+    if not Path(temp_dir_path).is_dir():
+        try:
+            Path(temp_dir_path).mkdir()
+        except OSError:
+            logging.error('TempDir path does not exist and could not be created. Defaulting to /tmp', exc_info=True)
+            return '/tmp'
+    return temp_dir_path

--- a/src/plugins/analysis/binwalk/code/binwalk.py
+++ b/src/plugins/analysis/binwalk/code/binwalk.py
@@ -6,6 +6,7 @@ from common_helper_files import get_binary_from_file
 from common_helper_process import execute_shell_command
 
 from analysis.PluginBase import AnalysisBasePlugin
+from helperFunctions.config import get_temp_dir_path
 from helperFunctions.dataConversion import make_unicode_string
 
 
@@ -23,7 +24,7 @@ class AnalysisPlugin(AnalysisBasePlugin):
 
     def process_object(self, file_object):
         result = {}
-        tmp_dir = TemporaryDirectory(prefix='fact_analysis_binwalk_')
+        tmp_dir = TemporaryDirectory(prefix='fact_analysis_binwalk_', dir=get_temp_dir_path(self.config))
         dir_path = tmp_dir.name
 
         signature_analysis_result = execute_shell_command('(cd {} && xvfb-run -a binwalk -BEJ {})'.format(dir_path, file_object.file_path))

--- a/src/plugins/analysis/input_vectors/code/input_vectors.py
+++ b/src/plugins/analysis/input_vectors/code/input_vectors.py
@@ -7,6 +7,7 @@ from docker.errors import DockerException
 from requests.exceptions import ReadTimeout
 
 from analysis.PluginBase import AnalysisBasePlugin
+from helperFunctions.config import get_temp_dir_path
 from helperFunctions.docker import run_docker_container
 from objects.file import FileObject
 
@@ -35,7 +36,7 @@ class AnalysisPlugin(AnalysisBasePlugin):
         logging.info('Up and running.')
 
     def process_object(self, file_object: FileObject):
-        with TemporaryDirectory(prefix=self.NAME) as tmp_dir:
+        with TemporaryDirectory(prefix=self.NAME, dir=get_temp_dir_path(self.config)) as tmp_dir:
             file_path = Path(tmp_dir) / file_object.file_name
             file_path.write_bytes(file_object.binary)
             try:

--- a/src/plugins/analysis/qemu_exec/code/qemu_exec.py
+++ b/src/plugins/analysis/qemu_exec/code/qemu_exec.py
@@ -17,6 +17,7 @@ from fact_helper_file import get_file_type_from_path
 from requests.exceptions import ReadTimeout
 
 from analysis.PluginBase import AnalysisBasePlugin
+from helperFunctions.config import get_temp_dir_path
 from helperFunctions.docker import run_docker_container
 from helperFunctions.tag import TagColor
 from helperFunctions.uid import create_uid
@@ -42,7 +43,7 @@ class Unpacker(UnpackBase):
             logging.error('could not unpack {}: file path not found'.format(file_object.uid))
             return None
 
-        extraction_dir = TemporaryDirectory(prefix='FACT_plugin_qemu_exec')
+        extraction_dir = TemporaryDirectory(prefix='FACT_plugin_qemu_exec', dir=get_temp_dir_path(self.config))
         self.extract_files_from_file(file_path, extraction_dir.name)
         return extraction_dir
 

--- a/src/plugins/analysis/software_components/code/software_components.py
+++ b/src/plugins/analysis/software_components/code/software_components.py
@@ -7,6 +7,7 @@ from typing import List
 from common_helper_files import get_dir_of_file
 
 from analysis.YaraPluginBase import YaraBasePlugin
+from helperFunctions.config import get_temp_dir_path
 from helperFunctions.dataConversion import make_unicode_string
 from helperFunctions.tag import TagColor
 from objects.file import FileObject
@@ -83,7 +84,7 @@ class AnalysisPlugin(YaraBasePlugin):
         if result['meta'].get('format_string'):
             key_strings = [s.decode() for _, _, s in result['strings'] if b'%s' in s]
             if key_strings:
-                versions.update(extract_data_from_ghidra(file_object.binary, key_strings))
+                versions.update(extract_data_from_ghidra(file_object.binary, key_strings, get_temp_dir_path(self.config)))
         if '' in versions and len(versions) > 1:  # if there are actual version results, remove the "empty" result
             versions.remove('')
         result['meta']['version'] = list(versions)

--- a/src/plugins/analysis/software_components/internal/resolve_version_format_string.py
+++ b/src/plugins/analysis/software_components/internal/resolve_version_format_string.py
@@ -14,8 +14,8 @@ TIMEOUT = 300
 KEY_FILE = 'key_file'
 
 
-def extract_data_from_ghidra(input_file_data: bytes, key_strings: List[str]) -> List[str]:
-    with TemporaryDirectory(prefix='FSR_') as tmp_dir:
+def extract_data_from_ghidra(input_file_data: bytes, key_strings: List[str], path: str = '/tmp') -> List[str]:
+    with TemporaryDirectory(prefix='FSR_', dir=path) as tmp_dir:
         tmp_dir_path = Path(tmp_dir)
         ghidra_input_file = tmp_dir_path / 'ghidra_input'
         (tmp_dir_path / KEY_FILE).write_text(json.dumps(key_strings))

--- a/src/test/unit/helperFunctions/test_mongo_task_conversion.py
+++ b/src/test/unit/helperFunctions/test_mongo_task_conversion.py
@@ -2,9 +2,10 @@ import unittest
 
 import pytest
 
-from helperFunctions.mongo_task_conversion import check_for_errors, \
-    get_uid_of_analysis_task, get_uploaded_file_binary, \
-    convert_analysis_task_to_fw_obj, is_sanitized_entry, _get_tag_list
+from helperFunctions.mongo_task_conversion import (
+    _get_tag_list, check_for_errors, convert_analysis_task_to_fw_obj, get_uid_of_analysis_task,
+    get_uploaded_file_binary, is_sanitized_entry
+)
 from objects.firmware import Firmware
 
 TEST_TASK = {
@@ -41,7 +42,7 @@ class TestMongoTask(unittest.TestCase):
         self.assertEqual(result['b'], 'Please specify the b')
 
     def test_get_uploaded_file_binary_error(self):
-        self.assertEqual(get_uploaded_file_binary(None), None, 'missing upload file should lead to None')
+        self.assertEqual(get_uploaded_file_binary(None, None), None, 'missing upload file should lead to None')
 
     def test_get_uid_of_analysis_task(self):
         analysis_task = {'binary': b'this is a test'}

--- a/src/unpacker/tar_repack.py
+++ b/src/unpacker/tar_repack.py
@@ -5,16 +5,18 @@ from tempfile import TemporaryDirectory
 
 from common_helper_files import get_binary_from_file
 from common_helper_process import execute_shell_command
+
+from helperFunctions.config import get_temp_dir_path
 from unpacker.unpack_base import UnpackBase
 
 
 class TarRepack(UnpackBase):
 
     def tar_repack(self, file_path):
-        extraction_directory = TemporaryDirectory(prefix='FACT_tar_repack')
+        extraction_directory = TemporaryDirectory(prefix='FACT_tar_repack', dir=get_temp_dir_path(self.config))
         self.extract_files_from_file(file_path, extraction_directory.name)
 
-        archive_directory = TemporaryDirectory(prefix='FACT_tar_repack')
+        archive_directory = TemporaryDirectory(prefix='FACT_tar_repack', dir=get_temp_dir_path(self.config))
         archive_path = os.path.join(archive_directory.name, 'download.tar.gz')
         tar_binary = self._repack_extracted_files(Path(extraction_directory.name, 'files'), archive_path)
 

--- a/src/unpacker/unpack.py
+++ b/src/unpacker/unpack.py
@@ -6,6 +6,7 @@ from typing import List
 
 from fact_helper_file import get_file_type_from_path
 
+from helperFunctions.config import get_temp_dir_path
 from helperFunctions.dataConversion import make_list_from_dict, make_unicode_string
 from helperFunctions.fileSystem import file_is_empty, get_object_path_excluding_fact_dirs
 from helperFunctions.tag import TagColor
@@ -33,7 +34,7 @@ class Unpacker(UnpackBase):
             self._store_unpacking_depth_skip_info(current_fo)
             return []
 
-        tmp_dir = TemporaryDirectory(prefix='fact_unpack_')
+        tmp_dir = TemporaryDirectory(prefix='fact_unpack_', dir=get_temp_dir_path(self.config))
 
         file_path = self._generate_local_file_path(current_fo)
 

--- a/src/web_interface/components/database_routes.py
+++ b/src/web_interface/components/database_routes.py
@@ -192,11 +192,10 @@ class DatabaseRoutes(ComponentBase):
                 error = 'please select a file or enter rules in the text area'
         return render_template('database/database_binary_search.html', error=error)
 
-    @staticmethod
-    def _get_items_from_binary_search_request(req):
+    def _get_items_from_binary_search_request(self, req):
         yara_rule_file = None
         if 'file' in req.files and req.files['file']:
-            _, yara_rule_file = get_file_name_and_binary_from_request(req)
+            _, yara_rule_file = get_file_name_and_binary_from_request(req, self._config)
         elif req.form['textarea']:
             yara_rule_file = req.form['textarea'].encode()
         firmware_uid = req.form.get('firmware_uid') if req.form.get('firmware_uid') else None

--- a/src/web_interface/components/io_routes.py
+++ b/src/web_interface/components/io_routes.py
@@ -5,6 +5,7 @@ from time import sleep
 import requests
 from flask import make_response, redirect, render_template, request
 
+from helperFunctions.config import get_temp_dir_path
 from helperFunctions.database import ConnectTo
 from helperFunctions.mongo_task_conversion import (
     check_for_errors, convert_analysis_task_to_fw_obj, create_analysis_task
@@ -33,7 +34,7 @@ class IORoutes(ComponentBase):
     def _app_upload(self):
         error = {}
         if request.method == 'POST':
-            analysis_task = create_analysis_task(request)
+            analysis_task = create_analysis_task(request, self._config)
             error = check_for_errors(analysis_task)
             if not error:
                 fw = convert_analysis_task_to_fw_obj(analysis_task)
@@ -128,7 +129,7 @@ class IORoutes(ComponentBase):
             firmware = connection.get_complete_object_including_all_summaries(uid)
 
         try:
-            with TemporaryDirectory() as folder:
+            with TemporaryDirectory(dir=get_temp_dir_path(self._config)) as folder:
                 binary, pdf_path = build_pdf_report(firmware, folder)
         except RuntimeError as error:
             return render_template('error.html', message=str(error))


### PR DESCRIPTION
The path for Temporary Directories is now configurable in the configuration file (`main.cfg`). This can be useful when the user running FACT doesn't have full access to `/tmp`