### PR TITLE
fixed bug in cve_lookup setup + improved error logging

### DIFF
--- a/src/plugins/analysis/cve_lookup/internal/database_interface.py
+++ b/src/plugins/analysis/cve_lookup/internal/database_interface.py
@@ -63,8 +63,8 @@ class DatabaseInterface:
         try:
             self.connection = connect(db_path)
         except SqliteException as exception:
-            logging.warning('Could not connect to CPE database: {} {}'.format(type(exception).__name__, exception))
-            raise exception
+            logging.warning(f'Could not connect to CPE database: {exception}', exc_info=True)
+            raise
 
     def execute_query(self, query: str):
         with self.get_cursor() as cursor:
@@ -87,7 +87,10 @@ class DatabaseInterface:
 
     def insert_rows(self, query: str, input_data: list):
         with self.get_cursor() as cursor:
-            cursor.executemany(query, input_data)
+            wrong_entries = {e for e in input_data if len(e) != query.count('?')}
+            if wrong_entries:
+                logging.warning(f"Ignoring possibly wrong entries: {[e[2] for e in wrong_entries]}")
+            cursor.executemany(query, list(set(input_data) - wrong_entries))
             self.connection.commit()
 
     @contextmanager
@@ -97,7 +100,7 @@ class DatabaseInterface:
             cursor = self.connection.cursor()
             yield cursor
         except SqliteException as error:
-            logging.error('[cve_lookup]: encountered error while accessing DB: {} {}'.format(type(error).__name__, error))
+            logging.error(f'[cve_lookup]: Encountered error while accessing DB: {error}', exc_info=True)
         finally:
             with suppress(AttributeError, SqliteException):
                 cursor.close()

--- a/src/plugins/analysis/cve_lookup/internal/database_interface.py
+++ b/src/plugins/analysis/cve_lookup/internal/database_interface.py
@@ -62,8 +62,8 @@ class DatabaseInterface:
         self.connection = None
         try:
             self.connection = connect(db_path)
-        except SqliteException as exception:
-            logging.warning(f'Could not connect to CPE database: {exception}', exc_info=True)
+        except SqliteException:
+            logging.error('Could not connect to CPE database.')
             raise
 
     def execute_query(self, query: str):
@@ -89,7 +89,7 @@ class DatabaseInterface:
         with self.get_cursor() as cursor:
             wrong_entries = {e for e in input_data if len(e) != query.count('?')}
             if wrong_entries:
-                logging.warning(f"Ignoring possibly wrong entries: {[e[2] for e in wrong_entries]}")
+                logging.warning(f'Ignoring possibly wrong entries: {[e[2] for e in wrong_entries]}')
             cursor.executemany(query, list(set(input_data) - wrong_entries))
             self.connection.commit()
 

--- a/src/plugins/analysis/cve_lookup/internal/setup_repository.py
+++ b/src/plugins/analysis/cve_lookup/internal/setup_repository.py
@@ -24,7 +24,7 @@ except (ImportError, ValueError, SystemError):
 
 CURRENT_YEAR = datetime.now().year
 DATABASE = DatabaseInterface()
-SPLIT_REGEX = r'(?<!\\)[:]'
+CPE_SPLIT_REGEX = r'(?<![\\:]):(?!:)|(?<=\\:):'  # don't split on '::' or '\:' but split on '\::'
 
 Years = namedtuple('Years', 'start_year end_year')
 
@@ -186,7 +186,7 @@ def setup_cve_feeds_table(cve_list: List[CveEntry]) -> List[Tuple[str, ...]]:
             year = entry.cve_id.split('-')[1]
             score_v2 = entry.impact.get('cvssV2', 'N/A')
             score_v3 = entry.impact.get('cvssV3', 'N/A')
