### PR TITLE
Elf analysis none bugfix

### DIFF
--- a/src/plugins/analysis/elf_analysis/code/elf_analysis.py
+++ b/src/plugins/analysis/elf_analysis/code/elf_analysis.py
@@ -26,7 +26,7 @@ class AnalysisPlugin(AnalysisBasePlugin):
     NAME = 'elf_analysis'
     DESCRIPTION = 'Analyzes and tags ELF executables and libraries'
     DEPENDENCIES = ['file_type']
-    VERSION = '0.3.1'
+    VERSION = '0.3.2'
     MIME_WHITELIST = ['application/x-executable', 'application/x-object', 'application/x-sharedlib']
 
     def __init__(self, plugin_administrator, config=None, recursive=True, offline_testing=False):

--- a/src/plugins/analysis/elf_analysis/code/elf_analysis.py
+++ b/src/plugins/analysis/elf_analysis/code/elf_analysis.py
@@ -1,12 +1,11 @@
 import json
 import logging
-import os
 import re
 from difflib import SequenceMatcher
+from pathlib import Path
 from typing import List, Optional
 
 import lief
-from common_helper_files import get_dir_of_file
 
 from analysis.PluginBase import AnalysisBasePlugin
 from helperFunctions.hash import normalize_lief_items
@@ -16,7 +15,8 @@ LIEF_DATA_ENTRIES = (
     'dynamic_entries', 'exported_functions', 'header', 'imported_functions', 'libraries', 'sections', 'segments',
     'symbols_version'
 )
-TEMPLATE_FILE_PATH = os.path.join(get_dir_of_file(__file__), '../internal/matching_template.json')
+TEMPLATE_FILE_PATH = Path(__file__).parent.parent / 'internal/matching_template.json'
+BEHAVIOUR_CLASSES = json.loads(TEMPLATE_FILE_PATH.read_text())
 
 # pylint: disable=c-extension-no-member
 
@@ -46,12 +46,6 @@ class AnalysisPlugin(AnalysisBasePlugin):
         return file_object
 
     @staticmethod
-    def _load_template_file_as_json_obj(path: str) -> dict:
-        with open(path, 'r') as fd:
-            data = json.load(fd)
-        return data
-
-    @staticmethod
     def _get_tags_from_library_list(libraries: list, behaviour_class: str, indicators: list, tags: list):
         for library, indicator in ((lib, ind) for lib in libraries for ind in indicators):
             if re.search(indicator, library):
@@ -64,11 +58,10 @@ class AnalysisPlugin(AnalysisBasePlugin):
                 tags.append(behaviour_class)
 
     def _get_tags(self, libraries: list, functions: list) -> list:
-        behaviour_classes = self._load_template_file_as_json_obj(TEMPLATE_FILE_PATH)
         tags = []
-        for behaviour_class in behaviour_classes:
+        for behaviour_class in BEHAVIOUR_CLASSES:
             if behaviour_class not in tags:
-                behaviour_indicators = behaviour_classes[behaviour_class]
+                behaviour_indicators = BEHAVIOUR_CLASSES[behaviour_class]
                 self._get_tags_from_function_list(functions, behaviour_class, behaviour_indicators, tags)
                 self._get_tags_from_library_list(libraries, behaviour_class, behaviour_indicators, tags)
         return list(set(tags))
@@ -130,10 +123,11 @@ class AnalysisPlugin(AnalysisBasePlugin):
                 binary_json_dict['imported_functions'] = normalize_lief_items(parsed_binary.imported_functions)
             if parsed_binary.libraries:
                 binary_json_dict['libraries'] = normalize_lief_items(parsed_binary.libraries)
-            if parsed_binary.sections:
-                elf_dict['modinfo'] = self.filter_modinfo(parsed_binary)
+            modinfo_data = self.filter_modinfo(parsed_binary)
+            if modinfo_data:
+                elf_dict['modinfo'] = modinfo_data
 
-        except (TypeError, lief.bad_file):
+        except (AttributeError, TypeError, lief.bad_file):
             logging.error(f'Bad file for lief/elf analysis {file_object.uid}.', exc_info=True)
             return elf_dict
 
@@ -151,12 +145,11 @@ class AnalysisPlugin(AnalysisBasePlugin):
 
     @staticmethod
     def filter_modinfo(binary) -> Optional[List[str]]:
-        # getting the information from the *.ko files .modinfo
+        # getting the information from the *.ko files .modinfo section
         modinfo = None
-        if binary is not None:
-            for section in binary.sections:
-                if section.name == '.modinfo':
-                    modinfo = bytes(section.content).decode()
-                    modinfo = [entry for entry in modinfo.split('\x00') if entry]
-                    break
+        for section in binary.sections:
+            if section.name == '.modinfo':
+                modinfo = bytes(section.content).decode()
+                modinfo = [entry for entry in modinfo.split('\x00') if entry]
+                break
         return modinfo

--- a/src/plugins/analysis/elf_analysis/test/test_plugin_elf_analysis.py
+++ b/src/plugins/analysis/elf_analysis/test/test_plugin_elf_analysis.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name,protected-access,wrong-import-order
 from collections import namedtuple
 from pathlib import Path
 
@@ -8,8 +9,6 @@ from objects.file import FileObject
 from test.common_helper import get_config_for_testing, get_test_data_dir
 
 from ..code.elf_analysis import AnalysisPlugin
-
-# pylint: disable=redefined-outer-name,protected-access
 
 TEST_DATA = Path(get_test_data_dir(), 'test_data_file.bin')
 
