### PR TITLE
fixed error in show_analysis caused by missing root_uid

### DIFF
--- a/src/web_interface/components/analysis_routes.py
+++ b/src/web_interface/components/analysis_routes.py
@@ -194,6 +194,9 @@ class AnalysisRoutes(ComponentBase):
     @AppRoute('/dependency-graph/<uid>/<root_uid>', GET)
     def show_elf_dependency_graph(self, uid, root_uid):
         with ConnectTo(FrontEndDbInterface, self._config) as db:
+            if root_uid in [None, 'None']:
+                fo = db.get_object(uid)
+                root_uid = list(fo.parent_firmware_uids)[0]
             data = db.get_data_for_dependency_graph(uid, root_uid)
 
             whitelist = ['application/x-executable', 'application/x-pie-executable', 'application/x-sharedlib', 'inode/symlink']

--- a/src/web_interface/components/analysis_routes.py
+++ b/src/web_interface/components/analysis_routes.py
@@ -195,8 +195,7 @@ class AnalysisRoutes(ComponentBase):
     def show_elf_dependency_graph(self, uid, root_uid):
         with ConnectTo(FrontEndDbInterface, self._config) as db:
             if root_uid in [None, 'None']:
-                fo = db.get_object(uid)
-                root_uid = list(fo.parent_firmware_uids)[0]
+                root_uid = db.get_object(uid).get_root_uid()
             data = db.get_data_for_dependency_graph(uid, root_uid)
 
             whitelist = ['application/x-executable', 'application/x-pie-executable', 'application/x-sharedlib', 'inode/symlink']

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -64,7 +64,7 @@
                 {% if not firmware.files_included %}
                     {{ button_tooltip('Show dependency graph', 'graph-button', '/dependency-graph/', 'project-diagram', danger=False, disabled=True) }}
                 {% else %}
-                    {{ button_tooltip('Show dependency graph', 'graph-button', '/dependency-graph/', 'project-diagram', 'window.location.href = \'/dependency-graph/' + firmware.uid + '/' + root_uid + '\'') }}
+                    {{ button_tooltip('Show dependency graph', 'graph-button', '/dependency-graph/', 'project-diagram', "window.location.href='/dependency-graph/{}/{}'".format(firmware.uid, root_uid)) }}
                 {% endif %}
                 {% if firmware.vendor %}
                     {{ button_tooltip('Update analysis', 'update-button', '/update-analysis/', 'redo-alt') }}


### PR DESCRIPTION
Fixed bug in on "show analysis" page caused by missing root UID (can happen e.g. when coming from a DB search)

```python
{% block body %}{% endblock %}
File "<template>", line 67, in block 'body'
TypeError: can only concatenate str (not "NoneType") to str
```