### PR TITLE
fixed bug with rubocop linter installation in older systems

### DIFF
--- a/src/plugins/analysis/linter/apt-pkgs-runtime.txt
+++ b/src/plugins/analysis/linter/apt-pkgs-runtime.txt
@@ -2,4 +2,3 @@ liblua5.3-dev
 lua5.3
 luarocks
 shellcheck
-ruby

--- a/src/plugins/analysis/linter/dnf-pkgs-runtime.txt
+++ b/src/plugins/analysis/linter/dnf-pkgs-runtime.txt
@@ -3,4 +3,3 @@ lua-devel
 luarocks
 nodejs
 ShellCheck
-ruby

--- a/src/plugins/analysis/linter/install.py
+++ b/src/plugins/analysis/linter/install.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=ungrouped-imports
 
 import logging
 from pathlib import Path
@@ -22,12 +23,12 @@ class LinterInstaller(AbstractPluginInstaller):
         run_cmd_with_logging('sudo luarocks install argparse')
         run_cmd_with_logging('sudo luarocks install luacheck')
         run_cmd_with_logging('sudo luarocks install luafilesystem')
-        run_cmd_with_logging('sudo gem install rubocop')
 
     def install_docker_images(self):
         run_cmd_with_logging('docker pull crazymax/linguist')
         run_cmd_with_logging('docker pull cytopia/eslint')
         run_cmd_with_logging('docker pull ghcr.io/phpstan/phpstan')
+        run_cmd_with_logging('docker pull pipelinecomponents/rubocop')
 
 
 # Alias for generic use
@@ -35,6 +36,5 @@ Installer = LinterInstaller
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
-    distribution = check_distribution()
-    installer = Installer(distribution)
+    installer = Installer(distribution=check_distribution())
     installer.install()

--- a/src/plugins/analysis/linter/test/test_ruby_linter.py
+++ b/src/plugins/analysis/linter/test/test_ruby_linter.py
@@ -44,7 +44,10 @@ MOCK_RESPONSE = '''
 
 
 def test_do_analysis(monkeypatch):
-    monkeypatch.setattr('plugins.analysis.linter.internal.linters.subprocess.run', lambda *_, **__: CompletedProcess('args', 0, stdout=MOCK_RESPONSE))
+    monkeypatch.setattr(
+        'plugins.analysis.linter.internal.linters.run_docker_container',
+        lambda *_, **__: CompletedProcess('args', 0, stdout=MOCK_RESPONSE)
+    )
     result = run_rubocop('any/path')
 
     assert len(result) == 1


### PR DESCRIPTION
`rubocop` linter installation failed for bionic and buster. This PR should fix this.

- switched to rubocop docker image to fix installation problems on older systems
- pylint fixes