### PR TITLE
Reimplement dependency graph with tools for navigation

### DIFF
--- a/src/test/unit/web_interface/test_dependency_graph.py
+++ b/src/test/unit/web_interface/test_dependency_graph.py
@@ -67,8 +67,8 @@ GRAPH_RES_SYMLINK = {'nodes':
                        'full_file_type': 'test text'},
                       {'label': 'file three', 'id': '0987654', 'group': 'inode/symlink',
                        'full_file_type': 'symbolic link to \'file two\''}],
-                      'edges': [{'from': '0987654', 'to': '7654321', 'id': 0},
-                                {'from': '7654321', 'to': '1234567', 'id': 1}],
+                     'edges': [{'from': '0987654', 'to': '7654321', 'id': 0},
+                               {'from': '7654321', 'to': '1234567', 'id': 1}],
                      'groups': ['application/x-executable', 'inode/symlink']}
 
 WHITELIST = ['application/x-executable', 'application/x-sharedlib', 'inode/symlink']

--- a/src/test/unit/web_interface/test_dependency_graph.py
+++ b/src/test/unit/web_interface/test_dependency_graph.py
@@ -47,7 +47,7 @@ GRAPH_RES = {'nodes':
                'full_file_type': 'test text'},
               {'label': 'file two', 'id': '7654321', 'group': 'application/x-executable',
                'full_file_type': 'test text'}],
-             'edges': [{'source': '7654321', 'target': '1234567', 'id': 0}],
+             'edges': [{'from': '7654321', 'to': '1234567', 'id': 0}],
              'groups': ['application/x-executable']}
 
 GRAPH_PART_SYMLINK = {'nodes':
@@ -67,8 +67,8 @@ GRAPH_RES_SYMLINK = {'nodes':
                        'full_file_type': 'test text'},
                       {'label': 'file three', 'id': '0987654', 'group': 'inode/symlink',
                        'full_file_type': 'symbolic link to \'file two\''}],
-                     'edges': [{'id': 0, 'source': '0987654', 'target': '7654321'},
-                               {'id': 1, 'source': '7654321', 'target': '1234567'}],
+                      'edges': [{'from': '0987654', 'to': '7654321', 'id': 0},
+                                {'from': '7654321', 'to': '1234567', 'id': 1}],
                      'groups': ['application/x-executable', 'inode/symlink']}
 
 WHITELIST = ['application/x-executable', 'application/x-sharedlib', 'inode/symlink']

--- a/src/web_interface/components/analysis_routes.py
+++ b/src/web_interface/components/analysis_routes.py
@@ -196,9 +196,11 @@ class AnalysisRoutes(ComponentBase):
         with ConnectTo(FrontEndDbInterface, self._config) as db:
             data = db.get_data_for_dependency_graph(uid)
 
-            whitelist = ['application/x-executable', 'application/x-sharedlib', 'inode/symlink']
+            whitelist = ['application/x-executable', 'application/x-pie-executable', 'application/x-sharedlib', 'inode/symlink']
 
             data_graph_part = create_data_graph_nodes_and_groups(data, whitelist)
