### PR TITLE
Making radare web service host/ip configurable

### DIFF
--- a/src/config/main.cfg
+++ b/src/config/main.cfg
@@ -137,4 +137,4 @@ authentication = false
 nginx = false
 intercom_poll_delay = 1.0
 # this is used in redirecting to the radare web service.  It should generally be the IP or host name when running on a remote host.
-radare2_host = 'localhost'
+radare2_host = localhost

--- a/src/config/main.cfg
+++ b/src/config/main.cfg
@@ -136,3 +136,5 @@ throw_exceptions = false
 authentication = false
 nginx = false
 intercom_poll_delay = 1.0
+# this is used in redirecting to the radare web service.  It should generally be the IP or host name when running on a remote host.
+radare2_host = 'localhost'

--- a/src/helperFunctions/web_interface.py
+++ b/src/helperFunctions/web_interface.py
@@ -62,8 +62,8 @@ def get_template_as_string(view_name):
 def get_radare_endpoint(config):
     radare2_host = config['ExpertSettings']['radare2_host']
     if config.getboolean('ExpertSettings', 'nginx'):
-        return 'https://' + radare2_host + '/radare'
-    return 'http://' + radare2_host + ':8000'
+        return 'https://{}/radare'.format(radare2_host)
+    return 'http://{}:8000'.format(radare2_host)
 
 
 def password_is_legal(pw: str) -> bool:

--- a/src/helperFunctions/web_interface.py
+++ b/src/helperFunctions/web_interface.py
@@ -60,9 +60,10 @@ def get_template_as_string(view_name):
 
 
 def get_radare_endpoint(config):
+    radare2_host = config['ExpertSettings']['radare2_host']
     if config.getboolean('ExpertSettings', 'nginx'):
-        return 'https://localhost/radare'
-    return 'http://localhost:8000'
+        return 'https://' + radare2_host + '/radare'
+    return 'http://' + radare2_host + ':8000'
 
 
 def password_is_legal(pw: str) -> bool:

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -440,6 +440,7 @@ def get_config_for_testing(temp_dir=None):
     if temp_dir is not None:
         config.set('data_storage', 'firmware_file_storage_directory', temp_dir.name)
         config.set('Logging', 'mongoDbLogFile', os.path.join(temp_dir.name, 'mongo.log'))
+    config.set('ExpertSettings', 'radare2_host', 'localhost')
     return config
 
 


### PR DESCRIPTION
This PR makes the radare2 host url configurable via the main.cfg
file. The default value is set to 'localhost', but should be set
to the IP or hostname of where ever the radare service is running
in distributed configurations.

Fixes #436 