### PR TITLE
Yara 3.9 support

### DIFF
--- a/src/helperFunctions/install.py
+++ b/src/helperFunctions/install.py
@@ -143,18 +143,6 @@ def check_if_command_in_path(command: str) -> bool:
     return True
 
 
-def check_string_in_command_output(command: str, target_string: str) -> bool:
-    '''
-    Execute command and test if string is contained in its output (i.e. stdout).
-
-    :param command: Command to execute.
-    :param target_string: String to match on output.
-    :return: `True` if string was found and return code was 0, else `False`.
-    '''
-    output, return_code = execute_shell_command_get_return_code(command)
-    return return_code == 0 and target_string in output
-
-
 def install_github_project(project_path: str, commands: List[str]):
     '''
     Install github project by cloning it, running a set of commands and removing the cloned files afterwards.

--- a/src/helperFunctions/yara_binary_search.py
+++ b/src/helperFunctions/yara_binary_search.py
@@ -115,12 +115,12 @@ def get_yara_error(rules_file: Union[str, bytes]) -> Optional[Exception]:
     :param rules_file: A string containing yara rules.
     :result: The exception if compiling the rules causes an exception or ``None`` otherwise.
     '''
-    if isinstance(rules_file, bytes):
-        rules_file = rules_file.decode()
     try:
+        if isinstance(rules_file, bytes):
+            rules_file = rules_file.decode()
         yara.compile(source=rules_file)
         return None
-    except (yara.Error, TypeError) as error:
+    except (yara.Error, TypeError, UnicodeDecodeError) as error:
         return error
 
 

--- a/src/helperFunctions/yara_binary_search.py
+++ b/src/helperFunctions/yara_binary_search.py
@@ -1,5 +1,6 @@
 from configparser import ConfigParser
 from os.path import basename
+from pathlib import Path
 from subprocess import CalledProcessError
 from tempfile import NamedTemporaryFile
 from typing import Dict, List, Optional, Tuple, Union
