### PR TITLE
hide loading gif when going back in page history

### DIFF
--- a/src/web_interface/static/js/loading.js
+++ b/src/web_interface/static/js/loading.js
@@ -2,3 +2,8 @@ function showImg() {
     $('#form').hide();
     $('#loading_img').css({'display': 'block'});
 }
+
+function hideImg() {
+    $('#form').show();
+    $('#loading_img').css({'display': 'none'});
+}

--- a/src/web_interface/templates/database/database_search.html
+++ b/src/web_interface/templates/database/database_search.html
@@ -7,6 +7,12 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='web_css/bootstrap-select.min.css') }}" />
     <script type="text/javascript" src="{{ url_for('static', filename='web_js/bootstrap-select.min.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/loading.js') }}"></script>
+    <script>
+        $(window).bind("pageshow", function(event) {
+          // if we come back to the page make sure that the loading gif is not covering up the form
+          hideImg();
+        });
+    </script>
 {% endblock %}
 
 

--- a/src/web_interface/templates/upload/upload.html
+++ b/src/web_interface/templates/upload/upload.html
@@ -13,6 +13,12 @@
     </script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/upload.js') }}"></script>
     <script type="text/javascript" src="{{ url_for('static', filename='js/loading.js') }}"></script>
+    <script>
+        $(window).bind("pageshow", function(event) {
+          // if we come back to the page make sure that the loading gif is not covering up the form
+          hideImg();
+        });
+    </script>
 
 {% endblock %}
 


### PR DESCRIPTION
There was a problem with the loading gif covering the basic search and upload form when going back to the page (e.g. by clicking on the "go back" button in the browser). This should fix this problem.