### PR TITLE
pin pymongo version

### DIFF
--- a/src/install/requirements_common.txt
+++ b/src/install/requirements_common.txt
@@ -21,7 +21,7 @@ yara-python
 git+https://github.com/fkie-cad/fact_helper_file.git
 
 # Python MongoDB bindings
-pymongo
+pymongo<4
 pyyaml
 
 # Common code modules


### PR DESCRIPTION
- the newly released version 4 of pymongo produces errors with the DB interface
- this fix pins the version to <4