### PR TITLE
fix unnecessary warnings in plugin system

### DIFF
--- a/src/helperFunctions/plugin.py
+++ b/src/helperFunctions/plugin.py
@@ -19,6 +19,8 @@ def _get_plugin_src_dirs(base_dir: str) -> List[str]:
     plugin_dirs = get_dirs_in_dir(str(plug_in_base_path))
     plugins = []
     for plugin_path in plugin_dirs:
+        if plugin_path.endswith('__pycache__'):
+            continue
         plugin_code_dir = Path(plugin_path, 'code')
         if plugin_code_dir.is_dir():
             plugins.append(str(plugin_code_dir))


### PR DESCRIPTION
remove redundant warnings like

```
[2021-06-18 11:56:20][plugin][WARNING]: Plugin has no code directory: /home/user/git/FACT_core/src/plugins/analysis/__pycache__
```