### PR TITLE
Do not overwrite docker proxy settings when proxy environment variables are set

### DIFF
--- a/src/plugins/analysis/qemu_exec/install.py
+++ b/src/plugins/analysis/qemu_exec/install.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import logging
-import os
 import urllib.request
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -22,15 +21,7 @@ class QemuExecInstaller(AbstractPluginInstaller):
     base_path = Path(__file__).resolve().parent
 
     def install_docker_images(self):
-        run_cmd_with_logging(f'docker build {self._get_build_args()} -t fact/qemu-exec:alpine-3.14 {self.base_path}/docker')
-
-    @staticmethod
-    def _get_build_args():
-        return ' '.join([
-            f'--build-arg {key}={os.environ[key]}'
-            for key in ['http_proxy', 'https_proxy', 'no_proxy', 'HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY']
-            if key in os.environ
-        ])
+        run_cmd_with_logging(f'docker build -t fact/qemu-exec:alpine-3.14 {self.base_path}/docker')
 
     def install_files(self):
         with TemporaryDirectory(dir=str(self.base_path)) as tmp_dir:


### PR DESCRIPTION
So I'm not quite sure which route to go here. To honor environment variables from the `*_PROXY` family, @jstucke initially implemented a function that checks for `*_PROXY` environment variable presence. The idea was to pass proxy settings to docker containers during the build process of some dockerized plugins.

However, in some edge cases these `--build-arg` switch injections make it very hard to select the correct path in a multi-proxy environment. Exemplary scenario: *Use caching proxy **A** for the whole system, but use non-caching proxy **B** for docker containers*.

Now, the current implementation would not only use the system-wide proxy, but would also overwrite explicit [proxy configuration for docker environments](https://docs.docker.com/network/proxy/#configure-the-docker-client).

This draft PR suggests to remove the `--build-arg` functionality from the qemu plugin installation because it provides more flexibility in rather complex network setups.