### PR TITLE
converted current analyses duplicate file warning loggings to debug

### DIFF
--- a/src/scheduler/Analysis.py
+++ b/src/scheduler/Analysis.py
@@ -498,7 +498,8 @@ class AnalysisScheduler:  # pylint: disable=too-many-instance-attributes
             for parent in self._find_currently_analyzed_parents(fw_object):
                 updated_dict = self.currently_running[parent]
                 if fw_object.uid not in updated_dict['files_to_analyze']:
-                    logging.warning(f'Trying to remove {fw_object.uid} from current analysis of {parent} but it is not included')
+                    # probably a file that occurred multiple times in one firmware
+                    logging.debug(f'Failed to remove {fw_object.uid} from current analysis of {parent}')
                     continue
                 updated_dict['files_to_analyze'] = list(set(updated_dict['files_to_analyze']) - {fw_object.uid})
                 updated_dict['analyzed_files_count'] += 1

--- a/src/test/unit/scheduler/test_current_analyses.py
+++ b/src/test/unit/scheduler/test_current_analyses.py
@@ -69,9 +69,9 @@ class TestCurrentAnalyses(UtilityBase):
         fo = FileObject(binary=b'foo')
         fo.parent_firmware_uids = {'parent_uid'}
         fo.uid = 'foo'
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG):
             self.scheduler._remove_from_current_analyses(fo)
-            assert any('but it is not included' in m for m in caplog.messages)
+            assert any('Failed to remove' in m for m in caplog.messages)
 
     def test_remove_fully_from_current_analyses(self):
         self.scheduler.currently_running = {'parent_uid': {


### PR DESCRIPTION
- warning log entries will occur during firmware analysis when one file is included in the firmware multiple times
- since this is a common occurrence, the warning is not necessary
    - converted the warning log to debug