### PR TITLE
Create Dockerfile

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,6 +58,11 @@ $ src/install.py
 
 More advanced setup options can be viewed using the help function of the installer `$ src/install.py --help` and are explained in some detailed in the following paragraphs.
 
+If the environment variable `FACT_INSTALLER_SKIP_DOCKER` is set the installer
+will skip all pulling/building of docker images.
+This is primarily used for the docker container of FACT but can also be used to
+save some time when you already have the images.
+
 ## Multi system setup (**--backend**, **--frontend**, **--db**)
 
 The three components db, backend and frontend can be installed independently to create a distributed installation.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,6 +17,9 @@ $ ~/FACT_core/start_all_installed_fact_components
 Wait a few seconds, open your browser and go to `localhost:5000`  
 Use `Ctrl + c` in your terminal to shutdown FACT.
 
+## Docker installation
+See [docker instructions](docker/README.md).
+
 ## Simple One System Setup
 
 ### Pre-Install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:focal
+
+RUN apt -y update && apt -y upgrade
+# Install deps that are not automatically installed by pre_install.sh
+# TODO use "--no-install-recommends" here. git has some optional deps that prevent it from cloning
+RUN apt -y install git sudo lsb-release wget
+
+RUN DEBIAN_FRONTEND="noninteractive" apt -y install tzdata
+
+RUN useradd -r fact
+RUN mkdir /opt/FACT_core && chown fact: /opt/FACT_core
+RUN printf 'fact	ALL=(ALL:ALL) NOPASSWD: ALL\n' > /etc/sudoers.d/99_fact
+
+USER fact:fact
+RUN git clone --branch docker https://github.com/maringuu/FACT_core.git /opt/FACT_core
+RUN /opt/FACT_core/src/install/pre_install.sh
+
+# We cd to /tmp to have the directory writable for the log file
+RUN cd /tmp && FACT_INSTALLER_SKIP_DOCKER=y /opt/FACT_core/src/install.py
+
+COPY entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,53 @@
+VERSION ?= latest
+IMAGE_NAME ?= fkiecad/fact
+CONTAINER_NAME ?= fact
+
+DOCKER_HOST ?= /var/run/docker.sock
+
+# Default to the config contained in this repo
+FACT_CONFIG_DIR ?= $(shell realpath $(shell dirname $(MAKEFILE_LIST)))/../src/config
+
+FACT_FW_DATA_PATH ?= /media/data/fact_fw_data/
+FACT_FW_DATA_GID ?= $(shell id -g)
+FACT_WT_MONGODB_PATH ?= /media/data/fact_wt_mongodb/
+FACT_WT_MONGODB_GID ?= $(shell id -g)
+
+# Auto generate a help page from comments after the targets
+# https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+
+help: ## This help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+build: ## Build the container
+	docker build --rm -t $(IMAGE_NAME) .
+
+run: ## Run container
+	# --group-add is needed to give the user inside the contianer
+	# permission to read&write to the docker socket
+
+	# TODO remove -v /tmp:/tmp
+	# It is needed in some places e.g. src/unpacker/unpack_base.py:23-27
+	docker run \
+		-it \
+		--name $(CONTAINER_NAME) \
+		--hostname $(CONTAINER_NAME) \
+		--group-add $(shell getent group docker | cut -d: -f3) \
+		-v $(DOCKER_HOST):/var/run/docker.sock \
+		--mount type=bind,source=$(FACT_CONFIG_DIR),destination=/opt/FACT_core/src/config/ \
+		--group-add $(FACT_FW_DATA_GID) \
+		-v $(FACT_FW_DATA_PATH):/media/data/fact_fw_data/ \
+		--group-add $(FACT_WT_MONGODB_GID) \
+		-v $(FACT_WT_MONGODB_PATH):/media/data/fact_wt_mongodb/ \
+		-v /tmp:/tmp \
+		-p 5000:5000 \
+		$(IMAGE_NAME):$(VERSION) init_database
+
+start: ## Start container
+	docker start -i $(CONTAINER_NAME)
+
+stop: ## Stop a running container
+	docker stop $(CONTAINER_NAME)
+
+remove: ## Remove the container
+	docker rm $(CONTAINER_NAME)

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,37 @@
+# Docker image for FACT_core
+The `Dockerfile` provides an installation of all fact components (db, frontend,
+backend).
+To build the image run `make build`.
+All other commands can be shown with `make help`.
+
+Because FACT uses docker itselve, the docker socket from the host will be
+passed to the container. This means that the use you run `make run` with needs
+to have permissions to use docker.
+The docker images that FACT requires can be build/pulled with `install.py
+--backend-docker-images --frontend-docker-images`
+
+## Environment variables
+The Makefile uses the following environment variables.
+
+`VERSION`: The version to be tagged when running `make build`
+
+`IMAGE_NAME`: The name to be tagged when running `make build`
+
+`CONTAINER_NAME`: The name of the container
+
+`DOCKER_HOST`: Path to the docker socket. Default is `/var/run/docker.sock`
+
+`FACT_CONFIG_DIR`: Path to the directory containing all config files for FACT.
+Default is `../src/config`
+
+`FACT_FW_DATA_PATH`: Path to the fact\_fw\_data directory on the host. Default
+is /media/data/fact\_fw\_data/
+
+`FACT_FW_DATA_GID`: Group of the `FACT_FW_DATA_PATH` directory. The group must
+have rwx permissions. Default is `id -g`
+
+`FACT_WT_MONGODB_PATH`: Path to the fact_t_mongodb directory on the host.
+Default is /media/data/fact\_wt\_mongodb/
+
+`FACT_WT_MONGODB_GID`: Group of the `FACT_WT_MONGODB_PATH` directory. The group
+must have rwx permissions. Default is `id -g`

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$1" = "init_database" ] ; then
+    python3 /opt/FACT_core/src/init_database.py
+fi
+
+shift 1
+
+exec /opt/FACT_core/start_all_installed_fact_components "$@"

