### PR TITLE
fixed bug in live stats

### DIFF
--- a/src/web_interface/components/ajax_routes.py
+++ b/src/web_interface/components/ajax_routes.py
@@ -135,7 +135,7 @@ class AjaxRoutes(ComponentBase):
                 'backend_cpu_percentage': '{}%'.format(backend_data['system']['cpu_percentage']),
                 'number_of_running_analyses': len(backend_data['analysis']['current_analyses'])
             }
-        except KeyError:
+        except (KeyError, TypeError):
             return {'backend_cpu_percentage': 'n/a', 'number_of_running_analyses': 'n/a'}
 
     @staticmethod


### PR DESCRIPTION
this should fix a bug with the live stats on the "home" page when no stats can be retrieved from the DB (see #538)