### PR TITLE
pre_install.sh: Check if CODENAME is nonempty

### DIFF
--- a/src/install/pre_install.sh
+++ b/src/install/pre_install.sh
@@ -14,6 +14,9 @@ elif [ "${CODENAME}" = "rebecca" ] || [ "${CODENAME}" = "rafaela" ] || [ "${CODE
     sudo apt-get -y install "linux-image-extra-$(uname -r)" linux-image-extra-virtual
 elif  [ "${CODENAME}" = "kali-rolling" ]; then
     CODENAME=buster
+elif [ -z "${CODENAME}" ]; then
+	echo "Could not get Ubuntu codename. Please make sure that lsb-release is installed."
+	exit 1
 fi
 
 echo "Install Pre-Install Requirements"


### PR DESCRIPTION
I didn't have `lsb-release` installed and then wondered why I got `E: Malformed entry 50 in list file /etc/apt/sources.list` later. Now the `pre_install.sh` will print an error when CODENAME is empty.