### PR TITLE
Bugfix for download link template

### DIFF
--- a/src/web_interface/templates/generic_view/file_object_macros.html
+++ b/src/web_interface/templates/generic_view/file_object_macros.html
@@ -13,7 +13,7 @@
                 , Type: {{ file_object['mime-type'] }}
             {% endif %}
         </span>
-        <a href="location.href='/download/{{ file_object.uid }}'"><i class="fas fa-download"></i></a>
+        <a href="#" onclick="location.href='/download/{{ file_object.uid }}'"><i class="fas fa-download"></i></a>
     </p>
 {% endmacro %}
 

--- a/src/web_interface/templates/generic_view/file_object_macros.html
+++ b/src/web_interface/templates/generic_view/file_object_macros.html
@@ -13,7 +13,7 @@
                 , Type: {{ file_object['mime-type'] }}
             {% endif %}
         </span>
-        <a href="#" onclick="location.href='/download/{{ file_object.uid }}'"><i class="fas fa-download"></i></a>
+        <a href="/download/{{ file_object.uid }}"><i class="fas fa-download"></i></a>
     </p>
 {% endmacro %}
 


### PR DESCRIPTION
The download link template was broken and did not allow
for a user to download the appropriate file.  This commit
fixes the issue