--- a/src/install.py
+++ b/src/install.py
@@ -19,6 +19,7 @@
 
 import argparse
 import logging
+import os
 import sys
 from pathlib import Path
 
@@ -30,7 +31,10 @@ try:
     from helperFunctions.install import OperateInDirectory
     from install.common import main as common
     from install.frontend import main as frontend
+    from install.frontend import _install_docker_images as frontend_install_docker_images
     from install.backend import main as backend
+    from install.backend import _install_docker_images as backend_install_docker_images
+    from install.backend import _install_plugin_docker_images as backend_install_plugin_docker_images
     from install.db import main as db
 except ImportError:
     logging.critical('Could not import install dependencies. Please (re-)run install/pre_install.sh', exc_info=True)
@@ -46,6 +50,8 @@ BIONIC_CODE_NAMES = ['bionic', 'tara', 'tessa', 'tina', 'disco']
 DEBIAN_CODE_NAMES = ['buster', 'stretch', 'kali-rolling']
 FOCAL_CODE_NAMES = ['focal', 'ulyana']
 
+FACT_INSTALLER_SKIP_DOCKER = os.getenv("FACT_INSTALLER_SKIP_DOCKER")
+
 
 def _setup_argparser():
     parser = argparse.ArgumentParser(description='{} - {}'.format(PROGRAM_NAME, PROGRAM_DESCRIPTION))
@@ -53,6 +59,8 @@ def _setup_argparser():
     install_options = parser.add_argument_group('Install Options', 'Choose which components should be installed')
     for item in INSTALL_CANDIDATES:
         install_options.add_argument('-{}'.format(item[0].upper()), '--{}'.format(item), action='store_true', default=False, help='install {}'.format(item))
+    install_options.add_argument('--backend-docker-images', action='store_true', default=False, help='pull/build docker images required to run the backend')
+    install_options.add_argument('--frontend-docker-images', action='store_true', default=False, help='pull/build docker images required to run the frontend')
     install_options.add_argument('-N', '--nginx', action='store_true', default=False, help='install and configure nginx')
     install_options.add_argument('-R', '--no_radare', action='store_true', default=False, help='do not install radare view container')
     install_options.add_argument('-U', '--statistic_cronjob', action='store_true', default=False, help='install cronjob to update statistics hourly and variety data once a week.')
@@ -151,18 +159,30 @@ def install():
     welcome()
     distribution = check_distribution()
     none_chosen = not (args.frontend or args.db or args.backend)
