### PR TITLE
DbInterfaceBackend: Don't crash when updating when FileObject is alre…

### DIFF
--- a/src/storage/db_interface_backend.py
+++ b/src/storage/db_interface_backend.py
@@ -98,6 +98,8 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
     # ===== Update / UPDATE =====
 
     def update_object(self, fw_object: FileObject):
+        # If a file contained in an already analysed Firmware is uploaded it will be of type FileObject not Firmware
+        fw_object.__class__ = Firmware if self.is_firmware(fw_object.uid) else FileObject
         if isinstance(fw_object, Firmware):
             self.update_firmware(fw_object)
         self.update_file_object(fw_object)


### PR DESCRIPTION
Assigning `__class__` is not really nice, but since we the other functions of the db interface are allowed to use `isinstance` this is the only thing that comes to my mind.