### PR TITLE
Rework install scripts of plugins

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,6 +58,11 @@ $ src/install.py
 
 More advanced setup options can be viewed using the help function of the installer `$ src/install.py --help` and are explained in some detailed in the following paragraphs.
 
+If the environment variable `FACT_INSTALLER_SKIP_DOCKER` is set the installer
+will skip all pulling/building of docker images.
+This is primarily used for the docker container of FACT but can also be used to
+save some time when you already have the images.
+
 ## Multi system setup (**--backend**, **--frontend**, **--db**)
 
 The three components db, backend and frontend can be installed independently to create a distributed installation.

--- a/src/plugins/analysis/cwe_checker/install_docker.sh
+++ b/src/plugins/analysis/cwe_checker/install_docker.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 
-# change cwd to current file's directory
+# change cwd to this file's directory
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
-
-echo "------------------------------------"
-echo " Installing cwe_checker Plugin "
-echo "------------------------------------"
 
 echo "Trying to pull cwe_checker Docker image"
 docker pull fkiecad/cwe_checker:latest

--- a/src/plugins/analysis/file_system_metadata/install_docker.sh
+++ b/src/plugins/analysis/file_system_metadata/install_docker.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-# change cwd to current file's directory
+# change cwd to this file's directory
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 
 docker build -t fs_metadata_mounting docker || exit 1
-
-exit 0

--- a/src/plugins/analysis/input_vectors/install_docker.sh
+++ b/src/plugins/analysis/input_vectors/install_docker.sh
@@ -1,15 +1,9 @@
 #!/usr/bin/env bash
 
-# change cwd to current file's directory
+# change cwd to this file's directory
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
-
-echo "------------------------------------"
-echo " Installing input_vectors Plugin "
-echo "------------------------------------"
 
 docker pull fkiecad/radare-web-gui:latest || exit 1
 
 echo "Building docker container"
 docker build -t input-vectors . || exit 1
-
-exit 0

--- a/src/plugins/analysis/linter/install.sh
+++ b/src/plugins/analysis/linter/install.sh
@@ -39,7 +39,4 @@ else
 	sudo npm install -g jshint || exit 1
 fi
 
-# pull linguist docker image
-docker pull crazymax/linguist
-
 exit 0

--- a/src/plugins/analysis/linter/install_docker.sh
+++ b/src/plugins/analysis/linter/install_docker.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# pull linguist docker image
+docker pull crazymax/linguist
+

--- a/src/plugins/analysis/qemu_exec/install.sh
+++ b/src/plugins/analysis/qemu_exec/install.sh
@@ -2,14 +2,6 @@
 
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 
-# build docker container
-if docker info > /dev/null 2>&1 ; then
-    (cd docker && docker build --build-arg=http{,s}_proxy --build-arg=HTTP{,S}_PROXY -t fact/qemu:latest .) || exit 1
-else
-    echo "Error: docker daemon not running! Could not build docker image"
-    exit 1
-fi
-
 # get files for testing dynamically linked binary
 if [[ ! -e test/data/test_tmp_dir/lib/libc.so.6 ]]; then
     mkdir -p tmp

--- a/src/plugins/analysis/qemu_exec/install_docker.sh
+++ b/src/plugins/analysis/qemu_exec/install_docker.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
+
+# build docker container
+if docker info > /dev/null 2>&1 ; then
+    (cd docker && docker build --build-arg=http{,s}_proxy --build-arg=HTTP{,S}_PROXY -t fact/qemu:latest .) || exit 1
+else
+    echo "Error: docker daemon not running! Could not build docker image"
+    exit 1
+fi

--- a/src/plugins/analysis/software_components/install.sh
+++ b/src/plugins/analysis/software_components/install.sh
@@ -4,11 +4,8 @@ echo '-----------------------------------'
 echo 'Installation of Software Components'
 echo '-----------------------------------'
 
-# change cwd to current file's directory
+# change cwd to this file's directory
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
-
-# build docker container
-docker build -t fact/format_string_resolver docker || exit 1
 
 # extract software names
 python3 -c "from internal.extract_os_names import extract_names; extract_names()" || exit 1

--- a/src/plugins/analysis/software_components/install_docker.sh
+++ b/src/plugins/analysis/software_components/install_docker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# change cwd to this file's directory
+cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
+
+# build docker container
+docker build -t fact/format_string_resolver docker || exit 1


### PR DESCRIPTION
A new enviroment variable `FACT_INSTALLER_SKIP_DOCKER` is introduced. When this variable is set the installer will not pull/build any docker images.

Also two flags are added to the installer to pull/build the required docker images for the backend or frontend.

To make this seperation possible the plugin install scripts are split in two: `install.sh` and `install_docker.sh`.
The latter contains the pulling/building of docker images.

With this seperation it will be possible to use the installer in `Dockerfile`'s.

TODO:
- [x] Consider if an environment variable is the right way to communicate to the installer that no docker images shall be build/pulled
- [x] Documentation
