### PR TITLE
Switch to stable cwe_checker-Docker-image

### DIFF
--- a/src/plugins/analysis/cwe_checker/install.sh
+++ b/src/plugins/analysis/cwe_checker/install.sh
@@ -8,7 +8,7 @@ echo " Installing cwe_checker Plugin "
 echo "------------------------------------"
 
 echo "Trying to pull cwe_checker Docker image"
-docker pull fkiecad/cwe_checker:latest
+docker pull fkiecad/cwe_checker:stable
 return_code=$?
 
 if [[ ${return_code} -eq 0 ]]; then


### PR DESCRIPTION
Switch to the stable cwe_checker Docker image, since the latest container will introduce some breaking changes to its interface in the the future.