### PR TITLE
added checkbox to force single analysis update

### DIFF
--- a/src/scheduler/Analysis.py
+++ b/src/scheduler/Analysis.py
@@ -245,7 +245,7 @@ class AnalysisScheduler:  # pylint: disable=too-many-instance-attributes
             self._start_or_skip_analysis(analysis_to_do, fw_object)
 
     def _start_or_skip_analysis(self, analysis_to_do: str, file_object: FileObject):
-        if self._analysis_is_already_in_db_and_up_to_date(analysis_to_do, file_object.uid):
+        if not self._is_forced_update(file_object) and self._analysis_is_already_in_db_and_up_to_date(analysis_to_do, file_object.uid):
             logging.debug('skipping analysis "{}" for {} (analysis already in DB)'.format(analysis_to_do, file_object.uid))
             if analysis_to_do in self._get_cumulative_remaining_dependencies(file_object.scheduled_analysis):
                 self._add_completed_analysis_results_to_file_object(analysis_to_do, file_object)
@@ -301,6 +301,13 @@ class AnalysisScheduler:  # pylint: disable=too-many-instance-attributes
             logging.error('plug-in or system version of "{}" plug-in is or was invalid!'.format(analysis_plugin.NAME))
             return False
         return True
+
+    @staticmethod
+    def _is_forced_update(file_object: FileObject) -> bool:
+        try:
+            return bool(getattr(file_object, 'force_update'))
+        except AttributeError:
+            return False
 
 # ---- blacklist and whitelist ----
 

--- a/src/scheduler/Analysis.py
+++ b/src/scheduler/Analysis.py
@@ -305,6 +305,7 @@ class AnalysisScheduler:  # pylint: disable=too-many-instance-attributes
     @staticmethod
     def _is_forced_update(file_object: FileObject) -> bool:
         try:
+            logging.warning('This feature is deprecated and will be removed when analysis scheduling is fixed.')
             return bool(getattr(file_object, 'force_update'))
         except AttributeError:
             return False

--- a/src/test/unit/scheduler/test_analysis.py
+++ b/src/test/unit/scheduler/test_analysis.py
@@ -1,4 +1,4 @@
-# pylint: disable=protected-access,invalid-name
+# pylint: disable=protected-access,invalid-name,wrong-import-order
 import gc
 import os
 from multiprocessing import Manager, Queue
@@ -393,3 +393,11 @@ class TestAnalysisSkipping:
         self.scheduler.db_backend_service = self.BackendMock(analysis_entry)
         self.scheduler.analysis_plugins['plugin'] = self.PluginMock(version='1.0', system_version='1.0')
         assert self.scheduler._analysis_is_already_in_db_and_up_to_date('plugin', '') is False
+
+    def test_is_forced_update(self):
+        fo = MockFileObject()
+        assert self.scheduler._is_forced_update(fo) is False
+        fo.force_update = False
+        assert self.scheduler._is_forced_update(fo) is False
+        fo.force_update = True
+        assert self.scheduler._is_forced_update(fo) is True

--- a/src/web_interface/components/analysis_routes.py
+++ b/src/web_interface/components/analysis_routes.py
@@ -96,6 +96,7 @@ class AnalysisRoutes(ComponentBase):
         with ConnectTo(FrontEndDbInterface, self._config) as database:
             file_object = database.get_object(uid)
         file_object.scheduled_analysis = request.form.getlist('analysis_systems')
+        file_object.force_update = request.form.get('force_update') == 'true'
         with ConnectTo(InterComFrontEndBinding, self._config) as intercom:
             intercom.add_single_file_task(file_object)
         return redirect(url_for(self.show_analysis.__name__, uid=uid, root_uid=root_uid, selected_analysis=selected_analysis))

--- a/src/web_interface/templates/about.html
+++ b/src/web_interface/templates/about.html
@@ -64,6 +64,7 @@
             <li>Improved loading of analysis tags.</li>
             <li>New Swagger documentation for all REST endpoints.</li>
             <li>Added software signatures.</li>
+            <li>Added new feature to force single analysis update (will be removed when scheduling problems are fixed).</li>
             <li>Bug fixes.</li>
         </ul>
 

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -285,7 +285,12 @@
                                 </label>
                             {% endfor %}
                             <hr />
-                            <button class="btn btn-primary" type="submit" id="add_single_file_analysis" value=submit><i class="fas fa-play-circle"></i> Add</button>
+                            <label class="checkbox-inline" data-toggle="tooltip" title="disable smart analysis skipping" style="display: block;">
+                                <input type=checkbox name="force_update" value="true" unchecked>&nbsp;force analysis update<br />
+                            </label>
+                            <button class="btn btn-primary" type="submit" id="add_single_file_analysis" value=submit>
+                                <i class="fas fa-play-circle"></i> Add
+                            </button>
                         </form>
                     </div>
                 </div>


### PR DESCRIPTION
Added option to force re-analysis (aka "skip skip") for single file analysis.

Will directly be marked as deprecated and removed as soon as the following features are implemented:
- [ ] #605
- [ ] #606