### PR TITLE
frontend signal forwarding bugfix

### DIFF
--- a/src/start_fact_frontend.py
+++ b/src/start_fact_frontend.py
@@ -19,6 +19,7 @@
 
 import logging
 import pickle
+import signal
 import sys
 import tempfile
 from shlex import split
@@ -48,6 +49,7 @@ class UwsgiServer:
     def shutdown(self):
         if self.process:
             try:
+                self.process.send_signal(signal.SIGINT)
                 self.process.wait(timeout=30)
             except TimeoutExpired:
                 logging.error('frontend did not stop in time -> kill')


### PR DESCRIPTION
Fixed a bug where the SIGINT signal was not forwarded to uWSGI when starting FACT with `start_fact.py` / `start_all_installed_fact_components`