### PR TITLE
Dependency graph: use virtual paths

### DIFF
--- a/src/storage/db_interface_frontend.py
+++ b/src/storage/db_interface_frontend.py
@@ -328,10 +328,10 @@ class FrontEndDbInterface(MongoInterfaceCommon):
         ], allowDiskUse=True)
         return {entry['_id']: entry['UIDs'] for entry in query_result}
 
-    def get_data_for_dependency_graph(self, uid):
+    def get_data_for_dependency_graph(self, uid, root_uid):
         data = list(self.file_objects.find(
-            {'parents': uid},
-            {'_id': 1, 'processed_analysis.elf_analysis': 1, 'processed_analysis.file_type': 1, 'file_name': 1})
+            {'parents': uid, 'parent_firmware_uids': root_uid},
+            {'_id': 1, 'virtual_file_path': 1, 'processed_analysis.elf_analysis': 1, 'processed_analysis.file_type': 1, 'file_name': 1})
         )
         for entry in data:
             self.retrieve_analysis(entry['processed_analysis'])

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -76,6 +76,53 @@ TEST_FW = create_test_firmware(device_class='test class', device_name='test devi
 TEST_FW_2 = create_test_firmware(device_class='test_class', device_name='test_firmware_2', vendor='test vendor', bin_path='container/test.7z')
 TEST_TEXT_FILE = create_test_file_object()
 TEST_TEXT_FILE2 = create_test_file_object(bin_path='get_files_test/testfile2')
+TEST_GRAPH_DATA_ONE = {
+    'processed_analysis': {
+        'file_type': {
+            'mime': 'application/x-executable', 'full': 'test text'
+        }
+    },
+    'virtual_file_path': {
+        TEST_FW.uid: [
+            "|testgraph|/lib/file_one.so"                        
+        ]
+    },
+    '_id': '1234567',
+    'file_name': 'file_one.so'
+}
+TEST_GRAPH_DATA_TWO = {
+    'processed_analysis': {
+        'file_type': {
+            'mime': 'application/x-executable', 'full': 'test text'
+        },
+        'elf_analysis': {
+            'Output': {
+                'libraries': ['file_one.so']
+            }
+        }
+    },
+    'virtual_file_path': {
+        TEST_FW.uid: [
+            "|testgraph|/bin/file_two"                        
+        ]
+    },
+    '_id': '7654321',
+    'file_name': 'file_two'
+}
+TEST_GRAPH_DATA_THREE = {
+    'processed_analysis': {
+        'file_type': {
+            'mime': 'inode/symlink', 'full': 'symbolic link to \'file two\''
+        },
+    },
+    'virtual_file_path': {
+        TEST_FW.uid: [
+            "|testgraph|/sbin/file_three"
+        ]
+    },
+    '_id': '0987654',
+    'file_name': 'file_three'
+}
 NICE_LIST_DATA = {
     'uid': TEST_FW.uid,
     'files_included': TEST_FW.files_included,
@@ -395,32 +442,9 @@ class DatabaseMock:  # pylint: disable=too-many-public-methods
     def find_orphaned_objects(self):
         return {'root_fw_uid': ['missing_child_uid']}
 
-    def get_data_for_dependency_graph(self, uid):
+    def get_data_for_dependency_graph(self, uid, root_uid):
         if uid == 'testgraph':
-            file_object_one = {
-                'processed_analysis': {
-                    'file_type': {
-                        'mime': 'application/x-executable', 'full': 'test text'
-                    }
-                },
-                '_id': '1234567',
-                'file_name': 'file one'
-            }
-            file_object_two = {
-                'processed_analysis': {
-                    'file_type': {
-                        'mime': 'application/x-executable', 'full': 'test text'
-                    },
-                    'elf_analysis': {
-                        'Output': {
-                            'libraries': ['file one']
-                        }
-                    }
-                },
-                '_id': '7654321',
-                'file_name': 'file two'
-            }
-            return [file_object_one, file_object_two]
+            return [TEST_GRAPH_DATA_ONE, TEST_GRAPH_DATA_TWO]
         return []
 
 

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -84,7 +84,7 @@ TEST_GRAPH_DATA_ONE = {
     },
     'virtual_file_path': {
         TEST_FW.uid: [
-            "|testgraph|/lib/file_one.so"                        
+            '|testgraph|/lib/file_one.so'
         ]
     },
     '_id': '1234567',
@@ -103,7 +103,7 @@ TEST_GRAPH_DATA_TWO = {
     },
     'virtual_file_path': {
         TEST_FW.uid: [
-            "|testgraph|/bin/file_two"                        
+            '|testgraph|/bin/file_two'
         ]
     },
     '_id': '7654321',
@@ -112,12 +112,12 @@ TEST_GRAPH_DATA_TWO = {
 TEST_GRAPH_DATA_THREE = {
     'processed_analysis': {
         'file_type': {
-            'mime': 'inode/symlink', 'full': 'symbolic link to \'file two\''
+            'mime': 'inode/symlink', 'full': 'symbolic link to \'../bin/file_two\''
         },
     },
     'virtual_file_path': {
         TEST_FW.uid: [
-            "|testgraph|/sbin/file_three"
+            '|testgraph|/sbin/file_three'
         ]
     },
     '_id': '0987654',

--- a/src/test/unit/web_interface/test_app_show_analysis.py
+++ b/src/test/unit/web_interface/test_app_show_analysis.py
@@ -43,9 +43,9 @@ class TestAppShowAnalysis(WebInterfaceTest):
         assert self.mocked_interface.tasks[0].scheduled_analysis == ['plugin_a', 'plugin_b']
 
     def test_app_dependency_graph(self):
-        result = self.test_client.get('/dependency-graph/{}'.format('testgraph'))
+        result = self.test_client.get(f'/dependency-graph/testgraph/{TEST_FW.uid}')
         assert b'<strong>UID:</strong> testgraph' in result.data
         assert b'Error: Graph could not be rendered. The file chosen as root must contain a filesystem with binaries.' not in result.data
         assert b'Warning: Elf analysis plugin result is missing for 1 files' in result.data
-        result_error = self.test_client.get('/dependency-graph/{}'.format('1234567'))
+        result_error = self.test_client.get('/dependency-graph/123456/567879')
         assert b'Error: Graph could not be rendered. The file chosen as root must contain a filesystem with binaries.' in result_error.data

--- a/src/test/unit/web_interface/test_app_show_analysis.py
+++ b/src/test/unit/web_interface/test_app_show_analysis.py
@@ -6,7 +6,7 @@ from test.unit.web_interface.base import WebInterfaceTest  # pylint: disable=wro
 class TestAppShowAnalysis(WebInterfaceTest):
 
     def test_app_show_analysis_get_valid_fw(self):
-        result = self.test_client.get('/analysis/{}'.format(TEST_FW.uid)).data
+        result = self.test_client.get(f'/analysis/{TEST_FW.uid}').data
         assert b'<strong>UID:</strong> ' + make_bytes(TEST_FW.uid) in result
         assert b'data-toggle="tooltip" title="mandatory plugin description"' in result
         assert b'data-toggle="tooltip" title="optional plugin description"' in result
@@ -15,12 +15,12 @@ class TestAppShowAnalysis(WebInterfaceTest):
         assert b'1970-01-01' not in result
         assert b'unknown' in result
 
-        result = self.test_client.get('/analysis/{}'.format(TEST_FW_2.uid)).data
+        result = self.test_client.get(f'/analysis/{TEST_FW_2.uid}').data
         assert b'unknown' not in result
         assert b'2000-01-01' in result
 
     def test_app_show_analysis_file_with_preview(self):
-        result = self.test_client.get('/analysis/{}'.format(TEST_TEXT_FILE.uid)).data
+        result = self.test_client.get(f'/analysis/{TEST_TEXT_FILE.uid}').data
         assert b'<strong>UID:</strong> ' + make_bytes(TEST_TEXT_FILE.uid) in result
         assert b'Preview' in result
         assert b'test file:\ncontent:'
@@ -30,13 +30,13 @@ class TestAppShowAnalysis(WebInterfaceTest):
         assert b'Error!' in result
 
     def test_app_single_file_analysis(self):
-        result = self.test_client.get('/analysis/{}'.format(TEST_FW.uid))
+        result = self.test_client.get(f'/analysis/{TEST_FW.uid}')
 
         assert b'Add new analysis' in result.data
         assert b'Update analysis' in result.data
 
         assert not self.mocked_interface.tasks
-        post_new = self.test_client.post('/analysis/{}'.format(TEST_FW.uid), content_type='multipart/form-data', data={'analysis_systems': ['plugin_a', 'plugin_b']})
+        post_new = self.test_client.post(f'/analysis/{TEST_FW.uid}', content_type='multipart/form-data', data={'analysis_systems': ['plugin_a', 'plugin_b']})
 
         assert post_new.status_code == 302
         assert self.mocked_interface.tasks

--- a/src/test/unit/web_interface/test_dependency_graph.py
+++ b/src/test/unit/web_interface/test_dependency_graph.py
@@ -1,61 +1,30 @@
 import pytest
 
+from test.common_helper import TEST_FW, TEST_GRAPH_DATA_ONE, TEST_GRAPH_DATA_TWO, TEST_GRAPH_DATA_THREE
 from web_interface.components.dependency_graph import create_data_graph_edges, create_data_graph_nodes_and_groups
 
-FILE_ONE = {
-    'processed_analysis': {
-        'file_type': {
-            'mime': 'application/x-executable', 'full': 'test text'
-        }
-    },
-    '_id': '1234567',
-    'file_name': 'file one'
-}
-FILE_TWO = {
-    'processed_analysis': {
-        'file_type': {
-            'mime': 'application/x-executable', 'full': 'test text'
-        },
-        'elf_analysis': {
-            'Output': {
-                'libraries': ['file one']
-            }
-        }
-    },
-    '_id': '7654321',
-    'file_name': 'file two'
-}
-FILE_THREE = {
-    'processed_analysis': {
-        'file_type': {
-            'mime': 'inode/symlink', 'full': 'symbolic link to \'file two\''
-        },
-    },
-    '_id': '0987654',
-    'file_name': 'file three'
-}
 
 GRAPH_PART = {'nodes':
-              [{'label': 'file one', 'id': '1234567', 'group': 'application/x-executable',
+              [{'label': '/lib/file_one.so', 'entity': '1234567', 'id': '|testgraph|/lib/file_one.so', 'group': 'application/x-executable',
                 'full_file_type': 'test text'},
-               {'label': 'file two', 'id': '7654321', 'group': 'application/x-executable',
+               {'label': '/bin/file_two', 'entity': '7654321', 'id': '|testgraph|/bin/file_two', 'group': 'application/x-executable',
                 'full_file_type': 'test text'}],
               'edges': [],
               'groups': ['application/x-executable']}
 GRAPH_RES = {'nodes':
-             [{'label': 'file one', 'id': '1234567', 'group': 'application/x-executable',
+             [{'label': '/lib/file_one.so', 'entity': '1234567', 'id': '|testgraph|/lib/file_one.so', 'group': 'application/x-executable',
                'full_file_type': 'test text'},
-              {'label': 'file two', 'id': '7654321', 'group': 'application/x-executable',
+              {'label': '/bin/file_two', 'entity': '7654321', 'id': '|testgraph|/bin/file_two', 'group': 'application/x-executable',
                'full_file_type': 'test text'}],
-             'edges': [{'from': '7654321', 'to': '1234567', 'id': 0}],
+             'edges': [{'from': '|testgraph|/bin/file_two', 'to': '|testgraph|/lib/file_one.so', 'id': 0}],
              'groups': ['application/x-executable']}
 
 GRAPH_PART_SYMLINK = {'nodes':
-                      [{'label': 'file one', 'id': '1234567', 'group': 'application/x-executable',
+                      [{'label': '/lib/file_one.so', 'entity': '1234567', 'id': '|testgraph|/lib/file_one.so', 'group': 'application/x-executable',
                         'full_file_type': 'test text'},
-                       {'label': 'file two', 'id': '7654321', 'group': 'application/x-executable',
+                       {'label': '/bin/file_two', 'entity': '7654321', 'id': '|testgraph|/bin/file_two', 'group': 'application/x-executable',
                         'full_file_type': 'test text'},
-                       {'label': 'file three', 'id': '0987654', 'group': 'inode/symlink',
+                       {'label': '/sbin/file_three', 'entity': '0987654', 'id': '|testgraph|/sbin/file_three','group': 'inode/symlink',
                         'full_file_type': 'symbolic link to \'file two\''}],
                       'edges': [],
                       'groups': ['application/x-executable', 'inode/symlink']}
@@ -74,17 +43,17 @@ GRAPH_RES_SYMLINK = {'nodes':
 WHITELIST = ['application/x-executable', 'application/x-sharedlib', 'inode/symlink']
 
 
-@pytest.mark.parametrize('list_of_objects, whitelist, expected_result', [
-    ([FILE_ONE, FILE_TWO], WHITELIST, GRAPH_PART),
-    ([FILE_ONE, FILE_TWO, FILE_THREE], WHITELIST, GRAPH_PART_SYMLINK),
+@pytest.mark.parametrize('list_of_objects, parent_uid, root_uid, whitelist, expected_result', [
+    ([TEST_GRAPH_DATA_ONE, TEST_GRAPH_DATA_TWO], 'testgraph', TEST_FW.uid, WHITELIST, GRAPH_PART),
+    ([TEST_GRAPH_DATA_ONE, TEST_GRAPH_DATA_TWO, TEST_GRAPH_DATA_THREE], 'testgraph', TEST_FW.uid, WHITELIST, GRAPH_PART_SYMLINK),
 ])
-def test_create_graph_nodes_and_groups(list_of_objects, whitelist, expected_result):
-    assert create_data_graph_nodes_and_groups(list_of_objects, whitelist) == expected_result
+def test_create_graph_nodes_and_groups(list_of_objects, parent_uid, root_uid, whitelist, expected_result):
+    assert create_data_graph_nodes_and_groups(list_of_objects, parent_uid, root_uid, whitelist) == expected_result
 
 
 @pytest.mark.parametrize('list_of_objects, graph_part, expected_graph, expected_missing_analysis', [
-    ([FILE_ONE, FILE_TWO], GRAPH_PART, GRAPH_RES, 1),
-    ([FILE_ONE, FILE_TWO, FILE_THREE], GRAPH_PART_SYMLINK, GRAPH_RES_SYMLINK, 2),
+    ([TEST_GRAPH_DATA_ONE, TEST_GRAPH_DATA_TWO], GRAPH_PART, GRAPH_RES, 1),
+    #([TEST_GRAPH_DATA_ONE, TEST_GRAPH_DATA_TWO, TEST_GRAPH_DATA_THREE], GRAPH_PART_SYMLINK, GRAPH_RES_SYMLINK, 2),
 ])
 def test_create_graph_edges(list_of_objects, graph_part, expected_graph, expected_missing_analysis):
     assert create_data_graph_edges(list_of_objects, graph_part) == (expected_graph, expected_missing_analysis)

--- a/src/test/unit/web_interface/test_dependency_graph.py
+++ b/src/test/unit/web_interface/test_dependency_graph.py
@@ -1,43 +1,44 @@
 import pytest
 
-from test.common_helper import TEST_FW, TEST_GRAPH_DATA_ONE, TEST_GRAPH_DATA_TWO, TEST_GRAPH_DATA_THREE
+from test.common_helper import (  # pylint: disable=wrong-import-order
+    TEST_FW, TEST_GRAPH_DATA_ONE, TEST_GRAPH_DATA_THREE, TEST_GRAPH_DATA_TWO
+)
 from web_interface.components.dependency_graph import create_data_graph_edges, create_data_graph_nodes_and_groups
 
-
 GRAPH_PART = {'nodes':
-              [{'label': '/lib/file_one.so', 'entity': '1234567', 'id': '|testgraph|/lib/file_one.so', 'group': 'application/x-executable',
-                'full_file_type': 'test text'},
-               {'label': '/bin/file_two', 'entity': '7654321', 'id': '|testgraph|/bin/file_two', 'group': 'application/x-executable',
-                'full_file_type': 'test text'}],
+              [{'label': '/lib/file_one.so', 'elf_analysis_missing': True, 'entity': '1234567', 'id': '|testgraph|/lib/file_one.so', 'group': 'application/x-executable',
+                'full_file_type': 'test text', 'linked_libraries': []},
+               {'label': '/bin/file_two', 'elf_analysis_missing': False, 'entity': '7654321', 'id': '|testgraph|/bin/file_two', 'group': 'application/x-executable',
+                'full_file_type': 'test text', 'linked_libraries': ['file_one.so']}],
               'edges': [],
               'groups': ['application/x-executable']}
 GRAPH_RES = {'nodes':
-             [{'label': '/lib/file_one.so', 'entity': '1234567', 'id': '|testgraph|/lib/file_one.so', 'group': 'application/x-executable',
-               'full_file_type': 'test text'},
-              {'label': '/bin/file_two', 'entity': '7654321', 'id': '|testgraph|/bin/file_two', 'group': 'application/x-executable',
-               'full_file_type': 'test text'}],
+             [{'label': '/lib/file_one.so', 'elf_analysis_missing': True, 'entity': '1234567', 'id': '|testgraph|/lib/file_one.so', 'group': 'application/x-executable',
+               'full_file_type': 'test text', 'linked_libraries': []},
+              {'label': '/bin/file_two', 'elf_analysis_missing': False, 'entity': '7654321', 'id': '|testgraph|/bin/file_two', 'group': 'application/x-executable',
+               'full_file_type': 'test text', 'linked_libraries': ['file_one.so']}],
              'edges': [{'from': '|testgraph|/bin/file_two', 'to': '|testgraph|/lib/file_one.so', 'id': 0}],
              'groups': ['application/x-executable']}
 
 GRAPH_PART_SYMLINK = {'nodes':
-                      [{'label': '/lib/file_one.so', 'entity': '1234567', 'id': '|testgraph|/lib/file_one.so', 'group': 'application/x-executable',
-                        'full_file_type': 'test text'},
-                       {'label': '/bin/file_two', 'entity': '7654321', 'id': '|testgraph|/bin/file_two', 'group': 'application/x-executable',
-                        'full_file_type': 'test text'},
-                       {'label': '/sbin/file_three', 'entity': '0987654', 'id': '|testgraph|/sbin/file_three','group': 'inode/symlink',
-                        'full_file_type': 'symbolic link to \'file two\''}],
+                      [{'label': '/lib/file_one.so', 'elf_analysis_missing': True, 'entity': '1234567', 'id': '|testgraph|/lib/file_one.so', 'group': 'application/x-executable',
+                        'full_file_type': 'test text', 'linked_libraries': []},
+                       {'label': '/bin/file_two', 'elf_analysis_missing': False, 'entity': '7654321', 'id': '|testgraph|/bin/file_two', 'group': 'application/x-executable',
+                        'full_file_type': 'test text', 'linked_libraries': ['file_one.so']},
+                       {'label': '/sbin/file_three', 'elf_analysis_missing': True, 'entity': '0987654', 'id': '|testgraph|/sbin/file_three', 'group': 'inode/symlink',
+                        'full_file_type': 'symbolic link to \'../bin/file_two\'', 'linked_libraries': []}],
                       'edges': [],
                       'groups': ['application/x-executable', 'inode/symlink']}
 
 GRAPH_RES_SYMLINK = {'nodes':
-                     [{'label': 'file one', 'id': '1234567', 'group': 'application/x-executable',
-                       'full_file_type': 'test text'},
-                      {'label': 'file two', 'id': '7654321', 'group': 'application/x-executable',
-                       'full_file_type': 'test text'},
-                      {'label': 'file three', 'id': '0987654', 'group': 'inode/symlink',
-                       'full_file_type': 'symbolic link to \'file two\''}],
-                     'edges': [{'from': '0987654', 'to': '7654321', 'id': 0},
-                               {'from': '7654321', 'to': '1234567', 'id': 1}],
+                     [{'label': '/lib/file_one.so', 'elf_analysis_missing': True, 'entity': '1234567', 'id': '|testgraph|/lib/file_one.so', 'group': 'application/x-executable',
+                       'full_file_type': 'test text', 'linked_libraries': []},
+                      {'label': '/bin/file_two', 'elf_analysis_missing': False, 'entity': '7654321', 'id': '|testgraph|/bin/file_two', 'group': 'application/x-executable',
+                       'full_file_type': 'test text', 'linked_libraries': ['file_one.so']},
+                      {'label': '/sbin/file_three', 'elf_analysis_missing': True, 'entity': '0987654', 'id': '|testgraph|/sbin/file_three', 'group': 'inode/symlink',
+                       'full_file_type': 'symbolic link to \'../bin/file_two\'', 'linked_libraries': []}],
+                     'edges': [{'from': '|testgraph|/sbin/file_three', 'to': '|testgraph|/bin/file_two', 'id': 0},
+                               {'from': '|testgraph|/bin/file_two', 'to': '|testgraph|/lib/file_one.so', 'id': 1}],
                      'groups': ['application/x-executable', 'inode/symlink']}
 
 WHITELIST = ['application/x-executable', 'application/x-sharedlib', 'inode/symlink']
@@ -51,9 +52,9 @@ def test_create_graph_nodes_and_groups(list_of_objects, parent_uid, root_uid, wh
     assert create_data_graph_nodes_and_groups(list_of_objects, parent_uid, root_uid, whitelist) == expected_result
 
 
-@pytest.mark.parametrize('list_of_objects, graph_part, expected_graph, expected_missing_analysis', [
-    ([TEST_GRAPH_DATA_ONE, TEST_GRAPH_DATA_TWO], GRAPH_PART, GRAPH_RES, 1),
-    #([TEST_GRAPH_DATA_ONE, TEST_GRAPH_DATA_TWO, TEST_GRAPH_DATA_THREE], GRAPH_PART_SYMLINK, GRAPH_RES_SYMLINK, 2),
+@pytest.mark.parametrize('graph_part, expected_graph, expected_missing_analysis', [
+    (GRAPH_PART, GRAPH_RES, 1),
+    (GRAPH_PART_SYMLINK, GRAPH_RES_SYMLINK, 2),
 ])
-def test_create_graph_edges(list_of_objects, graph_part, expected_graph, expected_missing_analysis):
-    assert create_data_graph_edges(list_of_objects, graph_part) == (expected_graph, expected_missing_analysis)
+def test_create_graph_edges(graph_part, expected_graph, expected_missing_analysis):  # pylint: disable=too-many-function-args
+    assert create_data_graph_edges(graph_part) == (expected_graph, expected_missing_analysis)

--- a/src/web_interface/components/analysis_routes.py
+++ b/src/web_interface/components/analysis_routes.py
@@ -191,21 +191,21 @@ class AnalysisRoutes(ComponentBase):
         return self.get_update_analysis(uid, re_do=True)
 
     @roles_accepted(*PRIVILEGES['view_analysis'])
-    @AppRoute('/dependency-graph/<uid>', GET)
-    def show_elf_dependency_graph(self, uid):
+    @AppRoute('/dependency-graph/<uid>/<root_uid>', GET)
+    def show_elf_dependency_graph(self, uid, root_uid):
         with ConnectTo(FrontEndDbInterface, self._config) as db:
-            data = db.get_data_for_dependency_graph(uid)
+            data = db.get_data_for_dependency_graph(uid, root_uid)
 
             whitelist = ['application/x-executable', 'application/x-pie-executable', 'application/x-sharedlib', 'inode/symlink']
 
-            data_graph_part = create_data_graph_nodes_and_groups(data, whitelist)
+            data_graph_part = create_data_graph_nodes_and_groups(data, uid, root_uid, whitelist)
 
             colors = sorted(get_graph_colors(len(data_graph_part['groups'])))
 
             if not data_graph_part['nodes']:
                 flash('Error: Graph could not be rendered. '
                       'The file chosen as root must contain a filesystem with binaries.', 'danger')
-                return render_template('dependency_graph.html', **data_graph_part, uid=uid)
+                return render_template('dependency_graph.html', **data_graph_part, uid=uid, root_uid=root_uid)
 
             data_graph, elf_analysis_missing_from_files = create_data_graph_edges(data, data_graph_part)
 
@@ -213,4 +213,4 @@ class AnalysisRoutes(ComponentBase):
                 flash(f'Warning: Elf analysis plugin result is missing for {elf_analysis_missing_from_files} files', 'warning')
 
             # TODO: Add a loading icon?
-        return render_template('dependency_graph.html', **data_graph, uid=uid, colors=colors)
+        return render_template('dependency_graph.html', **data_graph, uid=uid, root_uid=root_uid, colors=colors)

--- a/src/web_interface/components/analysis_routes.py
+++ b/src/web_interface/components/analysis_routes.py
@@ -207,10 +207,16 @@ class AnalysisRoutes(ComponentBase):
                       'The file chosen as root must contain a filesystem with binaries.', 'danger')
                 return render_template('dependency_graph.html', **data_graph_part, uid=uid, root_uid=root_uid)
 
-            data_graph, elf_analysis_missing_from_files = create_data_graph_edges(data, data_graph_part)
+            data_graph, elf_analysis_missing_from_files = create_data_graph_edges(data_graph_part)
 
             if elf_analysis_missing_from_files > 0:
                 flash(f'Warning: Elf analysis plugin result is missing for {elf_analysis_missing_from_files} files', 'warning')
 
             # TODO: Add a loading icon?
-        return render_template('dependency_graph.html', **data_graph, uid=uid, root_uid=root_uid, colors=colors)
+        return render_template(
+            'dependency_graph.html',
+            **{key: json.dumps(data_graph[key]) for key in ['nodes', 'edges', 'groups']},
+            uid=uid,
+            root_uid=root_uid,
+            colors=colors
+        )

--- a/src/web_interface/components/dependency_graph.py
+++ b/src/web_interface/components/dependency_graph.py
@@ -39,7 +39,7 @@ def create_data_graph_nodes_and_groups(data, parent_uid, root_uid, whitelist):
                 continue
 
             linked_libraries = []
-            elf_analysis_missing = 'elf_analysis' not in file['processed_analysis'] 
+            elf_analysis_missing = 'elf_analysis' not in file['processed_analysis']
             with suppress(KeyError):
                 linked_libraries = file['processed_analysis']['elf_analysis']['Output']['libraries']
 
@@ -69,7 +69,7 @@ def create_data_graph_edges(data_graph):
         if node['elf_analysis_missing']:
             elf_analysis_missing_from_files += 1
             continue
-        
+
         linked_libraries = node['linked_libraries']
 
         for linked_lib_name in linked_libraries:

--- a/src/web_interface/components/dependency_graph.py
+++ b/src/web_interface/components/dependency_graph.py
@@ -98,7 +98,6 @@ def create_symbolic_link_edges(data_graph):
 
 
 def find_edges(node, linked_lib_name, data_graph, edge_id):
-    # TODO: FIX: THIS DOES NOT WORK BECAUSE WE ARE AGAIN WORKING WITH LABELS AND FILE OBJECTS
     for lib in data_graph['nodes']:
         if linked_lib_name != Path(lib['label']).name:
             continue

--- a/src/web_interface/components/dependency_graph.py
+++ b/src/web_interface/components/dependency_graph.py
@@ -62,7 +62,7 @@ def create_data_graph_nodes_and_groups(data, parent_uid, root_uid, whitelist):
 
 def create_data_graph_edges(data_graph):
 
-    edge_id = create_symbolic_link_edges(data_graph)
+    create_symbolic_link_edges(data_graph)
     elf_analysis_missing_from_files = 0
 
     for node in data_graph['nodes']:
@@ -73,14 +73,12 @@ def create_data_graph_edges(data_graph):
         linked_libraries = node['linked_libraries']
 
         for linked_lib_name in linked_libraries:
-            edge_id = find_edges(node, linked_lib_name, data_graph, edge_id)
+            find_edges(node, linked_lib_name, data_graph)
 
     return data_graph, elf_analysis_missing_from_files
 
 
 def create_symbolic_link_edges(data_graph):
-    edge_id = 0
-
     for node in data_graph['nodes']:
         if node['group'] == 'inode/symlink':
             link_to = Path(node['full_file_type'].split('\'')[1])
@@ -91,22 +89,17 @@ def create_symbolic_link_edges(data_graph):
 
             for match in data_graph['nodes']:
                 if match['label'] == str(link_to):
-                    edge = {'from': node['id'], 'to': match['id'], 'id': edge_id}
+                    edge = {'from': node['id'], 'to': match['id'], 'id': len(data_graph['edges'])}
                     data_graph['edges'].append(edge)
-                    edge_id += 1
-    return edge_id
 
 
-def find_edges(node, linked_lib_name, data_graph, edge_id):
+def find_edges(node, linked_lib_name, data_graph):
     for lib in data_graph['nodes']:
         if linked_lib_name != Path(lib['label']).name:
             continue
-        edge = {'from': node['id'], 'to': lib['id'], 'id': edge_id}
+        edge = {'from': node['id'], 'to': lib['id'], 'id': len(data_graph['edges'])}
         data_graph['edges'].append(edge)
-        edge_id += 1
         break
-
-    return edge_id
 
 
 def get_graph_colors(quantity):

--- a/src/web_interface/components/dependency_graph.py
+++ b/src/web_interface/components/dependency_graph.py
@@ -21,7 +21,7 @@ def create_data_graph_nodes_and_groups(data, parent_uid, root_uid, whitelist):
 
         if mime not in groups:
             groups.append(file['processed_analysis']['file_type']['mime'])
- 
+
         virtual_paths = file['virtual_file_path'][root_uid]
 
         for vpath in virtual_paths:
@@ -78,12 +78,10 @@ def create_symbolic_link_edges(data_graph):
         if node['group'] == 'inode/symlink':
             link_to = Path(node['full_file_type'].split('\'')[1])
 
-            import logging
             if not link_to.is_absolute():
                 base = Path(node['label']).parent
                 link_to = normpath(base / link_to)
 
-            logging.warn(link_to)
             for match in data_graph['nodes']:
                 if match['label'] == str(link_to):
                     edge = {'from': node['id'], 'to': match['id'], 'id': edge_id}

--- a/src/web_interface/static/js/dependency_graph.js
+++ b/src/web_interface/static/js/dependency_graph.js
@@ -15,7 +15,9 @@ function dependencyGraph(nodes, edges, groups, colors) {
     };
 
     // map group names to colors --> {'mime/type': {color: '#...'}}
+    // jshint ignore:start
     groupOptions = groups.reduce((obj, curr, i) => {return {...obj, [curr]: {color: colors[i]}}}, {});
+    // jshint ignore:end
 
     // set the graph options. Most of this is physics model initialization
     graphOptions = {

--- a/src/web_interface/static/js/dependency_graph.js
+++ b/src/web_interface/static/js/dependency_graph.js
@@ -108,7 +108,7 @@ function drawNodesList() {
     $('#nodeFilter')[0].value = '';
     nodesList.empty();
 
-    for (nodeId in allNodes) {
+    for (let nodeId in allNodes) {
         let node = dataset.nodes.get(nodeId);
         let color = groupOptions[node.group].color;
         if (node.label !== undefined) {
@@ -177,7 +177,7 @@ function nodeListSelectionHandler(ev) {
         // ... and invoke the selection handler by hand, because vis.js does
         // not fire a click event in this case.
         let params = {nodes: network.getSelectedNodes()};
-        neighbourhoodHighlight(params)
+        neighbourhoodHighlight(params);
     }
 }
 
@@ -193,7 +193,7 @@ function neighbourhoodHighlight(params) {
         network.focus(selectedNode, {scale: 0.4, animation: {easingFunction: 'easeInOutQuad'}});
  
         // mark all nodes as hard to read.
-        for (var nodeId in allNodes) {
+        for (let nodeId in allNodes) {
             allNodes[nodeId].color = "rgba(200,200,200,0.5)";
             if (allNodes[nodeId].hiddenLabel === undefined) {
                 allNodes[nodeId].hiddenLabel = allNodes[nodeId].label;
@@ -241,7 +241,7 @@ function neighbourhoodHighlight(params) {
         }
     } else if (highlightActive === true) {
         // reset all nodes
-        for (var nodeId in allNodes) {https://github.com/almende/vis/issues/2906
+        for (let nodeId in allNodes) {
             allNodes[nodeId].color = undefined;
             if (allNodes[nodeId].hiddenLabel !== undefined) {
                 allNodes[nodeId].label = allNodes[nodeId].hiddenLabel;
@@ -252,7 +252,7 @@ function neighbourhoodHighlight(params) {
     }
     // transform the object into an array
     var updateArray = [];
-    for (nodeId in allNodes) {
+    for (let nodeId in allNodes) {
         if (allNodes.hasOwnProperty(nodeId)) {
             updateArray.push(allNodes[nodeId]);
         }

--- a/src/web_interface/static/js/dependency_graph.js
+++ b/src/web_interface/static/js/dependency_graph.js
@@ -136,7 +136,7 @@ function drawDetails() {
     let color = groupOptions[node.group].color;
     details.append(`
         <div>
-            <a target="_blank" href="/analysis/${node.entity}">Analysis Results</a>
+            <span class="font-weight-bold">Analysis:&nbsp;</span><a target="_blank" href="/analysis/${node.entity}">&#x1F517;</a>
         </div>
         <div>
             <span class="font-weight-bold">Node:&nbsp;</span><span style="color: ${color};">&#9679;</span>&nbsp;${node.label}

--- a/src/web_interface/static/js/dependency_graph.js
+++ b/src/web_interface/static/js/dependency_graph.js
@@ -134,7 +134,7 @@ function drawDetails() {
     let color = groupOptions[node.group].color;
     details.append(`
         <div>
-            <a target="_blank" href="/analysis/${node.id}">Analysis Results</a>
+            <a target="_blank" href="/analysis/${node.entity}">Analysis Results</a>
         </div>
         <div>
             <span class="font-weight-bold">Node:&nbsp;</span><span style="color: ${color};">&#9679;</span>&nbsp;${node.label}

--- a/src/web_interface/templates/dependency_graph.html
+++ b/src/web_interface/templates/dependency_graph.html
@@ -29,11 +29,11 @@
 
 {% block body %}
     <div class="header mb-4" style="word-wrap: break-word">
-        <h3>
-            Dependency Graph for File {{ uid | replace_uid_with_hid }}
+        <h4>
+            Dependency Graph for {{ uid | replace_uid_with_hid }} in {{ root_uid | replace_uid_with_hid }}
             <br>
             <span style="font-size: 15px"><strong>UID:</strong> {{ uid }}</span>
-        </h3>
+        </h4>
     </div>
     <div class="row lb-3">
         <div class="col-lg-8 col-xl-10">

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -64,7 +64,7 @@
                 {% if not firmware.files_included %}
                     {{ button_tooltip('Show dependency graph', 'graph-button', '/dependency-graph/', 'project-diagram', danger=False, disabled=True) }}
                 {% else %}
-                    {{ button_tooltip('Show dependency graph', 'graph-button', '/dependency_graph/', 'project-diagram', 'window.location.href = \'/dependency-graph/' + '/' + firmware.uid + '/' + root_uid + '\'') }}
+                    {{ button_tooltip('Show dependency graph', 'graph-button', '/dependency-graph/', 'project-diagram', 'window.location.href = \'/dependency-graph/' + firmware.uid + '/' + root_uid + '\'') }}
                 {% endif %}
                 {% if firmware.vendor %}
                     {{ button_tooltip('Update analysis', 'update-button', '/update-analysis/', 'redo-alt') }}

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -64,7 +64,7 @@
                 {% if not firmware.files_included %}
                     {{ button_tooltip('Show dependency graph', 'graph-button', '/dependency-graph/', 'project-diagram', danger=False, disabled=True) }}
                 {% else %}
-                    {{ button_tooltip('Show dependency graph', 'graph-button', '/dependency-graph/', 'project-diagram') }}
+                    {{ button_tooltip('Show dependency graph', 'graph-button', '/dependency_graph/', 'project-diagram', 'window.location.href = \'/dependency-graph/' + '/' + firmware.uid + '/' + root_uid + '\'') }}
                 {% endif %}
                 {% if firmware.vendor %}
                     {{ button_tooltip('Update analysis', 'update-button', '/update-analysis/', 'redo-alt') }}


### PR DESCRIPTION
_This PR is supplementary to PR #726 and a follow-up of PR #725 ._

It fixes the dependency graph to properly display symlinks. Multiple links on a single file (i.e., in busybox-centric environments) produce the same object hash. Thus, FACT aggregates them in a single file object for deduplication and adds a virtual file path reference in the dataset.

As the previously reworked dependency graph created nodes based on file objects instead of virtual file paths, it did not incorporate all nodes existing in the path structure.

This PR fixes this issue.