### PR TITLE
init_postgres.py: Connect to correct host and port

### DIFF
--- a/src/init_postgres.py
+++ b/src/init_postgres.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import logging
 from configparser import ConfigParser
 from shlex import split


### PR DESCRIPTION
In a distributed setup we would always try to connect to localhost before this change.