+    # TODO maybe replace this with and arugment for argparser as it is not needed in the sh scripts
+    skip_docker = FACT_INSTALLER_SKIP_DOCKER is not None
+    # Note that the skip_docker environment variable overrides the cli argument
+    only_docker = not skip_docker and none_chosen and (args.backend_docker_images or args.frontend_docker_images)
 
     installation_directory = get_directory_of_current_file() / 'install'
 
     with OperateInDirectory(str(installation_directory)):
-        common(distribution)
+        if not only_docker:
+            common(distribution)
 
-        if args.frontend or none_chosen:
-            frontend(not args.no_radare, args.nginx)
-        if args.db or none_chosen:
-            db(distribution)
-        if args.backend or none_chosen:
-            backend(distribution)
+            if args.frontend or none_chosen:
+                frontend(skip_docker, not args.no_radare, args.nginx)
+            if args.db or none_chosen:
+                db(distribution)
+            if args.backend or none_chosen:
+                backend(skip_docker, distribution)
+        else:
+            if args.backend_docker_images:
+                backend_install_docker_images()
+                backend_install_plugin_docker_images()
+
+            if args.frontend_docker_images:
+                frontend_install_docker_images(not args.no_radare)
 
     if args.statistic_cronjob:
         install_statistic_cronjob()

