### PR TITLE
Added 10s timeouts in the installation scripts to prevent hanging

### DIFF
--- a/src/install.py
+++ b/src/install.py
@@ -143,7 +143,7 @@ def install_statistic_cronjob():
     cron_content = '0    *    *    *    *    {} > /dev/null 2>&1\n'.format(statistic_update_script_path)
     cron_content += '30    0    *    *    0    {} > /dev/null 2>&1\n'.format(variety_update_script_path)
     crontab_file_path.write_text(cron_content)
-    output, return_code = execute_shell_command_get_return_code('crontab {}'.format(crontab_file_path))
+    output, return_code = execute_shell_command_get_return_code('crontab {}'.format(crontab_file_path), timeout=10)
     if return_code != 0:
         logging.error(output)
     else:

--- a/src/install/backend.py
+++ b/src/install/backend.py
@@ -33,7 +33,7 @@ def main(distribution):
     # build extraction docker container
     logging.info('Building fact extraction container')
 
-    output, return_code = execute_shell_command_get_return_code('docker pull fkiecad/fact_extractor')
+    output, return_code = execute_shell_command_get_return_code('docker pull fkiecad/fact_extractor', timeout=10)
     if return_code != 0:
         raise InstallationError('Failed to pull extraction container:\n{}'.format(output))
 
@@ -53,7 +53,7 @@ def main(distribution):
 
     # compiling yara signatures
     compile_signatures()
-    _, yarac_return = execute_shell_command_get_return_code('yarac -d test_flag=false ../test/unit/analysis/test.yara ../analysis/signatures/Yara_Base_Plugin.yc')
+    _, yarac_return = execute_shell_command_get_return_code('yarac -d test_flag=false ../test/unit/analysis/test.yara ../analysis/signatures/Yara_Base_Plugin.yc', timeout=10)
     if yarac_return != 0:
         raise InstallationError('Failed to compile yara test signatures')
 
@@ -68,7 +68,7 @@ def main(distribution):
 def _edit_environment():
     logging.info('set environment variables...')
     for command in ['sudo cp -f fact_env.sh /etc/profile.d/', 'sudo chmod 755 /etc/profile.d/fact_env.sh', '. /etc/profile']:
-        output, return_code = execute_shell_command_get_return_code(command)
+        output, return_code = execute_shell_command_get_return_code(command, timeout=10)
         if return_code != 0:
             raise InstallationError('Failed to add environment changes [{}]\n{}'.format(command, output))
 
@@ -80,8 +80,8 @@ def _edit_sudoers():
         '/bin/mount', '/bin/umount', '/bin/chown'
     )))
     Path('/tmp/fact_overrides').write_text('{}\n'.format(sudoers_content))
-    chown_output, chown_code = execute_shell_command_get_return_code('sudo chown root:root /tmp/fact_overrides')
-    mv_output, mv_code = execute_shell_command_get_return_code('sudo mv /tmp/fact_overrides /etc/sudoers.d/fact_overrides')
+    chown_output, chown_code = execute_shell_command_get_return_code('sudo chown root:root /tmp/fact_overrides', timeout=10)
+    mv_output, mv_code = execute_shell_command_get_return_code('sudo mv /tmp/fact_overrides /etc/sudoers.d/fact_overrides', timeout=10)
     if not chown_code == mv_code == 0:
         raise InstallationError('Editing sudoers file did not succeed\n{}\n{}'.format(chown_output, mv_output))
 
@@ -91,20 +91,20 @@ def _create_firmware_directory():
 
     config = load_main_config()
     data_dir_name = config.get('data_storage', 'firmware_file_storage_directory')
