### PR TITLE
no more sanitize db duplicate entries

### DIFF
--- a/src/storage/db_interface_common.py
+++ b/src/storage/db_interface_common.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import pickle
+from hashlib import md5
 from typing import List, Set
 
 import gridfs
@@ -178,11 +179,21 @@ class MongoInterfaceCommon(MongoInterface):  # pylint: disable=too-many-instance
         for analysis_key in analysis_dict[key].keys():
             if analysis_key != 'summary':
                 file_name = '{}_{}_{}'.format(get_safe_name(key), get_safe_name(analysis_key), uid)
-                self.sanitize_fs.put(pickle.dumps(analysis_dict[key][analysis_key]), filename=file_name)
+                self._store_in_sanitize_db(pickle.dumps(analysis_dict[key][analysis_key]), file_name)
                 tmp_dict[analysis_key] = file_name
             else:
                 tmp_dict[analysis_key] = analysis_dict[key][analysis_key]
         return tmp_dict
+
+    def _store_in_sanitize_db(self, content: bytes, file_name: str):
+        if self.sanitize_fs.exists({'filename': file_name}):
+            md5_hash = md5(content).hexdigest()
+            if self.sanitize_fs.exists({'md5': md5_hash, 'filename': file_name}):
+                return  # there is already an up to date entry -> do nothing
+            for old_entry in self.sanitize_fs.find({'filename': file_name}):  # delete old entries first
+                logging.debug('deleting old sanitize db entry of {} with id {}'.format(file_name, old_entry._id))  # pylint: disable=protected-access
+                self.sanitize_fs.delete(old_entry._id)  # pylint: disable=protected-access
+        self.sanitize_fs.put(content, filename=file_name)
 
     def _retrieve_binaries(self, sanitized_dict, key):
         tmp_dict = {}

--- a/src/storage/db_interface_common.py
+++ b/src/storage/db_interface_common.py
@@ -188,7 +188,7 @@ class MongoInterfaceCommon(MongoInterface):  # pylint: disable=too-many-instance
     def _store_in_sanitize_db(self, content: bytes, file_name: str):
         if self.sanitize_fs.exists({'filename': file_name}):
             md5_hash = md5(content).hexdigest()
-            if self.sanitize_fs.exists({'md5': md5_hash, 'filename': file_name}):
+            if self.sanitize_fs.exists({'md5': md5_hash}):
                 return  # there is already an up to date entry -> do nothing
             for old_entry in self.sanitize_fs.find({'filename': file_name}):  # delete old entries first
                 logging.debug('deleting old sanitize db entry of {} with id {}'.format(file_name, old_entry._id))  # pylint: disable=protected-access

--- a/src/test/integration/storage/test_db_interface.py
+++ b/src/test/integration/storage/test_db_interface.py
@@ -136,10 +136,12 @@ class TestMongoInterface(unittest.TestCase):
         assert self.db_interface.sanitize_fs.find({'filename': gridfs_file_name}).count() == 1
         self.db_interface.sanitize_analysis(self.test_firmware.processed_analysis, self.test_firmware.uid)
         assert self.db_interface.sanitize_fs.find({'filename': gridfs_file_name}).count() == 1, 'duplicate entry was created'
+        md5 = self.db_interface.sanitize_fs.find_one({'filename': gridfs_file_name}).md5
 
         long_dict['stub_plugin']['result'] += 1  # new analysis result
         self.db_interface.sanitize_analysis(self.test_firmware.processed_analysis, self.test_firmware.uid)
         assert self.db_interface.sanitize_fs.find({'filename': gridfs_file_name}).count() == 1, 'duplicate entry was created'
+        assert self.db_interface.sanitize_fs.find_one({'filename': gridfs_file_name}).md5 != md5, 'hash of new file did not change'
 
     def test_retrieve_analysis(self):
         self.db_interface.sanitize_fs.put(pickle.dumps('This is a test!'), filename='test_file_path')

--- a/src/test/integration/storage/test_db_interface.py
+++ b/src/test/integration/storage/test_db_interface.py
@@ -13,6 +13,8 @@ from storage.db_interface_common import MongoInterfaceCommon
 from storage.MongoMgr import MongoMgr
 from test.common_helper import create_test_file_object, create_test_firmware, get_config_for_testing, get_test_data_dir
 
+# pylint: disable=protected-access,attribute-defined-outside-init
+
 TESTS_DIR = get_test_data_dir()
 test_file_one = path.join(TESTS_DIR, 'get_files_test/testfile1')
 TMP_DIR = TemporaryDirectory(prefix='fact_test_')
@@ -123,6 +125,21 @@ class TestMongoInterface(unittest.TestCase):
         self.assertIn('file_system_flag', sanitized_dict['stub_plugin'].keys())
         self.assertTrue(sanitized_dict['stub_plugin']['file_system_flag'])
         self.assertEqual(type(sanitized_dict['stub_plugin']['summary']), list)
+
+    def test_sanitize_db_duplicates(self):
+        long_dict = {'stub_plugin': {'result': 10000000000, 'misc': 'Bananarama', 'summary': []}}
+        gridfs_file_name = 'stub_plugin_result_{}'.format(self.test_firmware.uid)
+
+        self.test_firmware.processed_analysis = long_dict
+        assert self.db_interface.sanitize_fs.find({'filename': gridfs_file_name}).count() == 0
+        self.db_interface.sanitize_analysis(self.test_firmware.processed_analysis, self.test_firmware.uid)
+        assert self.db_interface.sanitize_fs.find({'filename': gridfs_file_name}).count() == 1
+        self.db_interface.sanitize_analysis(self.test_firmware.processed_analysis, self.test_firmware.uid)
+        assert self.db_interface.sanitize_fs.find({'filename': gridfs_file_name}).count() == 1, 'duplicate entry was created'
+
+        long_dict['stub_plugin']['result'] += 1  # new analysis result
+        self.db_interface.sanitize_analysis(self.test_firmware.processed_analysis, self.test_firmware.uid)
+        assert self.db_interface.sanitize_fs.find({'filename': gridfs_file_name}).count() == 1, 'duplicate entry was created'
 
     def test_retrieve_analysis(self):
         self.db_interface.sanitize_fs.put(pickle.dumps('This is a test!'), filename='test_file_path')
@@ -273,14 +290,14 @@ class TestSummary(unittest.TestCase):
         self.assertIn(self.test_fw.uid, result_set_fw, 'fw not in result set firmware')
 
     def test_get_uids_of_all_included_files(self):
-        def add_test_file_to_db_with_parent_uids(uid, parent_uids: Set[str]):
+        def add_test_file_to_db(uid, parent_uids: Set[str]):
             test_fo = create_test_file_object()
             test_fo.parent_firmware_uids = parent_uids
             test_fo.uid = uid
             self.db_interface_backend.add_object(test_fo)
-        add_test_file_to_db_with_parent_uids('uid1', {'foo'})
-        add_test_file_to_db_with_parent_uids('uid2', {'foo', 'bar'})
-        add_test_file_to_db_with_parent_uids('uid3', {'bar'})
+        add_test_file_to_db('uid1', {'foo'})
+        add_test_file_to_db('uid2', {'foo', 'bar'})
+        add_test_file_to_db('uid3', {'bar'})
         result = self.db_interface.get_uids_of_all_included_files('foo')
         assert result == {'uid1', 'uid2'}
 


### PR DESCRIPTION
- duplicate entries in the "sanitize_db" were created each time `sanitize_analysis()` was called
- fix: only create entry if there is none or if it has changed and delete old ones