### PR TITLE
fixed bad requests interface tests

### DIFF
--- a/src/test/unit/web_interface/rest/test_rest_binary_search.py
+++ b/src/test/unit/web_interface/rest/test_rest_binary_search.py
@@ -4,10 +4,8 @@ YARA_TEST_RULE = 'rule rulename {strings: $a = "foobar" condition: $a}'
 
 
 def test_no_data(test_app):
-    result = decode_response(test_app.post('/rest/binary_search'))
-    assert 'Input payload validation failed' in result['message']
-    assert 'errors' in result
-    assert 'is a required property' in result['errors']['rule_file']
+    response = test_app.post('/rest/binary_search')
+    assert response.status_code == 400
 
 
 def test_no_rule_file(test_app):

--- a/src/test/unit/web_interface/rest/test_rest_compare.py
+++ b/src/test/unit/web_interface/rest/test_rest_compare.py
@@ -7,8 +7,8 @@ UID_2 = 'decafbad' * 8 + '_2'
 
 
 def test_bad_request(test_app):
-    result = decode_response(test_app.put('/rest/compare'))
-    assert 'Input payload validation failed' in result['message']
+    response = test_app.put('/rest/compare')
+    assert response.status_code == 400
 
     result = test_app.get('/rest/compare/').data
     assert b'404 Not Found' in result

--- a/src/test/unit/web_interface/rest/test_rest_firmware.py
+++ b/src/test/unit/web_interface/rest/test_rest_firmware.py
@@ -2,6 +2,7 @@ import json
 from base64 import standard_b64encode
 from urllib.parse import quote
 
+import logging
 from test.common_helper import TEST_FW
 from test.unit.web_interface.rest.conftest import decode_response
 
@@ -68,13 +69,13 @@ def test_successful_uid_request(test_app):
 
 
 def test_bad_put_request(test_app):
-    result = decode_response(test_app.put('/rest/firmware'))
-    assert 'Input payload validation failed' in result['message']
+    response = test_app.put('/rest/firmware')
+    assert response.status_code == 400
 
 
-def test_submit_empty_data(test_app):
-    result = decode_response(test_app.put('/rest/firmware', data=json.dumps({})))
-    assert 'Input payload validation failed' in result['message']
+def test_submit_non_json_data(test_app):
+    response = test_app.put('/rest/firmware', data='non-json-string')
+    assert response.status_code == 400
 
 
 def test_submit_missing_item(test_app):


### PR DESCRIPTION
Flask's behavior changed between 2.0.2 and 2.0.3 with regards to requests containing unexpected Content-Types.
This causes FACT's API to answer with

```json
{
    "message": "The browser (or proxy) sent a request that this server could not understand."
}
```

instead of

```json
{
    "message": "Input payload validation failed"
}
```

However, some of our unit tests check only for the latter. This causes tests to fail when `flask>2.0.2` is installed. I suggest to check for `response.status_code == 400` instead of the response's message content. This is more robust across flask versions (and, btw, fixes our CI ;-) 