-            cpe_elements = replace_characters_and_wildcards(re.split(SPLIT_REGEX, cpe_id)[2:])
+            cpe_elements = replace_characters_and_wildcards(re.split(CPE_SPLIT_REGEX, cpe_id)[2:])
             row = (
                 entry.cve_id, year, cpe_id, score_v2, score_v3, *cpe_elements,
                 version_start_including, version_start_excluding, version_end_including, version_end_excluding
@@ -197,15 +197,15 @@ def setup_cve_feeds_table(cve_list: List[CveEntry]) -> List[Tuple[str, ...]]:
 
 def setup_cpe_table(cpe_list: list) -> list:
     return [
-        (cpe, *replace_characters_and_wildcards(re.split(SPLIT_REGEX, cpe)[2:]))
+        (cpe, *replace_characters_and_wildcards(re.split(CPE_SPLIT_REGEX, cpe)[2:]))
         for cpe in cpe_list
     ]
 
 
 class Choice(Enum):
-    cpe = 'cpe'
-    cve = 'cve'
-    both = 'both'
+    cpe = 'cpe'  # pylint: disable=invalid-name
+    cve = 'cve'  # pylint: disable=invalid-name
+    both = 'both'  # pylint: disable=invalid-name
 
     def cpe_was_chosen(self):
         return self.value in [self.cpe.value, self.both.value]

--- a/src/plugins/analysis/cve_lookup/test/test_database_interface.py
+++ b/src/plugins/analysis/cve_lookup/test/test_database_interface.py
@@ -50,7 +50,7 @@ def test_select_functionality():
 
 def test_insert_functionality():
     with DatabaseInterface(TEST_DB_PATH) as db:
-        db.insert_rows(TEST_QUERIES['test_insert'].format('test_table'), [[34]])
+        db.insert_rows(TEST_QUERIES['test_insert'].format('test_table'), [(34,)])
         test_insert_output = list(db.fetch_multiple(query=QUERIES['select_all'].format('test_table')))
         assert test_insert_output == [(23,), (34,)]
 

--- a/src/plugins/analysis/cve_lookup/test/test_setup_repository.py
+++ b/src/plugins/analysis/cve_lookup/test/test_setup_repository.py
@@ -295,7 +295,7 @@ def test_exists(monkeypatch):
 
 def test_extract_relevant_feeds():
     sr.DATABASE = sr.DatabaseInterface(PATH_TO_TEST + 'test_update.db')
-    assert [('CVE-2018-0002', 2018), ('CVE-2018-0003', 2018)] == sr.extract_relevant_feeds(from_table='new', where_table='outdated')
+    assert [('CVE-2018-0002', 2018), ('CVE-2018-0003', 2018)] == sorted(sr.extract_relevant_feeds(from_table='new', where_table='outdated'))
 
 
 def test_delete_outdated_feeds():
@@ -311,7 +311,7 @@ def test_create():
 
 def test_insert_into():
     sr.insert_into(query='test_insert', table_name='test', input_data=[(1,), (2,)])
-    assert [(1,), (2,)] == list(sr.DATABASE.fetch_multiple(query=QUERIES['select_all'].format('test')))
+    assert [(1,), (2,)] == sorted(sr.DATABASE.fetch_multiple(query=QUERIES['select_all'].format('test')))
 
 
 def test_drop_table():

--- a/src/plugins/analysis/cve_lookup/test/test_setup_repository.py
+++ b/src/plugins/analysis/cve_lookup/test/test_setup_repository.py
@@ -226,9 +226,11 @@ CVE_TABLE = [
 ]
 
 # contain input and expected results of the setup_cpe_format function
-CPE_LIST = ['cpe:2.3:a:\\$0.99_kindle_books_project:\\$0.99_kindle_books:6:*:*:*:*:android:*:*',
-            'cpe:2.3:a:1000guess:1000_guess:-:*:*:*:*:*:*:*', 'cpe:2.3:a:1024cms:1024_cms:0.7:*:*:*:*:*:*:*',
-            'cpe:2.3:a:1024cms:1024_cms:1.2.5:*:*:*:*:*:*:*', 'cpe:2.3:a:1024cms:1024_cms:1.3.1:*:*:*:*:*:*:*']
+CPE_LIST = [
+    'cpe:2.3:a:\\$0.99_kindle_books_project:\\$0.99_kindle_books:6:*:*:*:*:android:*:*',
+    'cpe:2.3:a:1000guess:1000_guess:-:*:*:*:*:*:*:*', 'cpe:2.3:a:1024cms:1024_cms:0.7:*:*:*:*:*:*:*',
+    'cpe:2.3:a:1024cms:1024_cms:1.2.5:*:*:*:*:*:*:*', 'cpe:2.3:a:1024cms:1024_cms:1.3.1:*:*:*:*:*:*:*'
+]
 CPE_TABLE = [
     ('cpe:2.3:a:\\$0.99_kindle_books_project:\\$0.99_kindle_books:6:*:*:*:*:android:*:*', 'a',
      '\\$0\\.99_kindle_books_project', '\\$0\\.99_kindle_books', '6', 'ANY', 'ANY', 'ANY', 'ANY', 'android', 'ANY', 'ANY'),
@@ -518,4 +520,22 @@ def test_setup_cve_summary_table():
 
 def test_setup_cpe_table():
     result = sr.setup_cpe_table(CPE_LIST)
-    assert CPE_TABLE == result
+    for entry in result:
+        assert len(entry) == 12
+    for actual, expected in zip(result, CPE_TABLE):
+        assert actual == expected
+
+
+def test_setup_cpe_entry_with_colons():
+    result = sr.setup_cpe_table([
+        'cpe:2.3:a:net::netmask_project:net::netmask:*:*:*:*:*:perl:*:*',
+        'cpe:2.3:a:lemonldap-ng:lemonldap\\:\\::1.0.3:*:*:*:*:*:*:*'
+    ])
+    expected_result = [
+        ('cpe:2.3:a:net::netmask_project:net::netmask:*:*:*:*:*:perl:*:*', 'a', 'net::netmask_project', 'net::netmask', 'ANY', 'ANY', 'ANY', 'ANY', 'ANY', 'perl', 'ANY', 'ANY'),
+        ('cpe:2.3:a:lemonldap-ng:lemonldap\\:\\::1.0.3:*:*:*:*:*:*:*', 'a', 'lemonldap\\-ng', 'lemonldap\\:\\:', '1\\.0\\.3', 'ANY', 'ANY', 'ANY', 'ANY', 'ANY', 'ANY', 'ANY')
+    ]
+    for entry in result:
+        assert len(entry) == 12
+    for actual, expected in zip(result, expected_result):
+        assert actual == expected


### PR DESCRIPTION
resolves #568 

there were some problems with the setup of the cve_lookup plugin:
- CVE entries can have CPE names with colons (which breaks parsing)
- there are new (broken?) CPE entries without "cpe23Uri"
- improved (more informative) error logging