### PR TITLE
escape deprecation fix + tmp file cleanup miss fix

### DIFF
--- a/src/helperFunctions/mongo_task_conversion.py
+++ b/src/helperFunctions/mongo_task_conversion.py
@@ -1,9 +1,11 @@
-import os
+import logging
 from configparser import ConfigParser
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, Optional, Tuple
 
-from flask import Request, escape
+from flask import Request
+from markupsafe import escape
 from werkzeug.datastructures import FileStorage
 
 from helperFunctions.config import get_temp_dir_path
@@ -42,7 +44,7 @@ def get_file_name_and_binary_from_request(request: Request, config: ConfigParser
     '''
     try:
         file_name = escape(request.files['file'].filename)
-    except Exception:
+    except AttributeError:
         file_name = 'no name'
     file_binary = _get_uploaded_file_binary(request.files['file'], config)
     return file_name, file_binary
@@ -84,7 +86,7 @@ def _get_meta_from_request(request: Request):
 def _get_meta_from_dropdowns(meta, request: Request):
     for item in meta.keys():
         if not meta[item] and item in DROPDOWN_FIELDS:
-            dd = request.form['{}_dropdown'.format(item)]
+            dd = request.form[f'{item}_dropdown']
             if dd != 'new entry':
                 meta[item] = escape(dd)
 
@@ -144,18 +146,16 @@ def _get_uploaded_file_binary(request_file: FileStorage, config: ConfigParser) -
     :param config: The FACT configuration.
     :return: The binary as byte string or `None` if no binary was found.
     '''
-    if request_file:
-        tmp_dir = TemporaryDirectory(prefix='fact_upload_', dir=get_temp_dir_path(config))
-        tmp_file_path = os.path.join(tmp_dir.name, 'upload.bin')
+    if not request_file:
+        return None
+    with TemporaryDirectory(prefix='fact_upload_', dir=get_temp_dir_path(config)) as tmp_dir:
+        tmp_file_path = Path(tmp_dir) / 'upload.bin'
         try:
-            request_file.save(tmp_file_path)
-            with open(tmp_file_path, 'rb') as tmp_file:
-                binary = tmp_file.read()
-            tmp_dir.cleanup()
-            return binary
-        except Exception:
+            request_file.save(str(tmp_file_path))
+            return tmp_file_path.read_bytes()
+        except IOError:
+            logging.error('Encountered error when trying to read uploaded file:', exc_info=True)
             return None
-    return None
 
 
 def check_for_errors(analysis_task: dict) -> Dict[str, str]:


### PR DESCRIPTION
- fixed deprecation warning of escape function:

> 'jinja2.escape' is deprecated and will be removed in Jinja 3.1. Import 'markupsafe.escape' instead.

- fixed possible miss of TemporaryDirectory cleanup function
- slight refactoring with pathlib