### PR TITLE
analysis/qemu_exec: Use `docker info` to test if docker is running

### DIFF
--- a/src/plugins/analysis/qemu_exec/code/qemu_exec.py
+++ b/src/plugins/analysis/qemu_exec/code/qemu_exec.py
@@ -353,5 +353,5 @@ def merge_identical_results(results: Dict[str, Dict[str, str]]):
 
 
 def docker_is_running() -> bool:
-    _, return_code = execute_shell_command_get_return_code('pgrep dockerd')
+    _, return_code = execute_shell_command_get_return_code('docker info')
     return return_code == 0

--- a/src/plugins/analysis/qemu_exec/install.sh
+++ b/src/plugins/analysis/qemu_exec/install.sh
@@ -3,7 +3,7 @@
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 
 # build docker container
-if [[ $(pgrep dockerd) ]]; then
+if docker info > /dev/null 2>&1 ; then
     (cd docker && docker build --build-arg=http{,s}_proxy --build-arg=HTTP{,S}_PROXY -t fact/qemu:latest .) || exit 1
 else
     echo "Error: docker daemon not running! Could not build docker image"


### PR DESCRIPTION
Previously `pgrep dockerd` was used to detect whether docker is running.
This assumes that the process is called "dockerd" and also is part of the
current the pid_namespace.
`docker info` on the other hand relies on docker's internal logic to find
out whether the server is running or not.


References #561 