-    mkdir_output, mkdir_code = execute_shell_command_get_return_code('sudo mkdir -p --mode=0744 {}'.format(data_dir_name))
-    chown_output, chown_code = execute_shell_command_get_return_code('sudo chown {}:{} {}'.format(os.getuid(), os.getgid(), data_dir_name))
+    mkdir_output, mkdir_code = execute_shell_command_get_return_code('sudo mkdir -p --mode=0744 {}'.format(data_dir_name), timeout=10)
+    chown_output, chown_code = execute_shell_command_get_return_code('sudo chown {}:{} {}'.format(os.getuid(), os.getgid(), data_dir_name), timeout=10)
     if not all(code == 0 for code in (mkdir_code, chown_code)):
         raise InstallationError('Failed to create directories for binary storage\n{}\n{}'.format(mkdir_output, chown_output))
 
 
 def _install_plugins(distribution):
     logging.info('Installing plugins')
-    find_output, return_code = execute_shell_command_get_return_code('find ../plugins -iname "install.sh"')
+    find_output, return_code = execute_shell_command_get_return_code('find ../plugins -iname "install.sh"', timeout=10)
     if return_code != 0:
         raise InstallationError('Error retrieving plugin installation scripts')
     for install_script in find_output.splitlines(keepends=False):
         logging.info('Running {}'.format(install_script))
-        shell_output, return_code = execute_shell_command_get_return_code('{} {}'.format(install_script, distribution))
+        shell_output, return_code = execute_shell_command_get_return_code('{} {}'.format(install_script, distribution), timeout=10)
         if return_code != 0:
             raise InstallationError('Error in installation of {} plugin\n{}'.format(Path(install_script).parent.name, shell_output))
 
@@ -124,16 +124,16 @@ def _install_yara(distribution):
     else:
         broken, output = False, ''
 
-        wget_output, wget_code = execute_shell_command_get_return_code('wget https://github.com/VirusTotal/yara/archive/v3.7.1.zip')
+        wget_output, wget_code = execute_shell_command_get_return_code('wget https://github.com/VirusTotal/yara/archive/v3.7.1.zip', timeout=10)
         if wget_code != 0:
             raise InstallationError('Error on yara download.\n{}'.format(wget_output))
-        zip_output, zip_code = execute_shell_command_get_return_code('unzip v3.7.1.zip')
+        zip_output, zip_code = execute_shell_command_get_return_code('unzip v3.7.1.zip', timeout=10)
         if zip_code == 0:
             yara_folder = [child for child in Path('.').iterdir() if 'yara-3.' in child.name][0]
             with OperateInDirectory(yara_folder.name, remove=True):
                 os.chmod('bootstrap.sh', 0o775)
                 for command in ['./bootstrap.sh', './configure --enable-magic', 'make -j$(nproc)', 'sudo make install']:
-                    output, return_code = execute_shell_command_get_return_code(command)
+                    output, return_code = execute_shell_command_get_return_code(command, timeout=10)
                     if return_code != 0:
                         broken = True
                         break

