### PR TITLE
Analsysis/Compare: Don't die on failing import

### DIFF
--- a/src/compare/compare.py
+++ b/src/compare/compare.py
@@ -78,8 +78,17 @@ class Compare:
     def _init_plugins(self):
         self.source = import_plugins('compare.plugins', 'plugins/compare')  # pylint: disable=attribute-defined-outside-init
         for plugin_name in self.source.list_plugins():
-            plugin = self.source.load_plugin(plugin_name)
-            plugin.ComparePlugin(self, config=self.config, db_interface=self.db_interface)
+            try:
+                plugin = self.source.load_plugin(plugin_name)
+            except Exception as e:
+                # This exception could be caused by invalid syntax
+                # Invalid syntax may be caused by plugin dependencies that got
+                # upgraded to incompatible versions
+                logging.error(f'Could not import plugin {plugin_name} due to Exception: {e}')
+            else:
+                plugin.ComparePlugin(self, config=self.config, db_interface=self.db_interface)
+
+
 
     def register_plugin(self, name, c_plugin_instance):
         self.compare_plugins[name] = c_plugin_instance

--- a/src/scheduler/Analysis.py
+++ b/src/scheduler/Analysis.py
@@ -206,8 +206,15 @@ class AnalysisScheduler:  # pylint: disable=too-many-instance-attributes
     def load_plugins(self):
         source = import_plugins('analysis.plugins', 'plugins/analysis')
         for plugin_name in source.list_plugins():
-            plugin = source.load_plugin(plugin_name)
-            plugin.AnalysisPlugin(self, config=self.config)
+            try:
+                plugin = source.load_plugin(plugin_name)
+            except Exception as e:
+                # This exception could be caused by invalid syntax
+                # Invalid syntax may be caused by plugin dependencies that got
+                # upgraded to incompatible versions
+                logging.error(f'Could not import plugin {plugin_name} due to Exception: {e}')
+            else:
+                plugin.AnalysisPlugin(self, config=self.config)
 
     def start_scheduling_process(self):
         logging.debug('Starting scheduler...')


### PR DESCRIPTION
This wraps importing plugins in a try-except block.

Now a plugin can contain invalid code and the fact backend will still start.