@@ -34,7 +35,8 @@ class YaraBinarySearchScanner:
         :param rule_file_path: The file path to the yara rule file.
         :return: The output from the yara scan.
         '''
-        command = 'yara -r {} {}'.format(rule_file_path, self.db_path if target_path is None else target_path)
+        compiled_flag = '-C' if Path(rule_file_path).read_bytes().startswith(b"YARA") else ''
+        command = f'yara -r {compiled_flag} {rule_file_path} {target_path or self.db_path}'
         return execute_shell_command(command)
 
     def _execute_yara_search_for_single_firmware(self, rule_file_path: str, firmware_uid: str) -> str:
@@ -53,11 +55,7 @@ class YaraBinarySearchScanner:
         for line in raw_result.split('\n'):
             if line and 'warning' not in line:
                 rule, match = line.split(' ')
-                match = basename(match)
-                if rule in results:
-                    results[rule].append(match)
-                else:
-                    results[rule] = [match]
+                results.setdefault(rule, []).append(basename(match))
         return results
 
     @staticmethod
@@ -82,9 +80,9 @@ class YaraBinarySearchScanner:
                 self._eliminate_duplicates(results)
                 return results
             except yara.SyntaxError as yara_error:
-                return 'There seems to be an error in the rule file:\n{}'.format(yara_error)
+                return f'There seems to be an error in the rule file:\n{yara_error}'
             except CalledProcessError as process_error:
-                return 'Error when calling YARA:\n{}'.format(process_error.output.decode())
+                return f'Error when calling YARA:\n{process_error.output.decode()}'
 
     def _get_raw_result(self, firmware_uid: Optional[str], temp_rule_file: NamedTemporaryFile) -> str:
         if firmware_uid is None:

--- a/src/install/backend.py
+++ b/src/install/backend.py
@@ -4,12 +4,13 @@ import stat
 from contextlib import suppress
 from pathlib import Path
 
+import requests
 from common_helper_process import execute_shell_command_get_return_code
-from compile_yara_signatures import main as compile_signatures
 
+from compile_yara_signatures import main as compile_signatures
 from helperFunctions.install import (
-    InstallationError, OperateInDirectory, apt_install_packages, check_string_in_command_output, dnf_install_packages,
-    load_main_config, read_package_list_from_file, run_cmd_with_logging
+    InstallationError, OperateInDirectory, apt_install_packages, dnf_install_packages, load_main_config,
+    read_package_list_from_file, run_cmd_with_logging
 )
 
 BIN_DIR = Path(__file__).parent.parent / 'bin'
@@ -117,22 +118,31 @@ def _install_plugins(distribution):
 
 
 def _install_yara():  # pylint: disable=too-complex
-    logging.info('Installing yara')
 
     # CAUTION: Yara python binding is installed in install/common.py, because it is needed in the frontend as well.
 
-    if check_string_in_command_output('yara --version', '3.7.1'):
-        logging.info('skipping yara installation (already installed)')
+    try:
+        latest_url = requests.get('https://github.com/VirusTotal/yara/releases/latest').url
+        latest_version = latest_url.split('/tag/')[1]
+    except (AttributeError, KeyError):
+        raise InstallationError('Could not find latest yara version') from None
+
+    installed_version, return_code = execute_shell_command_get_return_code('yara --version')
+    if return_code == 0 and installed_version.strip() == latest_version.strip('v'):
+        logging.info('Skipping yara installation: Already installed and up to date')
         return
 
-    wget_output, wget_code = execute_shell_command_get_return_code('wget https://github.com/VirusTotal/yara/archive/v3.7.1.zip')
+    logging.info(f'Installing yara {latest_version}')
+    archive = f'{latest_version}.zip'
+    download_url = f'https://github.com/VirusTotal/yara/archive/refs/tags/{archive}'
+    wget_output, wget_code = execute_shell_command_get_return_code(f'wget {download_url}')
     if wget_code != 0:
         raise InstallationError(f'Error on yara download.\n{wget_output}')
-    zip_output, return_code = execute_shell_command_get_return_code('unzip v3.7.1.zip')
-    Path('v3.7.1.zip').unlink()
+    zip_output, return_code = execute_shell_command_get_return_code(f'unzip {archive}')
+    Path(archive).unlink()
     if return_code != 0:
         raise InstallationError(f'Error on yara extraction.\n{zip_output}')
-    yara_folder = [child for child in Path('.').iterdir() if 'yara-3.' in child.name][0]
+    yara_folder = [p for p in Path('.').iterdir() if p.name.startswith('yara-')][0]
     with OperateInDirectory(yara_folder.name, remove=True):
         os.chmod('bootstrap.sh', 0o775)
         for command in ['./bootstrap.sh', './configure --enable-magic', 'make -j$(nproc)', 'sudo make install']:

--- a/src/install/requirements_common.txt
+++ b/src/install/requirements_common.txt
@@ -15,7 +15,7 @@ python-magic
 requests
 ssdeep
 xmltodict
-yara-python==3.7.0
+yara-python
 
 git+https://github.com/fkie-cad/fact_helper_file.git
 

--- a/src/plugins/analysis/software_components/test/test_plugin_software_components_signatures.py
+++ b/src/plugins/analysis/software_components/test/test_plugin_software_components_signatures.py
@@ -1,12 +1,10 @@
-import os
-
-from common_helper_files import get_dir_of_file
+from pathlib import Path
 
 from test.yara_signature_testing import SignatureTestingMatching, SignatureTestingMeta
 
-TEST_DATA_DIR = os.path.join(get_dir_of_file(__file__), 'data')
-SIGNATURE_PATH = os.path.join(get_dir_of_file(__file__), '../signatures/')
-TEST_SIGNATURE_PATH = os.path.join(get_dir_of_file(__file__), '../test/data/signatures/')
+TEST_DATA_DIR = Path(__file__).parent / 'data'
+SIGNATURE_PATH = Path(__file__).parent.parent / 'signatures/'
+TEST_SIGNATURE_PATH = Path(__file__).parent.parent / 'test/data/signatures/'
 
 
 class TestSoftwareSignatureMeta:
@@ -17,7 +15,7 @@ class TestSoftwareSignatureMeta:
 
     def test_check_meta_fields(self):
         missing_fields = self.sigTest.check_meta_fields(SIGNATURE_PATH)
-        assert not missing_fields, 'Missing meta fields: {}'.format(missing_fields.__str__())
+        assert not missing_fields, f'Missing meta fields: {missing_fields.__str__()}'
 
     def test_check_meta_fields_missing(self):
         missing_fields = self.sigTest.check_meta_fields(TEST_SIGNATURE_PATH)
@@ -28,11 +26,11 @@ class TestSoftwareSignatureMeta:
         )
 
 
-class TestAllKnownSoftwareMatched:
+class TestAllSoftwareSignaturesMatched:
 
     def setup_method(self):
         self.sig_tester = SignatureTestingMatching()  # pylint: disable=attribute-defined-outside-init
 
     def test_all_signatures_matched(self):
-        diff = self.sig_tester.check(SIGNATURE_PATH, os.path.join(TEST_DATA_DIR, 'software_component_test_list.txt'))
-        assert diff == set(), 'Missing signature for {}'.format(diff)
+        diff = self.sig_tester.check(SIGNATURE_PATH, TEST_DATA_DIR / 'software_component_test_list.txt')
+        assert diff == set(), f'Missing signature for {diff}'

--- a/src/test/unit/analysis/test_yara_plugin_base.py
+++ b/src/test/unit/analysis/test_yara_plugin_base.py
@@ -1,3 +1,5 @@
+# pylint: disable=wrong-import-order
+
 import logging
 import os
 from pathlib import Path
@@ -32,9 +34,9 @@ class TestAnalysisYaraBasePlugin(AnalysisPluginTest):
         test_file.processed_analysis.update({self.PLUGIN_NAME: []})
         processed_file = self.analysis_plugin.process_object(test_file)
         results = processed_file.processed_analysis[self.PLUGIN_NAME]
-        self.assertEqual(len(results), 2, 'not all matches found')
-        self.assertTrue('testRule' in results, 'testRule match not found')
-        self.assertEqual(results['summary'], ['testRule'])
+        assert len(results) == 2, 'not all matches found'
+        assert 'testRule' in results, 'testRule match not found'
+        assert results['summary'] == ['testRule']
 
     def test_process_object_nothing_found(self):
         test_file = FileObject(file_path=os.path.join(get_test_data_dir(), 'zero_byte'))
@@ -45,7 +47,7 @@ class TestAnalysisYaraBasePlugin(AnalysisPluginTest):
 
 
 def test_parse_yara_output():
-    matches = YaraBasePlugin._parse_yara_output(YARA_TEST_OUTPUT)
+    matches = YaraBasePlugin._parse_yara_output(YARA_TEST_OUTPUT)  # pylint: disable=protected-access
 
     assert isinstance(matches, dict), 'matches should be dict'
     assert 'PgpPublicKeyBlock' in matches.keys(), 'Pgp block should have been matched'
@@ -56,7 +58,7 @@ def test_parse_yara_output():
 
 
 def test_get_signature_file_name():
-    assert YaraBasePlugin._get_signature_file_name('/foo/bar/plugin_name/code/test.py') == 'plugin_name.yc'
+    assert YaraBasePlugin._get_signature_file_name('/foo/bar/plugin_name/code/test.py') == 'plugin_name.yc'  # pylint: disable=protected-access
 
 
 def test_parse_meta_data_error(caplog):

--- a/src/test/unit/helperFunctions/test_install.py
+++ b/src/test/unit/helperFunctions/test_install.py
@@ -5,8 +5,7 @@ from tempfile import TemporaryDirectory
 import pytest
 
 from helperFunctions.install import (
-    InstallationError, OperateInDirectory, _run_shell_command_raise_on_return_code, check_string_in_command_output,
-    read_package_list_from_file
+    InstallationError, OperateInDirectory, _run_shell_command_raise_on_return_code, read_package_list_from_file
 )
 
 
@@ -58,16 +57,6 @@ def test_operate_in_directory():
         with OperateInDirectory(folder, remove=True):
             assert Path(file2.name).is_file()
         assert file1.is_file() and not file2.is_file() and not folder.is_dir()
-
-
-@pytest.mark.parametrize('command, string, expected_output', [
-    ('echo test', 'test', True),
-    ('echo abcdef', 'bcde', True),
-    ('echo abcdef', 'xyz', False),
-    ('false', 'false', False),
-])
-def test_check_string_in_command(command, string, expected_output):
-    assert check_string_in_command_output(command, string) == expected_output
 
 
 def test_read_package_list_from_file():

--- a/src/test/yara_signature_testing.py
+++ b/src/test/yara_signature_testing.py
@@ -1,59 +1,44 @@
 import logging
-import os
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List
 
-from common_helper_files import get_files_in_dir
 from common_helper_yara import compile_rules, get_all_matched_strings, scan
 
 
 class SignatureTestingMatching:
 
     def __init__(self):
-        self.tmp_dir = TemporaryDirectory(prefix='fact_software_signature_test')
-        self.signature_file_path = os.path.join(self.tmp_dir.name, 'test_sig.yc')
         self.matches = []
         self.test_file = None
         self.signature_path = None
         self.strings_to_match = None
 
-    def check(self, signature_path, test_file):
-        self.test_file = test_file
+    def check(self, signature_path: Path, test_file: Path):
         self.signature_path = signature_path
-        self._get_list_of_test_data()
+        self.strings_to_match = test_file.read_text().strip().split('\n')
         self._execute_yara_matching()
-        return self._intersect_lists()
+        return set(self.strings_to_match).difference(self.matches)
 
     def _execute_yara_matching(self):
-        compile_rules(self.signature_path, self.signature_file_path, external_variables={'test_flag': 'true'})
-        scan_result = scan(self.signature_file_path, self.test_file)
-        self.matches = get_all_matched_strings(scan_result)
-
-    def _get_list_of_test_data(self):
-        with open(self.test_file, mode='r', encoding='utf8') as pointer:
-            self.strings_to_match = pointer.read().split('\n')
-        self.strings_to_match.pop()
-
-    def _intersect_lists(self):
-        strings_to_match = set(self.strings_to_match)
-        return strings_to_match.difference(self.matches)
+        with TemporaryDirectory(prefix='fact_software_signature_test') as tmp_dir:
+            signature_file_path = Path(tmp_dir) / 'test_sig.yc'
+            compile_rules(self.signature_path, signature_file_path, external_variables={'test_flag': 'true'})
+            scan_result = scan(signature_file_path, self.test_file, compiled=True)
+            self.matches = get_all_matched_strings(scan_result)
 
 
 class SignatureTestingMeta:
     META_FIELDS = ['software_name', 'open_source', 'website', 'description']
     missing_meta_fields = []
 
-    def check_meta_fields(self, sig_path):
-        sig_dir = sig_path
-        list_of_files = get_files_in_dir(sig_dir)
-        for file in list_of_files:
+    def check_meta_fields(self, sig_path: Path):
+        for file in sig_path.iterdir():
             self.check_for_file(file)
         return self.missing_meta_fields
 
-    def check_for_file(self, file_path):
-        with open(file_path, 'r') as fd:
-            raw = fd.read()
-        rules = self._split_rules(raw)
+    def check_for_file(self, file_path: Path):
+        rules = self._split_rules(file_path.read_text())
         for rule in rules:
             self.check_meta_fields_of_rule(rule)
 
@@ -82,5 +67,5 @@ class SignatureTestingMeta:
                 self._register_missing_field(required_field, rule_name)
 
     def _register_missing_field(self, missing_field: str, rule_name: str):
-        self.missing_meta_fields.append('{} in {}'.format(missing_field, rule_name))
-        logging.error('CST: No meta field {} for rule {}.'.format(missing_field, rule_name))
+        self.missing_meta_fields.append(f'{missing_field} in {rule_name}')
+        logging.error(f'CST: No meta field {missing_field} for rule {rule_name}.')

--- a/src/web_interface/components/database_routes.py
+++ b/src/web_interface/components/database_routes.py
@@ -177,7 +177,7 @@ class DatabaseRoutes(ComponentBase):
                     with ConnectTo(InterComFrontEndBinding, self._config) as connection:
                         request_id = connection.add_binary_search_request(yara_rule_file, firmware_uid)
                     return redirect(url_for('get_binary_search_results', request_id=request_id, only_firmware=only_firmware))
-                error = f'Error in YARA rules: {get_yara_error(yara_rule_file)}'
+                error = f'Error in YARA rules: {get_yara_error(yara_rule_file)} (pre-compiled rules are not supported here!)'
             else:
                 error = 'please select a file or enter rules in the text area'
         return render_template('database/database_binary_search.html', error=error)


### PR DESCRIPTION
Resolves #634 
- changed installation to install the latest yara version
- fixed incompatibility issues with yara versions >= 3.9 (needs new parameter `-C` when using pre-compiled rules)
- added handling for internal server error when trying to upload a compiled rule file in the binary search UI
- refactoring

:exclamation:  https://github.com/fkie-cad/common_helper_yara/pull/4 needs to be merged first