### PR TITLE
kernel config hardening check version incompatibility bugfix

### DIFF
--- a/src/plugins/analysis/kernel_config/requirements.txt
+++ b/src/plugins/analysis/kernel_config/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/a13xp0p0v/kconfig-hardened-check
+git+https://github.com/a13xp0p0v/kconfig-hardened-check@v0.5.14 


### PR DESCRIPTION
Pinned `kconfig-hardened-check` version to v0.5.14