### PR TITLE
Md5 quick search bugfix

### DIFF
--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -12,6 +12,7 @@ from typing import List, Optional, Union
 from helperFunctions.config import load_config
 from helperFunctions.data_conversion import get_value_of_first_key
 from helperFunctions.fileSystem import get_src_dir
+from helperFunctions.tag import TagColor
 from objects.file import FileObject
 from objects.firmware import Firmware
 from storage.db_setup import DbSetup
@@ -29,6 +30,7 @@ def create_test_firmware(device_class='Router', device_name='test_router', vendo
     fw.device_class = device_class
     fw.device_name = device_name
     fw.vendor = vendor
+    fw.tags = {'test_tag': TagColor.GRAY}
 
     fw.release_date = '1970-01-01'
     fw.version = version

--- a/src/test/unit/web_interface/test_quick_search.py
+++ b/src/test/unit/web_interface/test_quick_search.py
@@ -31,7 +31,7 @@ class DbMock(CommonDatabaseMock):
         return None
 
 
-class TestAppAdvancedSearch(WebInterfaceTest):
+class TestAppQuickSearch(WebInterfaceTest):
 
     @classmethod
     def setup_class(cls, *_, **__):

--- a/src/test/unit/web_interface/test_quick_search.py
+++ b/src/test/unit/web_interface/test_quick_search.py
@@ -1,0 +1,63 @@
+# pylint: disable=wrong-import-order
+from storage.db_interface_frontend import MetaEntry
+from test.common_helper import TEST_FW_2, CommonDatabaseMock
+from test.unit.web_interface.base import WebInterfaceTest
+
+
+class DbMock(CommonDatabaseMock):
+
+    @staticmethod
+    def generic_search(search_dict: dict, skip: int = 0, limit: int = 0,  # pylint: disable=unused-argument
+                       only_fo_parent_firmware: bool = False, inverted: bool = False, as_meta: bool = False):  # pylint: disable=unused-argument
+        result = []
+        if search_dict.get('$or', {}).get('file_name', {}).get('$like') == TEST_FW_2.file_name:
+            result.append(TEST_FW_2.uid)
+        elif search_dict.get('$or', {}).get('device_name', {}).get('$like') == TEST_FW_2.device_name:
+            result.append(TEST_FW_2.uid)
+        elif search_dict.get('$or', {}).get('vendor', {}).get('$like') == TEST_FW_2.vendor:
+            result.append(TEST_FW_2.uid)
+        elif search_dict.get('$or', {}).get('sha256') == TEST_FW_2.sha256:
+            result.append(TEST_FW_2.uid)
+        elif search_dict.get('$or', {}).get('firmware_tags') in TEST_FW_2.tags:
+            result.append(TEST_FW_2.uid)
+
+        if as_meta:
+            return [MetaEntry(uid, 'hid', {}, 0) for uid in result]
+        return result
+
+    def get_object(self, uid: str, analysis_filter=None):
+        if uid == TEST_FW_2.uid:
+            return TEST_FW_2
+        return None
+
+
+class TestAppAdvancedSearch(WebInterfaceTest):
+
+    @classmethod
+    def setup_class(cls, *_, **__):
+        super().setup_class(db_mock=DbMock)
+        cls.config['database'] = {}
+        cls.config['database']['results-per-page'] = '10'
+
+    def test_quick_search_file_name(self):
+        assert TEST_FW_2.uid in self._start_quick_search(TEST_FW_2.file_name)
+
+    def test_quick_search_device_name(self):
+        assert TEST_FW_2.uid in self._start_quick_search(TEST_FW_2.device_name)
+
+    def test_quick_search_vendor(self):
+        assert TEST_FW_2.uid in self._start_quick_search(TEST_FW_2.vendor)
+
+    def test_quick_search_sha256(self):
+        assert TEST_FW_2.uid in self._start_quick_search(TEST_FW_2.sha256)
+
+    def test_quick_search_tags(self):
+        assert TEST_FW_2.uid in self._start_quick_search(list(TEST_FW_2.tags)[0])
+
+    def _start_quick_search(self, search_term):
+        response = self.test_client.get(
+            '/database/quick_search',
+            query_string={'search_term': search_term},
+            follow_redirects=True
+        )
+        return response.data.decode()

--- a/src/web_interface/components/database_routes.py
+++ b/src/web_interface/components/database_routes.py
@@ -258,7 +258,6 @@ class DatabaseRoutes(ComponentBase):
             'device_name': {'$like': search_term},
             'vendor': {'$like': search_term},
             'file_name': {'$like': search_term},
-            'md5': search_term,
             'sha256': search_term,
             'firmware_tags': search_term,
         }}

--- a/src/web_interface/templates/base.html
+++ b/src/web_interface/templates/base.html
@@ -210,7 +210,7 @@
         <!-- Navbar Quick Search Input -->
         <div id="quick_search_div" class="nav navbar-nav ml-md-auto d-block">
             <div class="input-group mr-sm-2" style="z-index: 100;" >
-                <input type="text" class="form-control" placeholder="Quick search name, vendor or hash"
+                <input type="text" class="form-control" placeholder="Quick search filename, vendor, device, sha256 hash or tags"
                        id="quick_search_input" onKeyDown="if(event.keyCode==13) quickSearch();"
                        style="margin: 0; background-color: #e7e7e7; border-radius: 0; border-top-left-radius: .25rem; border-bottom-left-radius: .25rem; width: 120px; transition: width 0.5s ease-in-out;">
                 <div class="input-group-append">


### PR DESCRIPTION
- removed md5 from quick search (it was broken anyway)
- added unit tests for quick search (there weren't any)
- updated placeholder string to better reflect what can be searched for