### PR TITLE
adding the Tilera/TILE-Gx architecture for detection

### DIFF
--- a/src/plugins/analysis/architecture_detection/code/architecture_detection.py
+++ b/src/plugins/analysis/architecture_detection/code/architecture_detection.py
@@ -72,7 +72,8 @@ class MetaDataDetector:
         'SuperH': ['Renesas SH'],
         'ESP': ['Tensilica Xtensa'],
         'Alpha': ['Alpha'],
-        'M68K': ['m68k', '68020']
+        'M68K': ['m68k', '68020'],
+        'Tilera': ['TILE-Gx', 'TILE64', 'TILEPro']
     }
     bitness = {
         '8-bit': ['8-bit'],

--- a/src/plugins/analysis/architecture_detection/test/test_plugin_architecture_detection.py
+++ b/src/plugins/analysis/architecture_detection/test/test_plugin_architecture_detection.py
@@ -82,6 +82,9 @@ class TestArchDetection(AnalysisPluginTest):
              'interpreter /lib/ld-uClibc.so.0, for GNU/Linux 4.8.0, not stripped'),
             ('ESP', '32-bit', 'little endian',
              'ELF 32-bit LSB executable, Tensilica Xtensa, version 1 (SYSV), statically linked, with debug_info, not stripped'),
+            ('Tilera', '32-bit', 'little endian',
+             'ELF 32-bit LSB executable, Tilera TILE-Gx, version 1 (SYSV), dynamically linked, interpreter /lib32/ld.so.1, '
+             'for GNU/Linux 2.6.32, stripped'),
         ]
         for data_set in architecture_test_data:
             self.start_process_object_meta_for_architecture(*data_set)


### PR DESCRIPTION
Adding TILE* family of architectures.  Not sure if you have a preference on the arch name since `Tilera` is the company name?  