### PR TITLE
Virtualenv compat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
         args: [--rcfile=.pylintrc]
 
 -   repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 1.11.0
+    rev: 2.1.5
     hooks:
     -   id: shellcheck
 

--- a/src/helperFunctions/hash.py
+++ b/src/helperFunctions/hash.py
@@ -47,11 +47,12 @@ def get_ssdeep_comparison(first, second):
 
 
 def get_tlsh(code):
-    return tlsh.hash(make_bytes(code))
+    tlsh_hash = tlsh.hash(make_bytes(code))  # pylint: disable=c-extension-no-member
+    return tlsh_hash if tlsh_hash != 'TNULL' else ''
 
 
 def get_tlsh_comparison(first, second):
-    return tlsh.diff(first, second)
+    return tlsh.diff(first, second)  # pylint: disable=c-extension-no-member
 
 
 def get_imphash(file_object):
@@ -66,6 +67,7 @@ def get_imphash(file_object):
     if _is_elf_file(file_object):
         try:
             with _suppress_stdout():
+                # pylint: disable=c-extension-no-member
                 functions = normalize_lief_items(lief.parse(file_object.file_path).imported_functions)
             return md5(','.join(sorted(functions)).encode()).hexdigest()
         except Exception:

--- a/src/helperFunctions/install.py
+++ b/src/helperFunctions/install.py
@@ -2,6 +2,7 @@ import configparser
 import logging
 import os
 import shutil
+import sys
 from pathlib import Path
 from typing import List, Tuple, Union
 
@@ -239,3 +240,7 @@ def load_main_config() -> configparser.ConfigParser:
         raise InstallationError('Could not load config at path {}'.format(config_path))
     config.read(str(config_path))
     return config
+
+
+def is_virtualenv() -> bool:
+    return sys.prefix != getattr(sys, 'base_prefix', getattr(sys, 'real_prefix', None))

--- a/src/install/backend.py
+++ b/src/install/backend.py
@@ -19,9 +19,9 @@ def main(skip_docker, distribution):
 
     # dependencies
     if distribution == 'fedora':
-        dnf_install_packages('libjpeg-devel', 'openssl-devel', 'python3-tkinter')
+        dnf_install_packages('libjpeg-devel', 'openssl-devel')
     else:
-        apt_install_packages('libjpeg-dev', 'libssl-dev', 'python3-tk')
+        apt_install_packages('libjpeg-dev', 'libssl-dev')
 
     pip3_install_packages('pluginbase', 'Pillow', 'cryptography', 'pyopenssl', 'matplotlib', 'docker', 'networkx')
 

--- a/src/install/common.py
+++ b/src/install/common.py
@@ -25,14 +25,7 @@ def main(distribution):  # pylint: disable=too-many-statements
 
     _update_package_sources(distribution)
 
-    _, is_repository = execute_shell_command_get_return_code('git status')
-    if is_repository == 0:
-        # update submodules
-        git_output, git_code = execute_shell_command_get_return_code('(cd ../../ && git submodule foreach "git pull")')
-        if git_code != 0:
-            raise InstallationError('Failed to update submodules\n{}'.format(git_output))
-    else:
-        logging.warning('FACT is not set up using git. Note that *adding submodules* won\'t work!!')
+    _update_submodules()
 
     # make bin dir
     BIN_DIR.mkdir(exist_ok=True)
@@ -58,14 +51,17 @@ def main(distribution):  # pylint: disable=too-many-statements
 
     # install general python dependencies
     if distribution == 'fedora':
-        dnf_install_packages('file-devel')
-        dnf_install_packages('libffi-devel')
+        dnf_install_packages('file-devel', 'libffi-devel')
+        if is_virtualenv():
+            pip3_install_packages('ssdeep')
+        else:
+            dnf_install_packages('python3-ssdeep')
     else:
-        apt_install_packages('libmagic-dev')
-        apt_install_packages('libfuzzy-dev')
+        apt_install_packages('libmagic-dev', 'libfuzzy-dev')
+        pip3_install_packages('ssdeep')
 
     pip3_install_packages('git+https://github.com/fkie-cad/fact_helper_file.git')
-    pip3_install_packages('psutil', 'pytest', 'pytest-cov', 'pylint', 'python-magic', 'xmltodict', 'yara-python==3.7.0', 'appdirs', 'flaky', 'python-tlsh', 'ssdeep')
+    pip3_install_packages('psutil', 'pytest', 'pytest-cov', 'pylint', 'python-magic', 'xmltodict', 'yara-python==3.7.0', 'appdirs', 'flaky', 'python-tlsh')
 
     pip3_install_packages('lief')
 
@@ -94,6 +90,16 @@ def main(distribution):  # pylint: disable=too-many-statements
         Path('start_all_installed_fact_components').symlink_to('src/start_fact.py')
 
     return 0
+
+
+def _update_submodules():
+    _, is_repository = execute_shell_command_get_return_code('git status')
+    if is_repository == 0:
+        git_output, git_code = execute_shell_command_get_return_code('(cd ../../ && git submodule foreach "git pull")')
+        if git_code != 0:
+            raise InstallationError('Failed to update submodules\n{}'.format(git_output))
+    else:
+        logging.warning('FACT is not set up using git. Note that *adding submodules* won\'t work!!')
 
 
 def _update_package_sources(distribution):

