### PR TITLE
added new source for vis-network + updated template

### DIFF
--- a/src/install/frontend.py
+++ b/src/install/frontend.py
@@ -80,7 +80,7 @@ def _install_nginx():
 
 
 def _generate_and_install_certificate():
-    logging.info("Generating self-signed certificate")
+    logging.info('Generating self-signed certificate')
     execute_commands_and_raise_on_return_code([
         'openssl genrsa -out fact.key 4096',
         'echo "{}" | openssl req -new -key fact.key -out fact.csr'.format(DEFAULT_CERT),
@@ -90,7 +90,7 @@ def _generate_and_install_certificate():
 
 
 def _configure_nginx():
-    logging.info("Configuring nginx")
+    logging.info('Configuring nginx')
     execute_commands_and_raise_on_return_code([
         'sudo cp /etc/nginx/nginx.conf /etc/nginx/nginx.conf.bak',
         'sudo rm /etc/nginx/nginx.conf',
@@ -108,22 +108,23 @@ def _install_css_and_js_files():
         wget_static_web_content('https://github.com/vakata/jstree/zipball/3.3.9', '.', ['unzip 3.3.9', 'rm 3.3.9', 'rm -rf ./web_js/jstree/vakata*', 'mv vakata* web_js/jstree'], 'jstree')
         wget_static_web_content('https://ajax.googleapis.com/ajax/libs/angularjs/1.4.8/angular.min.js', '.', [], 'angularJS')
         wget_static_web_content('https://github.com/chartjs/Chart.js/releases/download/v2.3.0/Chart.js', '.', [], 'charts.js')
-        wget_static_web_content('https://registry.npmjs.org/vis-network/-/vis-network-8.5.2.tgz', '.', ['tar xf vis-network-8.5.2.tgz', 'rm -rf vis', 'mv package/dist vis'], 'vis-network')
 
         _build_highlight_js()
 
         for css_url in [
-                'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css',
-                'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.8.0/css/bootstrap-datepicker.standalone.css'
+            'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css',
+            'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.8.0/css/bootstrap-datepicker.standalone.css',
+            'https://unpkg.com/vis-network@8.5.6/styles/vis-network.min.css',
         ]:
             wget_static_web_content(css_url, 'web_css', [])
 
         for js_url in [
-                'https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min.js',
-                'https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js',
-                'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js',
-                'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.8.0/js/bootstrap-datepicker.js',
-                'https://raw.githubusercontent.com/moment/moment/develop/moment.js'
+            'https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min.js',
+            'https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js',
+            'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js',
+            'https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.8.0/js/bootstrap-datepicker.js',
+            'https://raw.githubusercontent.com/moment/moment/develop/moment.js',
+            'https://unpkg.com/vis-network@8.5.6/standalone/umd/vis-network.min.js',
         ]:
             wget_static_web_content(js_url, 'web_js', [])
 
@@ -162,7 +163,7 @@ def _install_docker_images(radare):
 
 
 def main(skip_docker, radare, nginx):
-    run_cmd_with_logging("sudo -EH pip3 install -r ./requirements_frontend.txt")
+    run_cmd_with_logging('sudo -EH pip3 install -r ./requirements_frontend.txt')
 
     # installing web/js-frameworks
     _install_css_and_js_files()

--- a/src/plugins/analysis/linter/code/source_code_analysis.py
+++ b/src/plugins/analysis/linter/code/source_code_analysis.py
@@ -12,10 +12,10 @@ from analysis.PluginBase import AnalysisBasePlugin
 from helperFunctions.docker import run_docker_container
 
 try:
-    from ..internal import js_linter, lua_linter, python_linter, shell_linter
+    from ..internal import lua_linter, python_linter, shell_linter
 except ImportError:
     sys.path.append(str(Path(__file__).parent.parent))
-    from internal import js_linter, lua_linter, python_linter, shell_linter
+    from internal import lua_linter, python_linter, shell_linter
 
 
 class AnalysisPlugin(AnalysisBasePlugin):
@@ -36,7 +36,8 @@ class AnalysisPlugin(AnalysisBasePlugin):
     SCRIPT_TYPES = {
         'shell': {'mime': 'shell', 'shebang': 'sh', 'ending': '.sh', 'linter': shell_linter.ShellLinter},
         'lua': {'mime': 'luascript', 'shebang': 'lua', 'ending': '.lua', 'linter': lua_linter.LuaLinter},
-        'javascript': {'mime': 'java', 'shebang': 'java', 'ending': '.js', 'linter': js_linter.JavaScriptLinter},
+        # FIXME: deactivated because of npm installation issues
+        # 'javascript': {'mime': 'java', 'shebang': 'java', 'ending': '.js', 'linter': js_linter.JavaScriptLinter},
         'python': {'mime': 'python', 'shebang': 'python', 'ending': '.py', 'linter': python_linter.PythonLinter}
     }
 

--- a/src/plugins/analysis/linter/install.sh
+++ b/src/plugins/analysis/linter/install.sh
@@ -35,9 +35,10 @@ else
 	echo " Installing python linter..."
 	sudo -EH pip3 install --upgrade pylint || exit 1
 
-	echo " Installing javascript linter..."
-	sudo apt-get -y install npm || exit 1
-	sudo npm install -g jshint || exit 1
+# FIXME: deactivated because of npm installation issues
+#	echo " Installing javascript linter..."
+#	sudo apt-get -y install npm || exit 1
+#	sudo npm install -g jshint || exit 1
 fi
 
 exit 0

--- a/src/plugins/analysis/linter/install.sh
+++ b/src/plugins/analysis/linter/install.sh
@@ -17,9 +17,10 @@ then
 	echo " Installing python linter..."
 	sudo -EH pip3 install --upgrade pylint || exit 1
 
-	echo " Installing javascript linter..."
-	sudo dnf install -y nodejs npm
-	sudo npm install -g jshint || exit 1
+# FIXME: deactivated because of npm installation issues
+#	echo " Installing javascript linter..."
+#	sudo dnf install -y nodejs npm
+#	sudo npm install -g jshint || exit 1
 
 else
 	echo "Installing shell linter..."

--- a/src/plugins/analysis/linter/test/test_js_linter.py
+++ b/src/plugins/analysis/linter/test/test_js_linter.py
@@ -29,6 +29,8 @@ def stub_linter():
     return JavaScriptLinter()
 
 
+# FIXME: deactivated because of npm installation issues
+@pytest.skip('disabled until js linter installation is fixed')
 def test_do_analysis(stub_linter, monkeypatch):
     monkeypatch.setattr('plugins.analysis.linter.internal.js_linter.execute_shell_command', lambda command: MOCK_RESPONSE)
     result = stub_linter.do_analysis('any/path')
@@ -42,6 +44,8 @@ def test_do_analysis(stub_linter, monkeypatch):
     }
 
 
+# FIXME: deactivated because of npm installation issues
+@pytest.skip('disabled until js linter installation is fixed')
 def test_parse_linter_output_bad_line(stub_linter, monkeypatch):
     bad_line = '/any/path: line1, col 37, Empty block. W035\n\n1 error\n'
     monkeypatch.setattr('plugins.analysis.linter.internal.js_linter.execute_shell_command', lambda command: bad_line)

--- a/src/plugins/analysis/linter/test/test_js_linter.py
+++ b/src/plugins/analysis/linter/test/test_js_linter.py
@@ -30,7 +30,7 @@ def stub_linter():
 
 
 # FIXME: deactivated because of npm installation issues
-@pytest.skip('disabled until js linter installation is fixed')
+@pytest.mark.skip('disabled until js linter installation is fixed')
 def test_do_analysis(stub_linter, monkeypatch):
     monkeypatch.setattr('plugins.analysis.linter.internal.js_linter.execute_shell_command', lambda command: MOCK_RESPONSE)
     result = stub_linter.do_analysis('any/path')
@@ -45,7 +45,7 @@ def test_do_analysis(stub_linter, monkeypatch):
 
 
 # FIXME: deactivated because of npm installation issues
-@pytest.skip('disabled until js linter installation is fixed')
+@pytest.mark.skip('disabled until js linter installation is fixed')
 def test_parse_linter_output_bad_line(stub_linter, monkeypatch):
     bad_line = '/any/path: line1, col 37, Empty block. W035\n\n1 error\n'
     monkeypatch.setattr('plugins.analysis.linter.internal.js_linter.execute_shell_command', lambda command: bad_line)

--- a/src/test/acceptance/test_io_routes.py
+++ b/src/test/acceptance/test_io_routes.py
@@ -1,4 +1,3 @@
-import pytest
 from fact_helper_file import get_file_type_from_binary
 
 from storage.db_interface_backend import BackEndDbInterface
@@ -36,8 +35,6 @@ class TestAcceptanceIoRoutes(TestAcceptanceBase):
         self._stop_backend()
         super().tearDown()
 
-    # FIXME: fix handling of localhost in CI for this to work
-    @pytest.mark.skip('Does currently not work in the CI')
     def test_radare_button(self):
         response = self.test_client.get('/radare-view/{uid}'.format(uid=self.test_fw.uid))
         self.assertIn('200', response.status, 'radare view link failed')

--- a/src/test/acceptance/test_io_routes.py
+++ b/src/test/acceptance/test_io_routes.py
@@ -1,3 +1,4 @@
+import pytest
 from fact_helper_file import get_file_type_from_binary
 
 from storage.db_interface_backend import BackEndDbInterface
@@ -35,6 +36,8 @@ class TestAcceptanceIoRoutes(TestAcceptanceBase):
         self._stop_backend()
         super().tearDown()
 
+    # FIXME: fix handling of localhost in CI for this to work
+    @pytest.mark.skip('Does currently not work in the CI')
     def test_radare_button(self):
         response = self.test_client.get('/radare-view/{uid}'.format(uid=self.test_fw.uid))
         self.assertIn('200', response.status, 'radare view link failed')

--- a/src/web_interface/templates/dependency_graph.html
+++ b/src/web_interface/templates/dependency_graph.html
@@ -13,8 +13,8 @@
             height: 500px;
         }
     </style>
-    <script src="{{ url_for('static', filename='vis/vis-network.js') }}"></script>
-    <link href="{{ url_for('static', filename='vis/dist/vis-network.min.css') }}" rel="stylesheet" type="text/css" />
+    <script src="{{ url_for('static', filename='web_js/vis-network.min.js') }}"></script>
+    <link href="{{ url_for('static', filename='web_css/vis-network.min.css') }}" rel="stylesheet" type="text/css" />
 {% endblock %}
 
 
@@ -50,10 +50,10 @@
 
 
     <div class="row mb-3">
-        <div class="col-md-8">
-            <div id="dependencyGraph"></div>
+        <div class="col-lg-8 col-xl-10">
+            <div id="dependencyGraph" class="border rounded"></div>
         </div>
-        <div class="col-md-4">
+        <div class="col-lg-4 col-xl-2">
             <div class="header mb-4" style="word-wrap: break-word">
                 <h4 style="text-align: center">Legend</h4>
             </div>
@@ -220,7 +220,10 @@
             groups: group_options,
             interaction: {
                 hideEdgesOnDrag: true,
-                tooltipDelay: 200
+                tooltipDelay: 200,
+                dragNodes: false,
+                dragView: false,
+                zoomView: false
             },
             physics: {
                 forceAtlas2Based: {


### PR DESCRIPTION
- replaced flaky npm link for vis-network with unpkg link
- updated version to 8.5.6 (9.x.x was really laggy for no apparent reason)
- updated template
    - made legend non-interactable and a bit thinner
    - added border to visualize where graph ends (so that it doesn't look broken)
- skipped jshint installation and respective tests and removed javascript from linter plugin (this should be reverted when the eslint branch is merged)
- ~~skipped radare test (seems to be broken for the CI as it is now)~~ (rh: we managed to locate the infrastructural issue and reactivated the test)