### PR TITLE
File object update parents bugfix

### DIFF
--- a/src/helperFunctions/merge_generators.py
+++ b/src/helperFunctions/merge_generators.py
@@ -1,9 +1,10 @@
 import itertools
 from copy import deepcopy
 from random import sample, seed
-from typing import Sequence
+from typing import Iterable, List, Sequence, TypeVar
 
 seed()
+T = TypeVar('T')  # pylint: disable=invalid-name
 
 
 def _add_nested_list_to_dict(input_list, input_dict):
@@ -68,3 +69,13 @@ def shuffled(sequence):
     :return: A shuffled copy of `sequence`
     '''
     return sample(sequence, len(sequence))
+
+
+def merge_lists(*lists: Iterable[T]) -> List[T]:
+    '''
+    Merges multiple lists into one (sorted) list while only keeping unique entries.
+
+    :param lists: The lists to be merged.
+    :return: A merged list.
+    '''
+    return sorted(set.union(*(set(list_) for list_ in lists)))

--- a/src/storage/db_interface_backend.py
+++ b/src/storage/db_interface_backend.py
@@ -23,11 +23,11 @@ class BackEndDbInterface(MongoInterfaceCommon):
             return
         self.release_unpacking_lock(fo_fw.uid)
 
-    def update_object(self, new_object=None, old_object=None):
+    def update_object(self, new_object: FileObject, old_db_entry: dict):
         update_dictionary = {
-            'processed_analysis': self._update_processed_analysis(new_object, old_object),
-            'files_included': update_included_files(new_object, old_object),
-            'virtual_file_path': update_virtual_file_path(new_object, old_object),
+            'processed_analysis': self._update_processed_analysis(new_object, old_db_entry),
+            'files_included': update_included_files(new_object, old_db_entry),
+            'virtual_file_path': update_virtual_file_path(new_object, old_db_entry),
         }
 
         if isinstance(new_object, Firmware):
@@ -43,8 +43,8 @@ class BackEndDbInterface(MongoInterfaceCommon):
             collection = self.firmwares
         else:
             update_dictionary.update({
-                'parent_firmware_uids': merge_lists(old_object['parent_firmware_uids'], new_object.parent_firmware_uids),
-                'parents': merge_lists(old_object['parents'], new_object.parents)
+                'parent_firmware_uids': merge_lists(old_db_entry['parent_firmware_uids'], new_object.parent_firmware_uids),
+                'parents': merge_lists(old_db_entry['parents'], new_object.parents)
             })
             collection = self.file_objects
 
@@ -56,12 +56,12 @@ class BackEndDbInterface(MongoInterfaceCommon):
             old_pa[key] = new_object.processed_analysis[key]
         return self.sanitize_analysis(analysis_dict=old_pa, uid=new_object.uid)
 
-    def add_firmware(self, firmware):
-        old_object = self.firmwares.find_one({'_id': firmware.uid})
-        if old_object:
+    def add_firmware(self, firmware: Firmware):
+        old_db_entry = self.firmwares.find_one({'_id': firmware.uid})
+        if old_db_entry:
             logging.debug('Update old firmware!')
             try:
-                self.update_object(new_object=firmware, old_object=old_object)
+                self.update_object(new_object=firmware, old_db_entry=old_db_entry)
             except Exception:  # pylint: disable=broad-except
                 logging.error('Could not update firmware:', exc_info=True)
         else:
@@ -100,11 +100,11 @@ class BackEndDbInterface(MongoInterfaceCommon):
         return entry
 
     def add_file_object(self, file_object):
-        old_object = self.file_objects.find_one({'_id': file_object.uid})
-        if old_object:
+        old_db_entry = self.file_objects.find_one({'_id': file_object.uid})
+        if old_db_entry:
             logging.debug('Update old file_object!')
             try:
-                self.update_object(new_object=file_object, old_object=old_object)
+                self.update_object(new_object=file_object, old_db_entry=old_db_entry)
             except Exception:  # pylint: disable=broad-except
                 logging.error('Could not update file object:', exc_info=True)
         else:

--- a/src/storage/db_interface_backend.py
+++ b/src/storage/db_interface_backend.py
@@ -42,7 +42,8 @@ class BackEndDbInterface(MongoInterfaceCommon):
             collection = self.firmwares
         else:
             update_dictionary.update({
-                'parent_firmware_uids': list(set.union(set(old_object['parent_firmware_uids']), new_object.parent_firmware_uids))
+                'parent_firmware_uids': list(set.union(set(old_object['parent_firmware_uids']), new_object.parent_firmware_uids)),
+                'parents': list(set.union(set(old_object['parents']), new_object.parents))
             })
             collection = self.file_objects
 

--- a/src/storage/db_interface_backend.py
+++ b/src/storage/db_interface_backend.py
@@ -4,6 +4,7 @@ from time import time
 from pymongo.errors import PyMongoError
 
 from helperFunctions.data_conversion import convert_str_to_time
+from helperFunctions.merge_generators import merge_lists
 from helperFunctions.object_storage import update_included_files, update_virtual_file_path
 from objects.file import FileObject
 from objects.firmware import Firmware
@@ -42,8 +43,8 @@ class BackEndDbInterface(MongoInterfaceCommon):
             collection = self.firmwares
         else:
             update_dictionary.update({
-                'parent_firmware_uids': list(set.union(set(old_object['parent_firmware_uids']), new_object.parent_firmware_uids)),
-                'parents': list(set.union(set(old_object['parents']), new_object.parents))
+                'parent_firmware_uids': merge_lists(old_object['parent_firmware_uids'], new_object.parent_firmware_uids),
+                'parents': merge_lists(old_object['parents'], new_object.parents)
             })
             collection = self.file_objects
 

--- a/src/test/integration/storage/test_db_interface_backend.py
+++ b/src/test/integration/storage/test_db_interface_backend.py
@@ -102,14 +102,17 @@ class TestStorageDbInterfaceBackend(unittest.TestCase):
 
         self.test_fo.processed_analysis = first_dict
         self.test_fo.files_included = {'file a', 'file b'}
+        self.test_fo.parents = ['parent_1']
         self.db_interface_backend.add_file_object(self.test_fo)
         self.test_fo.processed_analysis = second_dict
         self.test_fo.files_included = {'file b', 'file c'}
+        self.test_fo.parents = ['parent_2']
         self.db_interface_backend.add_file_object(self.test_fo)
         received_object = self.db_interface.get_object(self.test_fo.uid)
-        self.assertEqual(0, received_object.processed_analysis['other_plugin']['result'])
-        self.assertEqual(1, received_object.processed_analysis['stub_plugin']['result'])
-        self.assertEqual(3, len(received_object.files_included))
+        assert received_object.processed_analysis['other_plugin']['result'] == 0
+        assert received_object.processed_analysis['stub_plugin']['result'] == 1
+        assert len(received_object.files_included) == 3
+        assert sorted(received_object.parents) == ['parent_1', 'parent_2']
 
     def test_add_and_get_object_including_comment(self):
         comment, author, date, uid = 'this is a test comment!', 'author', '1473431685', self.test_fo.uid

--- a/src/test/unit/helperFunctions/test_merge_generators.py
+++ b/src/test/unit/helperFunctions/test_merge_generators.py
@@ -1,14 +1,23 @@
-from helperFunctions import merge_generators
-from helperFunctions.merge_generators import sum_up_lists
+import pytest
+
+from helperFunctions.merge_generators import merge_lists, sum_up_lists
 
 
-class TestHelperFunctionsMergeGenerators:  # pylint: disable=no-self-use
+def test_sum_up_lists():
+    list_a = [['a', 1], ['b', 5]]
+    list_b = [['c', 3], ['b', 1]]
+    result = sum_up_lists(list_a, list_b)
+    assert len(result) == 3, 'number of entries not correct'
+    assert ['a', 1] in result
+    assert ['b', 6] in result
+    assert ['c', 3] in result
 
-    def test_sum_up_lists(self):
-        list_a = [['a', 1], ['b', 5]]
-        list_b = [['c', 3], ['b', 1]]
-        result = sum_up_lists(list_a, list_b)
-        assert len(result) == 3, 'number of entries not correct'
-        assert ['a', 1] in result
-        assert ['b', 6] in result
-        assert ['c', 3] in result
+
+@pytest.mark.parametrize('input_, expected_output', [
+    ([[]], []),
+    ([[], [], []], []),
+    ([[1, 2, 3]], [1, 2, 3]),
+    ([[1, 2, 3], [3, 4], [5]], [1, 2, 3, 4, 5]),
+])
+def test_merge_lists(input_, expected_output):
+    assert merge_lists(*input_) == expected_output


### PR DESCRIPTION
`parents` field was missing from `FileObject` update method.
This results in the `parents` being overwritten each time the object is updated.
This PR fixes this problem by merging the old parents and new parents instead (similar to the "parent firmware UIDs").
Added a test to make sure this works as intended.