--- a/src/install/backend.py
+++ b/src/install/backend.py
@@ -15,7 +15,7 @@ from helperFunctions.install import (
 BIN_DIR = Path(__file__).parent.parent / 'bin'
 
 
-def main(distribution):
+def main(skip_docker, distribution):
 
     # dependencies
     if distribution == 'fedora':
@@ -31,16 +31,13 @@ def main(distribution):
     # install checksec.sh
     _install_checksec(distribution)
 
-    # build extraction docker container
-    logging.info('Building fact extraction container')
-
-    output, return_code = execute_shell_command_get_return_code('docker pull fkiecad/fact_extractor')
-    if return_code != 0:
-        raise InstallationError(f'Failed to pull extraction container:\n{output}')
-
     # installing common code modules
     pip3_install_packages('git+https://github.com/fkie-cad/common_helper_yara.git')
     pip3_install_packages('git+https://github.com/mass-project/common_analysis_base.git')
+
+    if not skip_docker:
+        _install_docker_images()
+        _install_plugin_docker_images()
 
     # install plug-in dependencies
     _install_plugins(distribution)
@@ -63,6 +60,29 @@ def main(distribution):
         Path('start_fact_backend').symlink_to('src/start_fact_backend.py')
 
     return 0
+
+
+def _install_docker_images():
+    # pull extraction docker container
+    logging.info('Pulling fact extraction container')
+
+    output, return_code = execute_shell_command_get_return_code('docker pull fkiecad/fact_extractor')
+    if return_code != 0:
+        raise InstallationError(f'Failed to pull extraction container:\n{output}')
+
+
+def _install_plugin_docker_images():
+    # TODO cosider whether this should replace "source install_docker.sh" in the install.sh files
+    logging.info('Installing plugin docker dependecies')
+    find_output, return_code = execute_shell_command_get_return_code('find ../plugins -iname "install_docker.sh"')
+    if return_code != 0:
+        raise InstallationError('Error retrieving plugin docker installation scripts')
+    for install_script in find_output.splitlines(keepends=False):
+        logging.info('Running {}'.format(install_script))
+        shell_output, return_code = execute_shell_command_get_return_code(f'{install_script}')
+        if return_code != 0:
+            raise InstallationError(
+                f'Error in installation of {Path(install_script).parent.name} plugin docker images docker images\n{shell_output}')
 
 
 def _edit_environment():

--- a/src/plugins/analysis/cwe_checker/install_docker.sh
+++ b/src/plugins/analysis/cwe_checker/install_docker.sh
@@ -1,11 +1,7 @@
 #!/usr/bin/env bash
 
-# change cwd to current file's directory
+# change cwd to this file's directory
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
-
-echo "------------------------------------"
-echo " Installing cwe_checker Plugin "
-echo "------------------------------------"
 
 echo "Trying to pull cwe_checker Docker image"
 docker pull fkiecad/cwe_checker:latest

--- a/src/plugins/analysis/file_system_metadata/install_docker.sh
+++ b/src/plugins/analysis/file_system_metadata/install_docker.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 
-# change cwd to current file's directory
+# change cwd to this file's directory
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 
 docker build -t fs_metadata_mounting docker || exit 1
-
-exit 0

--- a/src/plugins/analysis/input_vectors/install_docker.sh
+++ b/src/plugins/analysis/input_vectors/install_docker.sh
@@ -1,15 +1,9 @@
 #!/usr/bin/env bash
 
-# change cwd to current file's directory
+# change cwd to this file's directory
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
-
-echo "------------------------------------"
-echo " Installing input_vectors Plugin "
-echo "------------------------------------"
 
 docker pull fkiecad/radare-web-gui:latest || exit 1
 
 echo "Building docker container"
 docker build -t input-vectors . || exit 1
-
-exit 0

--- a/src/plugins/analysis/linter/install.sh
+++ b/src/plugins/analysis/linter/install.sh
@@ -39,7 +39,4 @@ else
 	sudo npm install -g jshint || exit 1
 fi
 
-# pull linguist docker image
-docker pull crazymax/linguist
-
 exit 0

--- a/src/plugins/analysis/linter/install_docker.sh
+++ b/src/plugins/analysis/linter/install_docker.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# pull linguist docker image
+docker pull crazymax/linguist
+

--- a/src/plugins/analysis/qemu_exec/install.sh
+++ b/src/plugins/analysis/qemu_exec/install.sh
@@ -2,14 +2,6 @@
 
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
 
-# build docker container
-if docker info > /dev/null 2>&1 ; then
-    (cd docker && docker build --build-arg=http{,s}_proxy --build-arg=HTTP{,S}_PROXY -t fact/qemu:latest .) || exit 1
-else
-    echo "Error: docker daemon not running! Could not build docker image"
-    exit 1
-fi
-
 # get files for testing dynamically linked binary
 if [[ ! -e test/data/test_tmp_dir/lib/libc.so.6 ]]; then
     mkdir -p tmp

--- a/src/plugins/analysis/qemu_exec/install_docker.sh
+++ b/src/plugins/analysis/qemu_exec/install_docker.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
+
+# build docker container
+if docker info > /dev/null 2>&1 ; then
+    (cd docker && docker build --build-arg=http{,s}_proxy --build-arg=HTTP{,S}_PROXY -t fact/qemu:latest .) || exit 1
+else
+    echo "Error: docker daemon not running! Could not build docker image"
+    exit 1
+fi

--- a/src/plugins/analysis/software_components/install.sh
+++ b/src/plugins/analysis/software_components/install.sh
@@ -4,11 +4,8 @@ echo '-----------------------------------'
 echo 'Installation of Software Components'
 echo '-----------------------------------'
 
-# change cwd to current file's directory
+# change cwd to this file's directory
 cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
-
-# build docker container
-docker build -t fact/format_string_resolver docker || exit 1
 
 # extract software names
 python3 -c "from internal.extract_os_names import extract_names; extract_names()" || exit 1

--- a/src/plugins/analysis/software_components/install_docker.sh
+++ b/src/plugins/analysis/software_components/install_docker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# change cwd to this file's directory
+cd "$( dirname "${BASH_SOURCE[0]}" )" || exit 1
+
+# build docker container
+docker build -t fact/format_string_resolver docker || exit 1


### PR DESCRIPTION
Depends on #592 

This creats a `Dockerfile` which contains a FACT installation which should work out of the box.

I tested the analysis with a simple text file and the analysis seems to work.
I had to introduce a hacky workaround that I am not happy about to make this work https://github.com/fkie-cad/FACT_core/blob/1ebac9e9d666dd95db12f37ca83bbc5f5d8d3819/src/unpacker/unpack_base.py#L23-L27

The problem here is that the fact-extractor docker container writes its output to `/tmp/extractor` via a bind mount.
When running FACT in docker the docker daemon will create `/tmp/extractor` on the host; meaning that `/tmp/extractor` is not avaiable to the dockerised FACT. The workaround is to add `-v /tmp:/tmp` to `docker run`.

----
The problem described above is relevevant in two places.
```
# ripgrep "docker run"
src/helperFunctions/pdf.py
30:        f'docker run -m 512m -v {folder}:/tmp/interface --rm fkiecad/fact_pdf_report'

src/unpacker/unpack_base.py
24:            'docker run --privileged -m {}m -v /dev:/dev -v {}:/tmp/extractor --rm fkiecad/fact_extractor --chown {}:{}'.format(


```