### PR TITLE
elf_analysis: use lief's to_json instead of to_json_from_abstract

### DIFF
--- a/src/plugins/analysis/elf_analysis/code/elf_analysis.py
+++ b/src/plugins/analysis/elf_analysis/code/elf_analysis.py
@@ -115,7 +115,7 @@ class AnalysisPlugin(AnalysisBasePlugin):
         elf_dict = {}
         try:
             parsed_binary = lief.parse(file_object.file_path)
-            binary_json_dict = json.loads(lief.to_json_from_abstract(parsed_binary))
+            binary_json_dict = json.loads(lief.to_json(parsed_binary))
             if parsed_binary.exported_functions:
                 binary_json_dict['exported_functions'] = normalize_lief_items(parsed_binary.exported_functions)
             if parsed_binary.imported_functions:

--- a/src/plugins/analysis/elf_analysis/test/test_plugin_elf_analysis.py
+++ b/src/plugins/analysis/elf_analysis/test/test_plugin_elf_analysis.py
@@ -137,7 +137,7 @@ final_analysis_test_data = [
     ({'header': [], 'segments': [1, 2], 'a': []}, {}, 1)
 ]
 
-
+expected
 @pytest.mark.parametrize('binary_json_dict, elf_dict, expected', final_analysis_test_data)
 def test_get_final_analysis_dict(stub_plugin, binary_json_dict, elf_dict, expected):
     stub_plugin.get_final_analysis_dict(binary_json_dict, elf_dict)
@@ -152,7 +152,7 @@ def test_pie(stub_plugin):
 
 def test_plugin(stub_plugin, stub_object, monkeypatch):
     monkeypatch.setattr('lief.parse', lambda _: MOCK_LIEF_RESULT)
-    monkeypatch.setattr('lief.to_json_from_abstract', lambda _: MOCK_DATA)
+    monkeypatch.setattr('lief.to_json', lambda _: MOCK_DATA)
 
     stub_object.processed_analysis['file_type'] = {'mime': 'application/x-executable'}
     stub_plugin.process_object(stub_object)

--- a/src/plugins/analysis/elf_analysis/test/test_plugin_elf_analysis.py
+++ b/src/plugins/analysis/elf_analysis/test/test_plugin_elf_analysis.py
@@ -137,7 +137,7 @@ final_analysis_test_data = [
     ({'header': [], 'segments': [1, 2], 'a': []}, {}, 1)
 ]
 
-expected
+
 @pytest.mark.parametrize('binary_json_dict, elf_dict, expected', final_analysis_test_data)
 def test_get_final_analysis_dict(stub_plugin, binary_json_dict, elf_dict, expected):
     stub_plugin.get_final_analysis_dict(binary_json_dict, elf_dict)


### PR DESCRIPTION
fixes #753 

Do you guys see any reasons why we shouldn't use `to_json` instead of `to_json_from_abstract`? Tests show that it provides the expected outcome.