### PR TITLE
rest firmware put bugfix for when release_date is omitted

### DIFF
--- a/src/test/acceptance/rest/test_rest_compare.py
+++ b/src/test/acceptance/rest/test_rest_compare.py
@@ -55,7 +55,7 @@ class TestRestCompareFirmware(TestAcceptanceBase):
             'device_class': 'test_class',
             'version': '1.0',
             'vendor': 'test_vendor',
-            'release_date': '01.01.1970',
+            'release_date': '1970-01-01',
             'tags': '',
             'requested_analysis_systems': ['software_components']
         }

--- a/src/test/acceptance/rest/test_rest_download.py
+++ b/src/test/acceptance/rest/test_rest_download.py
@@ -1,6 +1,6 @@
-from base64 import standard_b64encode
 import time
 import urllib.parse
+from base64 import standard_b64encode
 
 from storage.db_interface_backend import BackEndDbInterface
 from test.acceptance.base import TestAcceptanceBase
@@ -21,14 +21,15 @@ class TestIntegrationRestDownloadFirmware(TestAcceptanceBase):
         super().tearDown()
 
     def _rest_search(self):
-        rv = self.test_client.get('/rest/firmware?query={}'.format(urllib.parse.quote('{"device_class": "test class"}')), follow_redirects=True)
-        self.assertIn(self.test_fw.uid.encode(), rv.data, 'test firmware not found in rest search')
+        query = '{"device_class": "test class"}'
+        rv = self.test_client.get(f'/rest/firmware?query={urllib.parse.quote(query)}', follow_redirects=True)
+        assert self.test_fw.uid.encode() in rv.data, 'test firmware not found in rest search'
 
     def _rest_download(self):
-        rv = self.test_client.get('/rest/binary/{}'.format(self.test_fw.uid), follow_redirects=True)
-        self.assertIn(standard_b64encode(self.test_fw.binary), rv.data, 'rest download response incorrect')
-        self.assertIn('"file_name": "{}"'.format(self.test_fw.file_name).encode(), rv.data, 'rest download response incorrect')
-        self.assertIn('"SHA256": "{}"'.format(self.test_fw.sha256).encode(), rv.data, 'rest download response incorrect')
+        rv = self.test_client.get(f'/rest/binary/{self.test_fw.uid}', follow_redirects=True)
+        assert standard_b64encode(self.test_fw.binary) in rv.data, 'rest download response incorrect'
+        assert f'"file_name": "{self.test_fw.file_name}"'.encode() in rv.data, 'rest download response incorrect'
+        assert f'"SHA256": "{self.test_fw.sha256}"'.encode() in rv.data, 'rest download response incorrect'
 
     def test_run_from_upload_to_show_analysis(self):
         self.test_fw = create_test_firmware(device_class='test class', device_name='test device', vendor='test vendor')

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -460,7 +460,7 @@ def get_firmware_for_rest_upload_test():
         'device_class': 'test_class',
         'version': '1.0',
         'vendor': 'test_vendor',
-        'release_date': '01.01.1970',
+        'release_date': '1970-01-01',
         'tags': '',
         'requested_analysis_systems': ['software_components']
     }

--- a/src/test/integration/web_interface/rest/test_rest_firmware.py
+++ b/src/test/integration/web_interface/rest/test_rest_firmware.py
@@ -67,7 +67,7 @@ class TestRestFirmware(RestTestBase):
             'device_class': 'test_class',
             'version': '1',
             'vendor': 'test_vendor',
-            'release_date': '01.01.1970',
+            'release_date': '1970-01-01',
             'tags': '',
             'requested_analysis_systems': ['dummy']
         }

--- a/src/test/unit/web_interface/rest/test_rest_firmware.py
+++ b/src/test/unit/web_interface/rest/test_rest_firmware.py
@@ -109,6 +109,14 @@ def test_submit_no_tags(test_app):
     assert result['status'] == 0
 
 
