### PR TITLE
pre-commit: Add double-quote-string-fixer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,8 @@ repos:
 
     -   id: check-yaml
 
+    -   id: double-quote-string-fixer
+
     -   id: end-of-file-fixer
         types: [python]
 


### PR DESCRIPTION
Maybe it is just me but out of habit I sometimes still use double quotes instead of single quotes.
This enforces single quotes.