### PR TITLE
fix(docker): build context path for plugins

### DIFF
--- a/src/plugins/analysis/file_system_metadata/install.py
+++ b/src/plugins/analysis/file_system_metadata/install.py
@@ -19,7 +19,7 @@ class FileSystemMetadataInstaller(AbstractPluginInstaller):
     base_path = Path(__file__).resolve().parent
 
     def install_docker_images(self):
-        run_cmd_with_logging('docker build -t fs_metadata_mounting docker')
+        run_cmd_with_logging(f'docker build -t fs_metadata_mounting {self.base_path}/docker')
 
 
 # Alias for generic use

--- a/src/plugins/analysis/input_vectors/install.py
+++ b/src/plugins/analysis/input_vectors/install.py
@@ -19,7 +19,7 @@ class InputVectorsInstaller(AbstractPluginInstaller):
     base_path = Path(__file__).resolve().parent
 
     def install_docker_images(self):
-        run_cmd_with_logging('docker build -t input-vectors .')
+        run_cmd_with_logging(f'docker build -t input-vectors {self.base_path}')
         run_cmd_with_logging('docker pull fkiecad/radare-web-gui:latest')
 
 

--- a/src/plugins/analysis/qemu_exec/install.py
+++ b/src/plugins/analysis/qemu_exec/install.py
@@ -22,7 +22,7 @@ class QemuExecInstaller(AbstractPluginInstaller):
 
     def install_docker_images(self):
         run_cmd_with_logging(
-            'docker build --build-arg=http{,s}_proxy --build-arg=HTTP{,S}_PROXY -t fact/qemu:latest docker',
+            f'docker build --build-arg=http{{,s}}_proxy --build-arg=HTTP{{,S}}_PROXY -t fact/qemu:latest {self.base_path}/docker',
             shell=True)
 
     def install_files(self):

--- a/src/plugins/analysis/software_components/install.py
+++ b/src/plugins/analysis/software_components/install.py
@@ -21,7 +21,7 @@ class SoftwareComponentsInstaller(AbstractPluginInstaller):
     base_path = Path(__file__).resolve().parent
 
     def install_docker_images(self):
-        run_cmd_with_logging('docker build -t fact/format_string_resolver docker')
+        run_cmd_with_logging(f'docker build -t fact/format_string_resolver {self.base_path}/docker')
 
     def install_files(self):
         extract_names()


### PR DESCRIPTION
> By default the docker build command will look for a Dockerfile at the root of the build context
https://docs.docker.com/engine/reference/commandline/build/#text-files

Tested on:
`Docker version 20.10.7, build 20.10.7-0ubuntu1~20.04.2`

Sample error log:
```
Traceback (most recent call last):
  File "/opt/FACT_core/src/install.py", line 183, in <module>
    install()
  File "/opt/FACT_core/src/install.py", line 153, in install
    install_docker_images(args)
  File "/opt/FACT_core/src/install.py", line 177, in install_docker_images
    backend_install_plugin_docker_images()
  File "/opt/FACT_core/src/install/backend.py", line 79, in install_plugin_docker_images
    _install_plugins(None, skip_docker=False, only_docker=True)
  File "/opt/FACT_core/src/install/backend.py", line 115, in _install_plugins
    plugin_installer.install_docker_images()
  File "/opt/FACT_core/src/plugins/analysis/software_components/install.py", line 24, in install_docker_images
    run_cmd_with_logging('docker build -t fact/format_string_resolver docker')
  File "/opt/FACT_core/src/helperFunctions/install.py", line 219, in run_cmd_with_logging
    raise err
  File "/opt/FACT_core/src/helperFunctions/install.py", line 214, in run_cmd_with_logging
    subprocess.run(cmd_, stdout=PIPE, stderr=PIPE, encoding='UTF-8', shell=shell, check=True, **kwargs)
  File "/usr/lib/python3.8/subprocess.py", line 516, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['docker', 'build', '-t', 'fact/format_string_resolver', 'docker']' returned non-zero exit status 1.
```

Notes:
- `input_vectors` install script should've worked with the relative path since `Dockerfile` is located at the directory root however I got the same error as above. Also `base_path` is never used so I believe the original purpose was to use absolute path for the build context