+def test_submit_no_release_date(test_app):
+    request_data = {**TEST_FW_PAYLOAD}
+    request_data.pop('release_date')
+    result = decode_response(test_app.put('/rest/firmware', json=request_data))
+    assert result['status'] == 0
+    assert result['request']['release_date'] == '1970-01-01'
+
+
 def test_request_update_bad_parameter(test_app):
     result = decode_response(test_app.put(f'/rest/firmware/{TEST_FW.uid}?update=no_list'))
     assert result['status'] == 1

--- a/src/test/unit/web_interface/rest/test_rest_firmware.py
+++ b/src/test/unit/web_interface/rest/test_rest_firmware.py
@@ -12,7 +12,7 @@ TEST_FW_PAYLOAD = {
     'device_name': 'no real device',
     'device_class': 'no real class',
     'version': 'no.real.version',
-    'release_date': '01.01.1970',
+    'release_date': '1970-01-01',
     'vendor': 'no real vendor',
     'tags': 'tag1,tag2',
     'requested_analysis_systems': ['file_type']
@@ -114,7 +114,15 @@ def test_submit_no_release_date(test_app):
     request_data.pop('release_date')
     result = decode_response(test_app.put('/rest/firmware', json=request_data))
     assert result['status'] == 0
+    assert isinstance(result['request']['release_date'], str)
     assert result['request']['release_date'] == '1970-01-01'
+
+
+def test_submit_invalid_release_date(test_app):
+    request_data = {**TEST_FW_PAYLOAD, 'release_date': 'invalid date'}
+    result = decode_response(test_app.put('/rest/firmware', json=request_data))
+    assert result['status'] == 1
+    assert 'Invalid date literal' in result['error_message']
 
 
 def test_request_update_bad_parameter(test_app):

--- a/src/web_interface/rest/rest_firmware.py
+++ b/src/web_interface/rest/rest_firmware.py
@@ -29,7 +29,7 @@ firmware_model = api.model('Upload Firmware', {
     'file_name':  fields.String(description='File Name', required=True),
     'version':  fields.String(description='Version', required=True),
     'vendor':  fields.String(description='Vendor', required=True),
-    'release_date':  fields.String(description='Release Date'),
+    'release_date':  fields.String(description='Release Date', default='1970-01-01'),
     'tags':  fields.String(description='Tags'),
     'requested_analysis_systems': fields.List(description='Selected Analysis Systems', cls_or_instance=fields.String),
     'binary': fields.String(description='Base64 String Representing the Raw Binary', required=True)

--- a/src/web_interface/rest/rest_firmware.py
+++ b/src/web_interface/rest/rest_firmware.py
@@ -4,6 +4,7 @@ from base64 import standard_b64decode
 
 from flask import request
 from flask_restx import Namespace, fields
+from flask_restx.fields import MarshallingError
 from pymongo.errors import PyMongoError
 
 from helperFunctions.database import ConnectTo
@@ -29,7 +30,7 @@ firmware_model = api.model('Upload Firmware', {
     'file_name':  fields.String(description='File Name', required=True),
     'version':  fields.String(description='Version', required=True),
     'vendor':  fields.String(description='Vendor', required=True),
-    'release_date':  fields.String(description='Release Date', default='1970-01-01'),
+    'release_date':  fields.Date(dt_format='iso8601', description='Release Date (ISO 8601)', default='1970-01-01'),
     'tags':  fields.String(description='Tags'),
     'requested_analysis_systems': fields.List(description='Selected Analysis Systems', cls_or_instance=fields.String),
     'binary': fields.String(description='Base64 String Representing the Raw Binary', required=True)
@@ -97,7 +98,11 @@ class RestFirmwareGetWithoutUid(RestResourceBase):
         The HTTP body must contain a json document of the structure shown below
         Important: The binary has to be a base64 string representing the raw binary you want to submit
         '''
-        data = self.validate_payload_data(firmware_model)
+        try:
+            data = self.validate_payload_data(firmware_model)
+        except MarshallingError as error:
+            logging.error(f'REST|firmware|PUT: Error in payload data: {error}')
+            return error_message(str(error), self.URL)
         result = self._process_data(data)
         if 'error_message' in result:
             logging.warning('Submission not according to API guidelines! (data could not be parsed)')


### PR DESCRIPTION
- added default date (`1970-01-01`)
- added validation for release_date field

resolves #687 