+
+            colors = sorted(get_graph_colors(len(data_graph_part['groups'])))
 
             if not data_graph_part['nodes']:
                 flash('Error: Graph could not be rendered. '
@@ -210,7 +212,5 @@ class AnalysisRoutes(ComponentBase):
             if elf_analysis_missing_from_files > 0:
                 flash(f'Warning: Elf analysis plugin result is missing for {elf_analysis_missing_from_files} files', 'warning')
 
-            color_list = get_graph_colors()
-
             # TODO: Add a loading icon?
-        return render_template('dependency_graph.html', **data_graph, uid=uid, color_list=color_list)
+        return render_template('dependency_graph.html', **data_graph, uid=uid, colors=colors)

--- a/src/web_interface/components/dependency_graph.py
+++ b/src/web_interface/components/dependency_graph.py
@@ -80,4 +80,4 @@ def find_edges(data_graph, edge_id, lib, file_object):
 
 
 def get_graph_colors(quantity):
-    return get_color_list(quantity, quantity)
+    return get_color_list(quantity, quantity) if quantity > 0 else []

--- a/src/web_interface/components/dependency_graph.py
+++ b/src/web_interface/components/dependency_graph.py
@@ -26,7 +26,7 @@ def create_data_graph_nodes_and_groups(data, whitelist):
 
             data_graph['nodes'].append(node)
 
-    data_graph['groups'] = groups
+    data_graph['groups'] = sorted(groups)
 
     return data_graph
 

--- a/src/web_interface/components/dependency_graph.py
+++ b/src/web_interface/components/dependency_graph.py
@@ -72,14 +72,12 @@ def find_edges(data_graph, edge_id, lib, file_object):
             target_id = node['id']
             break
     if target_id is not None:
-        edge = {'source': file_object['_id'], 'target': target_id, 'id': edge_id}
+        edge = {'from': file_object['_id'], 'to': target_id, 'id': edge_id}
         data_graph['edges'].append(edge)
         edge_id += 1
 
     return edge_id
 
 
-def get_graph_colors():
-    available_colors = get_color_list(10)
-    color_list = list(islice(chain(*repeat(available_colors, 4)), None, None, 4))
-    return color_list
+def get_graph_colors(quantity):
+    return get_color_list(quantity, quantity)

--- a/src/web_interface/components/dependency_graph.py
+++ b/src/web_interface/components/dependency_graph.py
@@ -58,7 +58,7 @@ def create_symbolic_link_edges(data_graph):
             link_to = node['full_file_type'].split('\'')[1]
             for match in data_graph['nodes']:
                 if match['label'] == link_to:
-                    edge = {'source': node['id'], 'target': match['id'], 'id': edge_id}
+                    edge = {'from': node['id'], 'to': match['id'], 'id': edge_id}
                     data_graph['edges'].append(edge)
                     edge_id += 1
     return edge_id

--- a/src/web_interface/static/css/dependency_graph.css
+++ b/src/web_interface/static/css/dependency_graph.css
@@ -2,6 +2,3 @@
     height: 800px;
 }
 
-#dependencyGraphLegend {
-    height: 500px;
-}

