### PR TITLE
Sd1446 vfp wrong rootfw bugfix

### DIFF
--- a/src/compare/compare.py
+++ b/src/compare/compare.py
@@ -58,7 +58,7 @@ class Compare(object):
                 self._add_content_to_general_dict(general, 'firmwares_including_this_file', fo.uid, list(fo.get_virtual_file_paths().keys()))
             self._add_content_to_general_dict(general, 'hid', fo.uid, fo.get_hid())
             self._add_content_to_general_dict(general, 'size', fo.uid, fo.size)
-            self._add_content_to_general_dict(general, 'virtual_file_path', fo.uid, fo.get_virtual_paths_for_one_uid())
+            self._add_content_to_general_dict(general, 'virtual_file_path', fo.uid, fo.get_virtual_paths_for_all_uids())
             self._add_content_to_general_dict(general, 'number_of_files', fo.uid, len(fo.list_of_all_included_files))
         return general
 

--- a/src/compare/compare.py
+++ b/src/compare/compare.py
@@ -6,7 +6,7 @@ from objects.firmware import Firmware
 from storage.binary_service import BinaryService
 
 
-class Compare(object):
+class Compare:
     '''
     This Module compares firmware images
     '''
@@ -76,7 +76,7 @@ class Compare(object):
         self._init_plugins()
 
     def _init_plugins(self):
-        self.source = import_plugins('compare.plugins', 'plugins/compare')
+        self.source = import_plugins('compare.plugins', 'plugins/compare')  # pylint: disable=attribute-defined-outside-init
         for plugin_name in self.source.list_plugins():
             plugin = self.source.load_plugin(plugin_name)
             plugin.ComparePlugin(self, config=self.config, db_interface=self.db_interface)

--- a/src/objects/file.py
+++ b/src/objects/file.py
@@ -225,6 +225,18 @@ class FileObject:  # pylint: disable=too-many-instance-attributes
             return file_paths[req_root_uid]
         return get_value_of_first_key(file_paths)  # fallback
 
+    def get_virtual_paths_for_all_uids(self) -> List[str]:
+        '''
+        Get all virtual file paths (VFPs) of the file in all firmware containers.
+
+        :return: List of virtual paths.
+        '''
+        return [
+            vfp
+            for vfp_list in self.get_virtual_file_paths().values()
+            for vfp in vfp_list
+        ]
+
     def get_virtual_file_paths(self) -> Dict[str, list]:
         '''
         Get virtual file paths of current file.

--- a/src/test/unit/objects/test_file.py
+++ b/src/test/unit/objects/test_file.py
@@ -73,3 +73,8 @@ class TestObjectsFile:  # pylint: disable=no-self-use
         assert fo.get_virtual_paths_for_one_uid(root_uid='non_existing') == [fo.uid]
         fo.virtual_file_path = {'other_root': ['some_vfp']}
         assert fo.get_virtual_paths_for_one_uid(root_uid='non_existing') == ['some_vfp']
+
+    def test_get_virtual_paths_for_all_uids(self):
+        fo = FileObject(binary=b'foo')
+        fo.virtual_file_path = {'root_uid_1': ['vfp1', 'vfp2'], 'root_uid_2': ['vfp3']}
+        assert sorted(fo.get_virtual_paths_for_all_uids()) == ['vfp1', 'vfp2', 'vfp3']

--- a/src/web_interface/components/jinja_filter.py
+++ b/src/web_interface/components/jinja_filter.py
@@ -110,10 +110,10 @@ class FilterClass:
         return render_template('generic_view/firmware_detail_tabular_field.html', firmware=firmware_meta_data)
 
     @staticmethod
-    def _render_general_information_table(firmware, other_versions, selected_analysis):
+    def _render_general_information_table(firmware, root_uid, other_versions, selected_analysis):
         return render_template(
             'generic_view/general_information.html',
-            firmware=firmware, other_versions=other_versions, selected_analysis=selected_analysis
+            firmware=firmware, root_uid=root_uid, other_versions=other_versions, selected_analysis=selected_analysis
         )
 
     @staticmethod

--- a/src/web_interface/templates/generic_view/general_information.html
+++ b/src/web_interface/templates/generic_view/general_information.html
@@ -54,7 +54,8 @@
             </tr>
         {% endif %}
         <tr>
-            {{ field_with_icon('project-diagram', firmware.get_virtual_paths_for_one_uid(root_uid=root_uid) | nice_virtual_path_list | list_group_collapse | safe, 'Complete file paths in container', 5) }}
+            {% set vfp_list = firmware.get_virtual_paths_for_one_uid(root_uid=root_uid) if root_uid else firmware.get_virtual_paths_for_all_uids() %}
+            {{ field_with_icon('project-diagram', vfp_list | nice_virtual_path_list | list_group_collapse | safe, 'Complete file paths in container', 5) }}
         </tr>
         {% if other_versions %}
             <tr>

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -120,7 +120,7 @@
 
     {# General info section #}
     <div class="col-lg-6">
-        {{ firmware | render_general_information(other_versions, selected_analysis) | safe }}
+        {{ firmware | render_general_information(root_uid, other_versions, selected_analysis) | safe }}
     </div>
 
 </div>


### PR DESCRIPTION
- fixed a bug where the wrong virtual file paths were displayed on the analysis page
  - changed the shown virtual paths in case no "root uid" is provided from a random firmware container to all firmware containers