### PR TITLE
fixed navbar scaling for medium width

### DIFF
--- a/src/web_interface/templates/base.html
+++ b/src/web_interface/templates/base.html
@@ -33,19 +33,22 @@
     <script type="text/javascript" src="{{ url_for('static', filename='web_js/bootstrap-datepicker.js') }}"></script>
 
     <script>
-            $(document).ready(function(){
-                $('[data-toggle="tooltip"]').tooltip();
-                $(".toggle").click(function(){
-                    $(".expand").toggle();
-                });
+        $(document).ready(function(){
+            $('[data-toggle="tooltip"]').tooltip();
+            $(".toggle").click(function(){
+                $(".expand").toggle();
             });
-            function quickSearch() {
-                let search_input = document.getElementById('quick_search_input').value;
-                window.location = '/database/quick_search?search_term=' + search_input;
-            }
-
-
-
+        });
+        function quickSearch() {
+            let search_input = document.getElementById('quick_search_input').value;
+            window.location = '/database/quick_search?search_term=' + search_input;
+        }
+        function expandQuickSearch() {
+            document.getElementById("quick_search_input").style.width = "300px";
+        }
+        function shrinkQuickSearch() {
+            document.getElementById("quick_search_input").style.width = "112px";
+        }
     </script>
 
     {% block head %}
@@ -108,9 +111,6 @@
                 font-family: 'Courier New', Courier, monospace;
                 font-size: 10px;
             }
-
-
-
     </style>
     {% block styles %}{% endblock %}
 </head>
@@ -122,11 +122,8 @@
         <span class="sr-only">Toggle navigation</span>
         <span class="navbar-toggler-icon"></span>
     </button>
-    <div class="navbar-brand d-none d-md-block mr-0 mr-md-2" style="vertical-align: middle; margin-left: 15px">
+    <div class="navbar-brand d-none d-md-block ml-3" data-toggle="tooltip" data-placement="bottom" title="Firmware Analysis and Comparison Tool" style="vertical-align: middle;">
         <span><img height="25px" src="{{ url_for('static', filename='fact_logo_inv.svg') }}"></span>
-    </div>
-    <div class="navbar-brand d-none d-xl-block" style="vertical-align: middle">
-        Firmware Analysis and Comparison Tool
     </div>
     <div id="navbarCollapse" class="collapse navbar-collapse">
         <!-- Navbar Elements -->
@@ -216,9 +213,10 @@
         <!-- Navbar Quick Search Input -->
         <div id="quick_search_div" class="nav navbar-nav ml-md-auto d-none d-md-block">
             <div class="input-group mr-sm-2">
-                <input type="text" class="form-control" placeholder="Quick search name, vendor and hash values"
+                <input type="text" class="form-control" placeholder="Quick search name, vendor or hash"
                        id="quick_search_input" onKeyDown="if(event.keyCode==13) quickSearch();"
-                       style="margin: 0; background-color: #e7e7e7; border-radius: 0; border-top-left-radius: .25rem; border-bottom-left-radius: .25rem;">
+                       onfocus="expandQuickSearch();" onblur="shrinkQuickSearch();"
+                       style="margin: 0; background-color: #e7e7e7; border-radius: 0; border-top-left-radius: .25rem; border-bottom-left-radius: .25rem; width: 112px; transition: width 0.5s ease-in-out;">
                 <div class="input-group-append">
                     <button class="btn btn-secondary" type="button" onclick="quickSearch()">
                         <i class="fas fa-search"></i>

--- a/src/web_interface/templates/base.html
+++ b/src/web_interface/templates/base.html
@@ -117,12 +117,13 @@
 
 <body>
 
-<nav role="navigation" class="navbar navbar-expand navbar-light flex-column flex-md-row bg-fact">
+<nav role="navigation" class="navbar navbar-expand-lg navbar-light flex-column flex-md-row bg-fact">
     <button type="button" data-target="#navbarCollapse" data-toggle="collapse" class="navbar-toggler">
         <span class="sr-only">Toggle navigation</span>
         <span class="navbar-toggler-icon"></span>
     </button>
-    <div class="navbar-brand d-none d-md-block ml-3" data-toggle="tooltip" data-placement="bottom" title="Firmware Analysis and Comparison Tool" style="vertical-align: middle;">
+    <div class="navbar-brand d-none d-md-block ml-3" data-toggle="tooltip" data-placement="bottom" data-delay='{"show": 500, "hide": 100}'
+         title="Firmware Analysis and Comparison Tool" style="vertical-align: middle;">
         <span><img height="25px" src="{{ url_for('static', filename='fact_logo_inv.svg') }}"></span>
     </div>
     <div id="navbarCollapse" class="collapse navbar-collapse">
@@ -211,7 +212,7 @@
         </ul>
 
         <!-- Navbar Quick Search Input -->
-        <div id="quick_search_div" class="nav navbar-nav ml-md-auto d-none d-md-block">
+        <div id="quick_search_div" class="nav navbar-nav ml-md-auto d-block">
             <div class="input-group mr-sm-2">
                 <input type="text" class="form-control" placeholder="Quick search name, vendor or hash"
                        id="quick_search_input" onKeyDown="if(event.keyCode==13) quickSearch();"


### PR DESCRIPTION
fixed navbar scaling for screen widths around half of FHD or QHD (which was broken since the admin dropdown menu was always displayed)

- removed FACT title from navbar
- reduced size of quick search input
    - made this input grow bigger when being focused on 
- made navbar collapsible for very small screens
- when authentication is turned on, long user names could still be problematic (because of the additional menu entry)