--- a/src/install/common.py
+++ b/src/install/common.py
@@ -15,7 +15,7 @@ from helperFunctions.install import (
 def install_pip(python_command):
     logging.info('Installing {} pip'.format(python_command))
     for command in ['wget https://bootstrap.pypa.io/get-pip.py', 'sudo -EH {} get-pip.py'.format(python_command), 'rm get-pip.py']:
-        output, return_code = execute_shell_command_get_return_code(command)
+        output, return_code = execute_shell_command_get_return_code(command, timeout=10)
         if return_code != 0:
             raise InstallationError('Error in pip installation for {}:\n{}'.format(python_command, output))
 
@@ -31,10 +31,10 @@ def main(distribution):  # pylint: disable=too-many-statements
         logging.info('Updating system')
         apt_update_sources()
 
-    _, is_repository = execute_shell_command_get_return_code('git status')
+    _, is_repository = execute_shell_command_get_return_code('git status', timeout=10)
     if is_repository == 0:
         # update submodules
-        git_output, git_code = execute_shell_command_get_return_code('(cd ../../ && git submodule foreach "git pull")')
+        git_output, git_code = execute_shell_command_get_return_code('(cd ../../ && git submodule foreach "git pull")', timeout=10)
         if git_code != 0:
             raise InstallationError('Failed to update submodules\n{}'.format(git_output))
     else:

--- a/src/install/db.py
+++ b/src/install/db.py
@@ -20,7 +20,7 @@ MONGO_MIRROR_COMMANDS = {
 
 
 def _get_db_directory():
-    output, return_code = execute_shell_command_get_return_code(r'grep -oP "dbPath:[\s]*\K[^\s]+" ../config/mongod.conf')
+    output, return_code = execute_shell_command_get_return_code(r'grep -oP "dbPath:[\s]*\K[^\s]+" ../config/mongod.conf', timeout=10)
     if return_code != 0:
         raise InstallationError('Unable to locate target for database directory')
     return output.strip()
@@ -30,7 +30,7 @@ def _add_mongo_mirror(distribution):
     apt_key_output, apt_key_code = execute_shell_command_get_return_code(
         MONGO_MIRROR_COMMANDS[distribution]['key']
     )
-    tee_output, tee_code = execute_shell_command_get_return_code(
+    tee_output, tee_code = execute__get_return_code(
         MONGO_MIRROR_COMMANDS[distribution]['sources']
     )
     if any(code != 0 for code in (apt_key_code, tee_code)):
@@ -51,15 +51,15 @@ def main(distribution):
 
     # creating DB directory
     fact_db_directory = _get_db_directory()
-    mkdir_output, _ = execute_shell_command_get_return_code('sudo mkdir -p --mode=0744 {}'.format(fact_db_directory))
-    chown_output, chown_code = execute_shell_command_get_return_code('sudo chown {}:{} {}'.format(os.getuid(), os.getgid(), fact_db_directory))
+    mkdir_output, _ = execute_shell_command_get_return_code('sudo mkdir -p --mode=0744 {}'.format(fact_db_directory), timeout=10)
+    chown_output, chown_code = execute_shell_command_get_return_code('sudo chown {}:{} {}'.format(os.getuid(), os.getgid(), fact_db_directory), timeout=10)
     if chown_code != 0:
         raise InstallationError('Failed to set up database directory. Check if parent folder exists\n{}'.format('\n'.join((mkdir_output, chown_output))))
 
     # initializing DB authentication
     logging.info('Initialize database')
     with OperateInDirectory('..'):
-        init_output, init_code = execute_shell_command_get_return_code('python3 init_database.py')
+        init_output, init_code = execute_shell_command_get_return_code('python3 init_database.py', timeout=10)
     if init_code != 0:
         raise InstallationError('Unable to initialize database\n{}'.format(init_output))
 

--- a/src/install/frontend.py
+++ b/src/install/frontend.py
@@ -17,7 +17,7 @@ COMPOSE_VENV = Path(__file__).parent.absolute() / 'compose-env'
 def execute_commands_and_raise_on_return_code(commands, error=None):  # pylint: disable=invalid-name
     for command in commands:
         bad_return = error if error else 'execute {}'.format(command)
-        output, return_code = execute_shell_command_get_return_code(command)
+        output, return_code = execute_shell_command_get_return_code(command, timeout=10)
         if return_code != 0:
             raise InstallationError('Failed to {}\n{}'.format(bad_return, output))
 
@@ -25,11 +25,11 @@ def execute_commands_and_raise_on_return_code(commands, error=None):  # pylint: 
 def wget_static_web_content(url, target_folder, additional_actions, resource_logging_name=None):
     logging.info('Install static {} content'.format(resource_logging_name if resource_logging_name else url))
     with OperateInDirectory(target_folder):
-        wget_output, wget_code = execute_shell_command_get_return_code('wget -nc {}'.format(url))
+        wget_output, wget_code = execute_shell_command_get_return_code('wget -nc {}'.format(url), timeout=10)
         if wget_code != 0:
             raise InstallationError('Failed to fetch resource at {}\n{}'.format(url, wget_output))
         for action in additional_actions:
-            action_output, action_code = execute_shell_command_get_return_code(action)
+            action_output, action_code = execute_shell_command_get_return_code(action, timeout=10)
             if action_code != 0:
                 raise InstallationError('Problem in processing resource at {}\n{}'.format(url, action_output))
 
@@ -62,8 +62,8 @@ def _create_directory_for_authentication():  # pylint: disable=invalid-name
     dburi = config.get('data_storage', 'user_database')
     factauthdir = '/'.join(dburi.split('/')[:-1])[10:]  # FIXME this should be beautified with pathlib
 
-    mkdir_output, mkdir_code = execute_shell_command_get_return_code('sudo mkdir -p --mode=0744 {}'.format(factauthdir))
-    chown_output, chown_code = execute_shell_command_get_return_code('sudo chown {}:{} {}'.format(os.getuid(), os.getgid(), factauthdir))
+    mkdir_output, mkdir_code = execute_shell_command_get_return_code('sudo mkdir -p --mode=0744 {}'.format(factauthdir), timeout=10)
+    chown_output, chown_code = execute_shell_command_get_return_code('sudo chown {}:{} {}'.format(os.getuid(), os.getgid(), factauthdir), timeout=10)
 
     if not all(return_code == 0 for return_code in [mkdir_code, chown_code]):
         raise InstallationError('Error in creating directory for authentication database.\n{}'.format('\n'.join((mkdir_output, chown_output))))
@@ -73,7 +73,7 @@ def _install_nginx():
     apt_install_packages('nginx')
     _generate_and_install_certificate()
     _configure_nginx()
-    nginx_output, nginx_code = execute_shell_command_get_return_code('sudo nginx -s reload')
+    nginx_output, nginx_code = execute_shell_command_get_return_code('sudo nginx -s reload', timeout=10)
     if nginx_code != 0:
         raise InstallationError('Failed to start nginx\n{}'.format(nginx_output))
 
@@ -175,19 +175,19 @@ def main(radare, nginx):
     if radare:
         logging.info('Initializing docker container for radare')
 
-        execute_shell_command_get_return_code('virtualenv {}'.format(COMPOSE_VENV))
-        output, return_code = execute_shell_command_get_return_code('{} install -U docker-compose'.format(COMPOSE_VENV / 'bin' / 'pip'))
+        execute_shell_command_get_return_code('virtualenv {}'.format(COMPOSE_VENV), timeout=10)
+        output, return_code = execute_shell_command_get_return_code('{} install -U docker-compose'.format(COMPOSE_VENV / 'bin' / 'pip'), timeout=10)
         if return_code != 0:
             raise InstallationError('Failed to set up virtualenv for docker-compose\n{}'.format(output))
 
         with OperateInDirectory('radare'):
-            output, return_code = execute_shell_command_get_return_code('{} build'.format(COMPOSE_VENV / 'bin' / 'docker-compose'))
+            output, return_code = execute_shell_command_get_return_code('{} build'.format(COMPOSE_VENV / 'bin' / 'docker-compose'), timeout=10)
             if return_code != 0:
                 raise InstallationError('Failed to initialize radare container:\n{}'.format(output))
 
     # pull pdf report container
     logging.info('Pulling pdf report container')
-    output, return_code = execute_shell_command_get_return_code('docker pull fkiecad/fact_pdf_report')
+    output, return_code = execute_shell_command_get_return_code('docker pull fkiecad/fact_pdf_report', timeout=10)
     if return_code != 0:
         raise InstallationError('Failed to pull pdf report container:\n{}'.format(output))
 


### PR DESCRIPTION
Second attempt to fix #477.   Only added timeouts to 5 installation files.  Timeouts are hardcoded at 10s at this time.  This time it throws an error while trying to `Install static jstree content` instead of hanging:
![timeout](https://user-images.githubusercontent.com/12942571/91479791-010f9100-e870-11ea-84b3-d368d342e402.PNG)
As a result I can see that the problem was caused by a permission error, which is much more helpful than getting stuck. Still haven't found the solution, but I have better clues now.