--- a/src/web_interface/static/js/dependency_graph.js
+++ b/src/web_interface/static/js/dependency_graph.js
@@ -171,7 +171,7 @@ function nodeListSelectionHandler(ev) {
 
     // if the user clicked a link on the nodes list, this will be defined
     if (ref.dataset.nodeid !== undefined) {
-        // we then programmatically selected the node in the network...
+        // we then programmatically select the node in the network...
         network.selectNodes([ref.dataset.nodeid]);
 
         // ... and invoke the selection handler by hand, because vis.js does

--- a/src/web_interface/static/js/dependency_graph.js
+++ b/src/web_interface/static/js/dependency_graph.js
@@ -1,274 +1,265 @@
-var nodes, groups, edges, network, legend_network, allNodes;
-    var highlightActive = false;
+var allConnectedNodes;
+var allNodes;
+var dataset;
+var graphOptions;
+var groupOptions;
+var highlightActive = false;
+var network;
 
-    // convenience method to stringify a JSON object
-    function toJSON(obj) {
-        return JSON.stringify(obj, null, 4);
-    }
+function dependencyGraph(nodes, edges, groups, colors) {
+    let graphCanvas = $("#dependencyGraph")[0];
 
-    var my_nodes = [];
-    var my_edges = [];
-    groups = [];
-
-    var graph_container = document.getElementById("dependencyGraph");
-    var legend_container = document.getElementById("dependencyGraphLegend");
-
-    for (i in get_nodes) {
-        my_nodes[i] = {id: get_nodes[i].id, label: get_nodes[i].label, group: get_nodes[i].group, full_file_type: get_nodes[i].full_file_type}
-    }
-    for (i in get_edges) {
-        my_edges[i] = {id: get_edges[i].id, from: get_edges[i].source, to: get_edges[i].target}
-    }
-    for (i in get_groups) {
-        groups.push(get_groups[i])
-    }
-
-    // create an array with nodes
-    nodes = new vis.DataSet();
-    nodes.add(my_nodes);
-
-    // create a legend
-    // and change group colors
-    var legend_nodes = new vis.DataSet();
-    var legend_nodes_array = [];
-    var x = 0;
-    var y = 0;
-    var step = 60;
-
-    var group_options = {};
-   
-    if (typeof color_list === 'undefined' || color_list.length <= 0) {
-        // bootstrap colors cyan, yellow, pink, blue, purple, orange
-        color_list = ['#17a2b8', '#ffc107', '#e83e8c', '#007bff', '#6f42c1', '#fd7e14'];
-    }
-    color_i = 0;
-
-    var id = 1;
-    var step_i = 0;
-    for (j in groups) {
-        legend_nodes_array.push({
-            id: id,
-            x: x,
-            y: y + step * step_i,
-            label: groups[j],
-            group: groups[j],
-            value: 1,
-            fixed: true,
-            physics: false
-        });
-        id = id + 1;
-        step_i = step_i + 1;
-        group_options [groups[j]] = {color: color_list[color_i]};
-        color_i = (color_i + 1)%color_list.length;
-    }
-    legend_nodes.add(legend_nodes_array);
-
-    // create an array with edges
-    edges = new vis.DataSet();
-    edges.add(my_edges);
-
-    // create a network
-    var data = {
-        nodes: nodes,
-        edges: edges,
+    dataset = {
+        nodes: new vis.DataSet(nodes),
+        edges: new vis.DataSet(edges)
     };
 
-    var legend_data = {
-        nodes: legend_nodes,
-    };
+    // map group names to colors --> {'mime/type': {color: '#...'}}
+    groupOptions = groups.reduce((obj, curr, i) => {return {...obj, [curr]: {color: colors[i]}}}, {});
 
-    function draw_network() {
-
-        var options = {
-            nodes: {
-                shape: 'dot',
-                scaling: {
-                    min: 10,
-                    max: 30
-                },
-                font: {
-                    size: 12,
-                    face: 'Tahoma'
-                }
-            },
-            groups: group_options,
-            edges: {
-                color:{inherit:true},
-                width: 0.15,
-                arrows: {
-                    to: true
-                }
-            },
-            interaction: {
-                hideEdgesOnDrag: true,
-                tooltipDelay: 200
-            },
-            physics: {
-                forceAtlas2Based: {
-                    gravitationalConstant: -129,
-                    centralGravity: 0.16,
-                    springLength: 0,
-                    springConstant: 0.4,
-                    damping: 0.85,
-                    avoidOverlap: 0.46
-                },
-                minVelocity: 0.75,
-                solver: 'forceAtlas2Based'
+    // set the graph options. Most of this is physics model initialization
+    graphOptions = {
+        nodes: {
+            shape: 'dot',
+            font: {
+                size: 18,
+                face: 'Tahoma'
             }
-        };
+        },
+        groups: groupOptions,
+        edges: {
+            color: { inherit: true },
+            width: 0.5,
+            arrows: { to: true },
+        },
+        interaction: {
+            dragNodes: false,
+        },
+        physics: {
+            enabled: true,
+            solver: 'forceAtlas2Based',
+            forceAtlas2Based: {
+                theta: 0.8,
+                springLength: 40,
+                springConstant: 0.05,
+                damping: 0.4,
+                avoidOverlap: 0.1,
+            },
+            maxVelocity: 2000,
+            minVelocity: 0.0,
+            timestep: 0.05,
+            adaptiveTimestep: true,
+            stabilization: {
+              enabled: false
+            }
+        },
+        layout: {
+            randomSeed: 0,
+            improvedLayout: false,
+        }
+    };
 
-        network = new vis.Network(graph_container, data, options,  main = "Dependency Graph");
+    // draw all components
+    network = drawNetwork(dataset, graphOptions, graphCanvas);
+    drawLegend(groups, colors);
+    drawNodesList();
+    drawDetails();
 
-        allNodes = nodes.get({ returnType: "Object" });
-        network.on("click", neighbourhoodHighlight);
+    // register event handlers
+    network.on("click", neighbourhoodHighlight);
+    $('#nodesList').click(nodeListSelectionHandler);
+    $('#nodeFilter').keyup(filterNodesList);
+}
 
-        network.on("oncontext", contextMenu);
+function drawLegend(groups, colors) {
+    // draw the legend
+    let legend = $('#legend');
+    for (let i = 0; i < groups.length; i++) {
+        legend.append('<div><span style="color: ' + colors[i] + ';">&#9679;</span> ' + groups[i] + '</div>');
+    }
+}
 
-        network.on("stabilizationIterationsDone", function (params) {
+function filterNodesList() {
+    // filter nodes list event handler
+    try {
+        // the filter input supports regex
+        var expr = new RegExp($(this).val(), 'i');
+    } catch(SyntaxError) {
+        // invalid search
+        return;
+    }
+
+    $("#nodesList > div").each(function(){
+        // hide all nodes in the list that are filtered out, show the rest
+        let mime = $(this).find('a')[0].dataset.nodemime;
+        let name = $(this).find('a')[0].dataset.nodelabel;
+
+        // we search both name and mime
+        if (mime.search(expr) < 0 && name.search(expr) < 0) {
+            $(this).fadeOut();
+        } else {
+            $(this).show();
+        }
+    });
+}
+
+function drawNodesList() {
+    let nodesList = $('#nodesList');
+    $('#nodeFilter')[0].value = '';
+    nodesList.empty();
+
+    for (nodeId in allNodes) {
+        let node = dataset.nodes.get(nodeId);
+        let color = groupOptions[node.group].color;
+        if (node.label !== undefined) {
+            nodesList.append('<div><span style="color: ' + color + ';">&#9679;</span>&nbsp;<a href="#" class="text-dark" data-nodeid="' + node.id + '" data-nodelabel="' + node.label + '" data-nodemime="' + node.group + '" style="text-decoration: none;">' + node.label + '</a></div>');
+        }
+    }
+}
+
+function drawDetails() {
+    // get details and flush contents
+    let details = $('#detailsBody');
+    details.empty();
+
+    // check if something is selected
+    let selected = network.getSelectedNodes();
+    if (selected.length == 0) {
+        details.append('<div>No node selected</div>');
+        return;
+    }
+
+    // show node details
+    let node = dataset.nodes.get(selected[0]);
+    let color = groupOptions[node.group].color;
+    details.append(`
+        <div>
+            <a target="_blank" href="/analysis/${node.id}">Analysis Results</a>
+        </div>
+        <div>
+            <span class="font-weight-bold">Node:&nbsp;</span><span style="color: ${color};">&#9679;</span>&nbsp;${node.label}
+        </div>
+        <div>
+            <span class="font-weight-bold">Mime:&nbsp;</span>${node.group}
+        </div>
+        <div>
+            <span class="font-weight-bold">Full:&nbsp;</span>${node.full_file_type}
+        </div>`
+    );
+}
+
+function drawNetwork(dataset, graphOptions, canvas) {
+    // create the network on an empty canvas
+    let network = new vis.Network(canvas, dataset, graphOptions,  main = "Dependency Graph");
+    allNodes = dataset.nodes.get({ returnType: "Object" });
+
+    // get a decent stabilization before starting a 60 second timeout that
+    // aborts the physics simulation to preserve resources
+    network.on("stabilizationIterationsDone", function (params) {
+        setTimeout(() => {
             network.stopSimulation();
             network.setOptions( { physics: false } );
-        });
-        network.stabilize(100);
-    };
-
-    function draw_legend() {
-
-        // create a legend graph
-        var legend_options = {
-            nodes: {
-                shape: 'dot',
-                scaling: {
-                    min: 10,
-                    max: 30
-                },
-                font: {
-                    size: 12,
-                    face: 'Tahoma'
-                }
-            },
-            groups: group_options,
-            interaction: {
-                hideEdgesOnDrag: true,
-                tooltipDelay: 200,
-                dragNodes: false,
-                dragView: false,
-                zoomView: false
-            },
-            physics: {
-                forceAtlas2Based: {
-                    gravitationalConstant: -129,
-                    centralGravity: 0.16,
-                    springLength: 0,
-                    springConstant: 0.4,
-                    damping: 0.85,
-                    avoidOverlap: 0.46
-                },
-                minVelocity: 0.75,
-                solver: 'forceAtlas2Based'
-            }
-        };
-
-        legend_network = new vis.Network(legend_container, legend_data, legend_options,  main = "Dependency Graph Legend");
-
-        legend_network.on("stabilizationIterationsDone", function (params) {
-            legend_network.stopSimulation();
-            legend_network.setOptions( { physics: false } );
-        });
-        legend_network.stabilize(100);
-    };
-
-    function contextMenu(params) {
-        params.event.preventDefault();
-        $('#context-menu').modal()
-        var nodeId = network.getNodeAt(params.pointer.DOM);
-        var href = '/analysis/' + nodeId;
-        var nodeLabel = allNodes[nodeId].label;
-        var link = '<a href="' + href + '">' + nodeLabel + '</a>';
-        var fileType = allNodes[nodeId].full_file_type;
-        document.getElementById('node-link').innerHTML = link;
-        document.getElementById('file-type').innerHTML = fileType;
-    };
-
-
-
-    function neighbourhoodHighlight(params) {
-        // if something is selected:
-        if (params.nodes.length > 0) {
-            highlightActive = true;
-            var i, j;
-            var selectedNode = params.nodes[0];
-            var degrees = 1;
-
-            // mark all nodes as hard to read.
-            for (var nodeId in allNodes) {
-                allNodes[nodeId].color = "rgba(200,200,200,0.5)";
-                if (allNodes[nodeId].hiddenLabel === undefined) {
-                    allNodes[nodeId].hiddenLabel = allNodes[nodeId].label;
-                    allNodes[nodeId].label = undefined;
-                }
-            }
-
-            var connectedNodes = network.getConnectedNodes(selectedNode);
-            var allConnectedNodes = [];
-
-            // get the second degree nodes
-            for (i = 1; i < degrees; i++) {
-                for (j = 0; j < connectedNodes.length; j++) {
-                    allConnectedNodes = allConnectedNodes.concat(
-                        network.getConnectedNodes(connectedNodes[j])
-                    );
-                }
-            }
-
-            // all second degree nodes get a different color and their label back
-            for (i = 0; i < allConnectedNodes.length; i++) {
-                allNodes[allConnectedNodes[i]].color = "rgba(150,150,150,0.75)";
-                if (allNodes[allConnectedNodes[i]].hiddenLabel !== undefined) {
-                    allNodes[allConnectedNodes[i]].label =
-                    allNodes[allConnectedNodes[i]].hiddenLabel;
-                    allNodes[allConnectedNodes[i]].hiddenLabel = undefined;
-                }
-            }
-
-            // all first degree nodes get their own color and their label back
-            for (i = 0; i < connectedNodes.length; i++) {
-                allNodes[connectedNodes[i]].color = undefined;
-                if (allNodes[connectedNodes[i]].hiddenLabel !== undefined) {
-                    allNodes[connectedNodes[i]].label =
-                    allNodes[connectedNodes[i]].hiddenLabel;
-                    allNodes[connectedNodes[i]].hiddenLabel = undefined;
-                }
-            }
-
-            // the main node gets its own color and its label back.
-            allNodes[selectedNode].color = undefined;
-            if (allNodes[selectedNode].hiddenLabel !== undefined) {
-                allNodes[selectedNode].label = allNodes[selectedNode].hiddenLabel;
-                allNodes[selectedNode].hiddenLabel = undefined;
-            }
-        } else if (highlightActive === true) {
-            // reset all nodes
-            for (var nodeId in allNodes) {
-                allNodes[nodeId].color = undefined;
-                if (allNodes[nodeId].hiddenLabel !== undefined) {
-                    allNodes[nodeId].label = allNodes[nodeId].hiddenLabel;
-                    allNodes[nodeId].hiddenLabel = undefined;
-                }
-            }
-            highlightActive = false;
-        }
-
-        // transform the object into an array
-        var updateArray = [];
-        for (nodeId in allNodes) {
-            if (allNodes.hasOwnProperty(nodeId)) {
-                updateArray.push(allNodes[nodeId]);
-            }
-        }
-        nodes.update(updateArray);
-    }
-
-    window.addEventListener("load", () => {
-        draw_network();
-        draw_legend();
+        }, 60000);
     });
+    network.stabilize(200);
+
+    return network;
+}
+
+function nodeListSelectionHandler(ev) {
+    let ref = ev.target;
+
+    // if the user clicked a link on the nodes list, this will be defined
+    if (ref.dataset.nodeid !== undefined) {
+        // we then programmatically selected the node in the network...
+        network.selectNodes([ref.dataset.nodeid]);
+
+        // ... and invoke the selection handler by hand, because vis.js does
+        // not fire a click event in this case.
+        let params = {nodes: network.getSelectedNodes()};
+        neighbourhoodHighlight(params)
+    }
+}
+
+// adapted source from visjs example:
+// https://visjs.github.io/vis-network/examples/network/exampleApplications/neighbourhoodHighlight.html
+function neighbourhoodHighlight(params) {
+    // if something is selected:
+    if (params.nodes.length > 0) {
+        highlightActive = true;
+        var i, j;
+        var selectedNode = params.nodes[0];
+        var degrees = 1;
+        network.focus(selectedNode, {scale: 0.4, animation: {easingFunction: 'easeInOutQuad'}});
+ 
+        // mark all nodes as hard to read.
+        for (var nodeId in allNodes) {
+            allNodes[nodeId].color = "rgba(200,200,200,0.5)";
+            if (allNodes[nodeId].hiddenLabel === undefined) {
+                allNodes[nodeId].hiddenLabel = allNodes[nodeId].label;
+                allNodes[nodeId].label = undefined;
+            }
+        }
+ 
+        var connectedNodes = network.getConnectedNodes(selectedNode);
+        allConnectedNodes = [];
+ 
+        // get the second degree nodes
+        for (i = 1; i < degrees; i++) {
+            for (j = 0; j < connectedNodes.length; j++) {
+                allConnectedNodes = allConnectedNodes.concat(
+                    network.getConnectedNodes(connectedNodes[j])
+                );
+            }
+        }
+ 
+        // all second degree nodes get a different color and their label back
+        for (i = 0; i < allConnectedNodes.length; i++) {
+            allNodes[allConnectedNodes[i]].color = "rgba(150,150,150,0.75)";
+            if (allNodes[allConnectedNodes[i]].hiddenLabel !== undefined) {
+                allNodes[allConnectedNodes[i]].label =
+                allNodes[allConnectedNodes[i]].hiddenLabel;
+                allNodes[allConnectedNodes[i]].hiddenLabel = undefined;
+            }
+        }
+ 
+        // all first degree nodes get their own color and their label back
+        for (i = 0; i < connectedNodes.length; i++) {
+            allNodes[connectedNodes[i]].color = undefined;
+            if (allNodes[connectedNodes[i]].hiddenLabel !== undefined) {
+                allNodes[connectedNodes[i]].label =
+                allNodes[connectedNodes[i]].hiddenLabel;
+                allNodes[connectedNodes[i]].hiddenLabel = undefined;
+            }
+        }
+ 
+        // the main node gets its own color and its label back.
+        allNodes[selectedNode].color = undefined;
+        if (allNodes[selectedNode].hiddenLabel !== undefined) {
+            allNodes[selectedNode].label = allNodes[selectedNode].hiddenLabel;
+            allNodes[selectedNode].hiddenLabel = undefined;
+        }
+    } else if (highlightActive === true) {
+        // reset all nodes
+        for (var nodeId in allNodes) {https://github.com/almende/vis/issues/2906
+            allNodes[nodeId].color = undefined;
+            if (allNodes[nodeId].hiddenLabel !== undefined) {
+                allNodes[nodeId].label = allNodes[nodeId].hiddenLabel;
+                allNodes[nodeId].hiddenLabel = undefined;
+            }
+        }
+        highlightActive = false;
+    }
+    // transform the object into an array
+    var updateArray = [];
+    for (nodeId in allNodes) {
+        if (allNodes.hasOwnProperty(nodeId)) {
+            updateArray.push(allNodes[nodeId]);
+        }
+    }
+    dataset.nodes.update(updateArray);
+
+    // re-draw nodes list and node detail view
+    drawNodesList();
+    drawDetails();
+}

--- a/src/web_interface/templates/dependency_graph.html
+++ b/src/web_interface/templates/dependency_graph.html
@@ -7,6 +7,19 @@
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/dependency_graph.css') }}">
    
     <script src="{{ url_for('static', filename='web_js/vis-network.min.js') }}"></script> 
+
+    <script type="text/javascript" src="{{ url_for('static', filename='js/dependency_graph.js') }}"></script>
+
+    <script type="text/javascript">
+        $(window).on("load", () => {
+            dependencyGraph(
+                {{ nodes | safe }},
+                {{ edges | safe }},
+                {{ groups | safe }},
+                {{ colors | safe }}
+            );
+        });
+    </script>
 {% endblock %}
     
 {% block style %}
@@ -15,25 +28,6 @@
 
 
 {% block body %}
-    <div class="modal" id="context-menu" tabindex="-1" role="dialog" aria-labelledby="contextLabel" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="contextLabel">Additional information</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body">
-                    Node:
-                    <p id='node-link'>No node selected.</p>
-                    <br>
-                    File type:
-                    <p id='file-type'>No node selected.</p>
-                </div>
-            </div>
-        </div>
-    </div>
     <div class="header mb-4" style="word-wrap: break-word">
         <h3>
             Dependency Graph for File {{ uid | replace_uid_with_hid }}
@@ -41,32 +35,56 @@
             <span style="font-size: 15px"><strong>UID:</strong> {{ uid }}</span>
         </h3>
     </div>
-
-
-    <div class="row mb-3">
+    <div class="row lb-3">
         <div class="col-lg-8 col-xl-10">
             <div id="dependencyGraph" class="border rounded"></div>
         </div>
         <div class="col-lg-4 col-xl-2">
-            <div class="header mb-4" style="word-wrap: break-word">
-                <h4 style="text-align: center">Legend</h4>
+            <div class="accordion" id="graphSidebar">
+                <div class="card">
+                  <div class="card-header" id="legendHeader" style="background-color: #255e54; padding: 0;">
+                      <button class="btn btn-link text-white" data-toggle="collapse" data-target="#legend" aria-expanded="true" aria-controls="legendBody" style="text-decoration: none; font-weight: 400;">
+                        Legend
+                      </button>
+                  </div>
+                  <div class="collapse show" aria-labelledby="legendHeader">
+                    <div id="legend" class="card-body" style="height: 125px; overflow: auto;">
+
+                    </div>
+                  </div>
+                </div>
+                <div class="card">
+                  <div class="card-header" id="detailsHeader" style="background-color: #255e54; padding: 0;">
+                      <button class="btn btn-link text-white" data-toggle="collapse" data-target="#details" aria-expanded="true" aria-controls="details" style="text-decoration: none; font-weight: 400;">
+                        Node Details
+                      </button>
+                  </div>
+                  <div id="details" class="collapse show" aria-labelledby="detailsHeader">
+                    <div id="detailsBody" class="card-body" style="height: 150px; overflow: auto;">
+                    </div>
+                  </div>
+                </div>
+                <div class="card">
+                  <div class="card-header" id="nodesHeader" style="background-color: #255e54; padding: 0;">
+                      <button class="btn btn-link text-white" data-toggle="collapse" data-target="#nodesBody" aria-expanded="true" aria-controls="nodesBody" style="text-decoration: none; font-weight: 400;">
+                        Connected Nodes
+                      </button>
+                  </div>
+                  <div id="nodesBody" class="collapse show" aria-labelledby="nodesHeader">
+                    <div class="card-body">
+                      <form>
+                        <div class="form-group">
+                          <input type="text" class="form-control" id="nodeFilter" placeholder="Filter by name/mime..." />
+                        </div>
+                      </form>
+                      <div id="nodesList" style="height: 314px; overflow: auto;">
+                      </div>
+                    </div>
+                  </div>
+                </div>
             </div>
-            <div id="dependencyGraphLegend"></div>
-            <span style="font-size: 15px">
-                A context menu providing additional information about the nodes is available on right click.
-            </span>
         </div>
     </div>
 
-<!--  insert js graph magic here  -->
-
-<script>
-    var get_nodes = {{ nodes | safe }};
-    var get_edges = {{ edges | safe }};
-    var get_groups = {{ groups | safe }};
-
-    var color_list = {{ color_list | safe }};
-</script>
-<script type="text/javascript" src="{{ url_for('static', filename='js/dependency_graph.js') }}"></script>
 
 {% endblock %}


### PR DESCRIPTION
![depgraph_rework](https://user-images.githubusercontent.com/5111321/147112510-b2d26085-bac9-486b-933f-ccea05575498.png)
 
Issue #712 made clear that the current dependency graph implementation is of limited use: Usage in larger environments fails due to missing tools for proper navigation. As the client-side code was rather messy and unmaintained, I took this as a chance to completely re-implement the feature with added functionality.

This PR includes following changes:

* Enabled `vis.js` physics using the rather fast [forceAtlas2Based](https://visjs.github.io/vis-network/docs/network/physics.html) solver
* Nodes are no longer draggable (the physics solver will take care of clustering, if even possible in complex dependecy graphs)
* Physics simulation will stop after 60 seconds to save power and CPU cycles (should be sufficient to kind of stabilize the graph)
* Each element in the sidebar is collapsible
* Moved right click modal with node information to a sidebar element
* Added `Connected Nodes` list as sidebar element
* `Connected Nodes` list is dynamically filterable/searchable using regex input
* Nodes in `Connected Nodes` can be used for navigation and further searching within the graph
* Reworked legend, made it a pure html text element in the sidebar
* Added support for `x-pie-executable` ELF files
* Linearly scalable colors for nodes and edges
* Deterministic colors: Colors were switched up between graphs in the previous implementation
* Added camera movements and generic zoom on node selection to visually aid graph navigation

_For a screenshot of the new dependency graph see above_