### PR TITLE
switch to the stable cwe_checker image instead of the latest one

### DIFF
--- a/src/plugins/analysis/cwe_checker/code/cwe_checker.py
+++ b/src/plugins/analysis/cwe_checker/code/cwe_checker.py
@@ -1,12 +1,11 @@
 '''
-This plugin implements a wrapper around the BAP plugin cwe_checker, which checks ELF executables for
+This plugin implements a wrapper around the cwe_checker, which checks ELF executables for
 several CWEs (Common Weakness Enumeration). Please refer to cwe_checkers implementation for further information.
 Please note that these checks are heuristics and the checks are static.
 This means that there are definitely false positives and false negatives. The objective of this
 plugin is to find potentially interesting binaries that deserve a deep manual analysis or intensive fuzzing.
 
-As the plugin depends on BAP, it depends on BAP's lifting capabilities. Currently, BAP
-lifts to the following architectures:
+Currently the cwe_checker supports the following architectures:
 - Intel x86 (32 and 64 bits)
 - ARM
 - PowerPC
@@ -22,7 +21,7 @@ from analysis.PluginBase import AnalysisBasePlugin
 from helperFunctions.docker import run_docker_container
 
 TIMEOUT_IN_SECONDS = 600  # 10 minutes
-DOCKER_IMAGE = 'fkiecad/cwe_checker:latest'
+DOCKER_IMAGE = 'fkiecad/cwe_checker:stable'
 
 
 class AnalysisPlugin(AnalysisBasePlugin):

--- a/src/plugins/analysis/cwe_checker/install.py
+++ b/src/plugins/analysis/cwe_checker/install.py
@@ -19,7 +19,7 @@ class CweCheckerInstaller(AbstractPluginInstaller):
     base_path = Path(__file__).resolve().parent
 
     def install_docker_images(self):
-        run_cmd_with_logging('docker pull fkiecad/cwe_checker:latest')
+        run_cmd_with_logging('docker pull fkiecad/cwe_checker:stable')
 
 
 # Alias for generic use


### PR DESCRIPTION
Switch the Docker image of the cwe_checker plugin to the stable image instead of the latest one. This should hopefully prevent issues like in #691. The downside is that bugfixes to the cwe_checker need longer until they also land in FACT.