@@ -35,7 +34,7 @@ MOCK_DATA = (
 MOCK_LIEF_RESULT = LiefResult(
     libraries=['libdl.so.2', 'libc.so.6'],
     imported_functions=['fdopen', 'calloc', 'strstr', 'raise', 'gmtime_r', 'strcmp'],
-    symbols_version=list(),
+    symbols_version=[],
     exported_functions=['SHA256_Transform', 'GENERAL_NAMES_free', 'i2d_RSAPrivateKey', 'd2i_OCSP_REQUEST'],
     sections=[])
 
@@ -101,7 +100,7 @@ def test_get_tags(stub_plugin, monkeypatch):
         'two': ['z', 'a'],
         'three': ['f', 'u']
     }
-    monkeypatch.setattr('plugins.analysis.elf_analysis.code.elf_analysis.AnalysisPlugin._load_template_file_as_json_obj', lambda _, __: behaviour_classes)
+    monkeypatch.setattr('plugins.analysis.elf_analysis.code.elf_analysis.BEHAVIOUR_CLASSES', behaviour_classes)
     tags = stub_plugin._get_tags(libraries=['a', 'b', 'c'], functions=['d', 'e', 'f'])
     assert sorted(tags) == ['three', 'two']
 
@@ -117,7 +116,7 @@ def test_get_symbols_version_entries(stub_plugin, symbol_versions, expected):
 
 def test_create_tags(stub_plugin, stub_object):
     stub_object.processed_analysis[stub_plugin.NAME] = {}
-    stub_result = LiefResult(libraries=['recvmsg', 'unknown'], imported_functions=list(), symbols_version=list(), exported_functions=list(), sections=list())
+    stub_result = LiefResult(libraries=['recvmsg', 'unknown'], imported_functions=[], symbols_version=[], exported_functions=[], sections=[])
     stub_plugin.create_tags(stub_result, stub_object)
 
     assert 'network' in stub_object.processed_analysis[stub_plugin.NAME]['tags']
@@ -162,6 +161,6 @@ def test_plugin(stub_plugin, stub_object, monkeypatch):
 
 def test_modinfo(stub_plugin):
     test_file = FileObject(file_path=str(TEST_DATA_DIR / 'test_data.ko'))
-    bin_dict, bin = stub_plugin._analyze_elf(test_file)
-    result = stub_plugin.filter_modinfo(bin)
+    _, binary = stub_plugin._analyze_elf(test_file)
+    result = stub_plugin.filter_modinfo(binary)
     assert result[0] == 'this are test data\n'

--- a/src/plugins/analysis/elf_analysis/view/elf_analysis.html
+++ b/src/plugins/analysis/elf_analysis/view/elf_analysis.html
@@ -2,7 +2,8 @@
 
 {% block analysis_result_details %}
 
-{% for key in firmware.processed_analysis[selected_analysis]['Output'].keys() | sort %}
+{% set analysis = firmware.processed_analysis[selected_analysis]['Output'] %}
+{% for key in analysis.keys() | sort %}
     <tr>
         <td>
             {{ key }}
@@ -14,26 +15,26 @@
 
             <div class="collapse w-100" id="{{ key }}">
                 <table class="table table-bordered mb-0 pb-0">
-                    {% if firmware.processed_analysis[selected_analysis]['Output'][key] | is_list %}
-                        {% if not firmware.processed_analysis[selected_analysis]['Output'][key] %}
+                    {% if analysis[key] | is_list %}
+                        {% if not analysis[key] %}
                             <tr>
                                 <td style="padding: 5px">None</td>
                             </tr>
-                        {% elif firmware.processed_analysis[selected_analysis]['Output'][key][0] is string %}
-                                {% for element in firmware.processed_analysis[selected_analysis]['Output'][key] %}
+                        {% elif analysis[key][0] is string %}
+                                {% for element in analysis[key] %}
                                     <tr>
                                         <td style="padding: 5px">{{ element }}</td>
                                     </tr>
                                 {% endfor %}
                         {% else %}
                             <tr>
-                                {% for unique_key in firmware.processed_analysis[selected_analysis]['Output'][key] | get_unique_keys_from_list_of_dicts | sort %}
+                                {% for unique_key in analysis[key] | get_unique_keys_from_list_of_dicts | sort %}
                                     <th style="padding: 5px">{{ unique_key }}</th>
                                 {% endfor %}
                             </tr>
-                            {% for dictionary in firmware.processed_analysis[selected_analysis]['Output'][key] %}
+                            {% for dictionary in analysis[key] %}
                                 <tr>
-                                    {% for unique_key in firmware.processed_analysis[selected_analysis]['Output'][key] | get_unique_keys_from_list_of_dicts | sort %}
+                                    {% for unique_key in analysis[key] | get_unique_keys_from_list_of_dicts | sort %}
                                         {% if unique_key in dictionary.keys() %}
                                             <td style="padding: 5px">{{ dictionary[unique_key] }}</td>
                                         {% else %}
@@ -43,8 +44,8 @@
                                 </tr>
                             {% endfor %}
                         {% endif %}
-                    {% else %}
-                        {% for k, v in firmware.processed_analysis[selected_analysis]['Output'][key].items() %}
+                    {% elif analysis[key] %}
+                        {% for k, v in analysis[key].items() %}
                             <tr>
                                 <td style="padding: 5px">{{ k }}</td>
                                 <td style="padding: 5px">{{ v }}</td>


### PR DESCRIPTION
Resolves #700 
- Fixed bug in plugin elf_analysis where `None` is stored in case of no `.modinfo` section
- added check to elf_analysis template so that the server does not crash in case `None` is stored in the DB
- refactoring