### PR TITLE
Orphaned objects

### DIFF
--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -371,6 +371,9 @@ class DatabaseMock:  # pylint: disable=too-many-public-methods
     def find_failed_analyses(self):
         return {'plugin': ['missing_child_uid']}
 
+    def find_orphaned_objects(self):
+        return {'root_fw_uid': ['missing_child_uid']}
+
 
 def fake_exit(self, *args):
     pass

--- a/src/test/integration/storage/test_db_interface_frontend.py
+++ b/src/test/integration/storage/test_db_interface_frontend.py
@@ -218,6 +218,22 @@ class TestStorageDbInterfaceFrontend(unittest.TestCase):
         missing_files = self.db_frontend_interface.find_missing_files()
         assert missing_files == {}
 
+    def test_find_orphaned_objects(self):
+        test_fo = create_test_file_object()
+        test_fo.uid = 'fo_uid'
+        test_fo.parent_firmware_uids = ['missing_parent_uid']
+        self.db_backend_interface.add_file_object(test_fo)
+        orphans = self.db_frontend_interface.find_orphaned_objects()
+        assert 'missing_parent_uid' in orphans
+        assert orphans['missing_parent_uid'] == ['fo_uid']
+
+        test_fw = create_test_firmware()
+        test_fw.uid = 'missing_parent_uid'
+        self.db_backend_interface.add_firmware(test_fw)
+
+        orphans = self.db_frontend_interface.find_orphaned_objects()
+        assert len(orphans) == 0
+
     def test_find_missing_analyses(self):
         test_fw_1 = create_test_firmware()
         test_fo = create_test_file_object()

--- a/src/test/unit/web_interface/test_app_missing_analyses.py
+++ b/src/test/unit/web_interface/test_app_missing_analyses.py
@@ -14,6 +14,9 @@ class MissingAnalysesDbMock(DatabaseMock):
     def find_failed_analyses(self):
         return self.result
 
+    def find_orphaned_objects(self):
+        return self.result
+
 
 class TestAppMissingAnalyses(WebInterfaceTest):
     def setUp(self, db_mock=None):

--- a/src/web_interface/components/miscellaneous_routes.py
+++ b/src/web_interface/components/miscellaneous_routes.py
@@ -78,6 +78,7 @@ class MiscellaneousRoutes(ComponentBase):
     def _app_find_missing_analyses(self):
         template_data = {
             'missing_files': self._find_missing_files(),
+            'orphaned_files': self._find_orphaned_files(),
             'missing_analyses': self._find_missing_analyses(),
             'failed_analyses': self._find_failed_analyses(),
         }
@@ -87,6 +88,16 @@ class MiscellaneousRoutes(ComponentBase):
         start = time()
         with ConnectTo(FrontEndDbInterface, config=self._config) as db:
             parent_to_included = db.find_missing_files()
+        return {
+            'tuples': list(parent_to_included.items()),
+            'count': self._count_values(parent_to_included),
+            'duration': format_time(time() - start),
+        }
+
+    def _find_orphaned_files(self):
+        start = time()
+        with ConnectTo(FrontEndDbInterface, config=self._config) as db:
+            parent_to_included = db.find_orphaned_objects()
         return {
             'tuples': list(parent_to_included.items()),
             'count': self._count_values(parent_to_included),

--- a/src/web_interface/rest/rest_missing_analyses.py
+++ b/src/web_interface/rest/rest_missing_analyses.py
@@ -18,9 +18,13 @@ class RestMissingAnalyses(Resource):
     @roles_accepted(*PRIVILEGES['delete'])
     def get(self):
         with ConnectTo(FrontEndDbInterface, self.config) as db:
-            missing_files = self._make_json_serializable(db.find_missing_files())
-            missing_analyses = self._make_json_serializable(db.find_missing_analyses())
-        return success_message(dict(missing_files=missing_files, missing_analyses=missing_analyses), self.URL)
+            missing_analyses_data = {
+                'missing_files': self._make_json_serializable(db.find_missing_files()),
+                'missing_analyses': self._make_json_serializable(db.find_missing_analyses()),
+                'failed_analyses': db.find_failed_analyses(),
+                'orphaned_objects': db.find_orphaned_objects(),
+            }
+        return success_message(missing_analyses_data, self.URL)
 
     @staticmethod
     def _make_json_serializable(set_dict: Dict[str, Set[str]]) -> Dict[str, List[str]]:

--- a/src/web_interface/templates/find_missing_analyses.html
+++ b/src/web_interface/templates/find_missing_analyses.html
@@ -66,7 +66,7 @@
                         {{ parent_uid }}
                     </td>
                     <td>
-                        {{ uid_list | nice_uid_list | safe }}
+                        {{ uid_list | nice_uid_list(filename_only=True) | safe }}
                     </td>
                 </tr>
                 {%- endfor -%}

--- a/src/web_interface/templates/find_missing_analyses.html
+++ b/src/web_interface/templates/find_missing_analyses.html
@@ -58,6 +58,20 @@
                 {% endfor %}
 {% endcall %}
 
+{# orphaned_files #}
+{% call missing_analyses_block(orphaned_files, "Orphaned Files", "Missing Parent Firmware UID", "File UID") %}
+                {%- for parent_uid, uid_list in orphaned_files.tuples | sort -%}
+                <tr>
+                    <td>
+                        {{ parent_uid }}
+                    </td>
+                    <td>
+                        {{ uid_list | nice_uid_list | safe }}
+                    </td>
+                </tr>
+                {%- endfor -%}
+{% endcall %}
+
 {# missing_analyses #}
 {% call missing_analyses_block(missing_analyses, "Missing Analyses", "Parent Firmware", "Files Missing Analyses") %}
                 {% for parent_uid, uid_list in missing_analyses.tuples | sort -%}


### PR DESCRIPTION
- added "orphaned objects" to the missing analyses page, showing file objects whose parent firmware is missing from the database