--- a/src/plugins/analysis/hash/code/hash.py
+++ b/src/plugins/analysis/hash/code/hash.py
@@ -38,7 +38,7 @@ class AnalysisPlugin(AnalysisBasePlugin):
             if hash_ in algorithms_available:
                 file_object.processed_analysis[self.NAME][hash_] = get_hash(hash_, file_object.binary)
             else:
-                logging.debug('algorithm {} not available'.format(hash_))
+                logging.debug(f'algorithm {hash_} not available')
         file_object.processed_analysis[self.NAME]['ssdeep'] = get_ssdeep(file_object.binary)
         file_object.processed_analysis[self.NAME]['imphash'] = get_imphash(file_object)
 
@@ -49,8 +49,5 @@ class AnalysisPlugin(AnalysisBasePlugin):
         return file_object
 
     def _get_hash_list_from_config(self):
-        try:
-            return read_list_from_config(self.config, self.NAME, 'hashes', default=['sha256'])
-        except Exception:
-            logging.warning("'file_hashes' -> 'hashes' not set in config")
-            return ['sha256']
+        hash_list = read_list_from_config(self.config, self.NAME, 'hashes', default=['sha256'])
+        return hash_list if hash_list else ['sha256']

--- a/src/plugins/analysis/hash/code/hash.py
+++ b/src/plugins/analysis/hash/code/hash.py
@@ -1,9 +1,9 @@
-from hashlib import algorithms_available
 import logging
+from hashlib import algorithms_available
 
-from helperFunctions.config import read_list_from_config
-from helperFunctions.hash import get_hash, get_ssdeep, get_imphash, get_tlsh
 from analysis.PluginBase import AnalysisBasePlugin
+from helperFunctions.config import read_list_from_config
+from helperFunctions.hash import get_hash, get_imphash, get_ssdeep, get_tlsh
 
 
 class AnalysisPlugin(AnalysisBasePlugin):
@@ -13,7 +13,7 @@ class AnalysisPlugin(AnalysisBasePlugin):
     NAME = 'file_hashes'
     DEPENDENCIES = ['file_type']
     DESCRIPTION = 'calculate different hash values of the file'
-    VERSION = '1.1'
+    VERSION = '1.2'
 
     def __init__(self, plugin_administrator, config=None, recursive=True):
         '''
@@ -34,11 +34,11 @@ class AnalysisPlugin(AnalysisBasePlugin):
         If you want to propagate results to parent objects store a list of strings 'summary' entry of your result dict
         '''
         file_object.processed_analysis[self.NAME] = {}
-        for h in self.hashes_to_create:
-            if h in algorithms_available:
-                file_object.processed_analysis[self.NAME][h] = get_hash(h, file_object.binary)
+        for hash_ in self.hashes_to_create:
+            if hash_ in algorithms_available:
+                file_object.processed_analysis[self.NAME][hash_] = get_hash(hash_, file_object.binary)
             else:
-                logging.debug('algorithm {} not available'.format(h))
+                logging.debug('algorithm {} not available'.format(hash_))
         file_object.processed_analysis[self.NAME]['ssdeep'] = get_ssdeep(file_object.binary)
         file_object.processed_analysis[self.NAME]['imphash'] = get_imphash(file_object)
 

--- a/src/plugins/analysis/tlsh/code/tlsh.py
+++ b/src/plugins/analysis/tlsh/code/tlsh.py
@@ -13,7 +13,7 @@ class AnalysisPlugin(AnalysisBasePlugin):
     NAME = 'tlsh'
     DESCRIPTION = 'find files with similar tlsh and calculate similarity value'
     DEPENDENCIES = ['file_hashes']
-    VERSION = '0.1'
+    VERSION = '0.2'
 
     def __init__(self, plugin_administrator, config=None, recursive=True, offline_testing=False):
         super().__init__(plugin_administrator, config=config, recursive=recursive, plugin_path=__file__, offline_testing=offline_testing)

--- a/src/test/unit/helperFunctions/test_hash.py
+++ b/src/test/unit/helperFunctions/test_hash.py
@@ -1,7 +1,11 @@
+# pylint: disable=wrong-import-order
+
+import os
 from pathlib import Path
 
 from helperFunctions.hash import (
-    _suppress_stdout, get_imphash, get_md5, get_sha256, get_ssdeep, get_ssdeep_comparison, normalize_lief_items
+    _suppress_stdout, get_imphash, get_md5, get_sha256, get_ssdeep, get_ssdeep_comparison, get_tlsh,
+    normalize_lief_items
 )
 from test.common_helper import create_test_file_object, get_test_data_dir
 
@@ -78,3 +82,8 @@ def test_suppress_stdout(capsys):
 
     with_decorator = capsys.readouterr()
     assert not with_decorator.out
+
+
+def test_get_tlsh():
+    assert get_tlsh(b"foobar") == ''  # make sure the result is not 'TNULL'
+    assert get_tlsh(os.urandom(2**7)) != ''  # the new tlsh version should work for smaller inputs


### PR DESCRIPTION
This PR should (hopefully) make FACT compatible to running Python from a venv.

- converted python package dependencies to pip dependencies 
- updated `tlsh` function for newer version 
    - added a test
    - bumped hash/tlsh plugin versions
    - observation: newer tlsh version is backwards compatible to old hashes and can compute hashes for string lenghts >=50 (old: >=256)
        - old tlsh version is not upwards compatible with new hashes (they have a new prefix)
- refactoring 