### PR TITLE
pip package installation error handling bugfix

### DIFF
--- a/src/helperFunctions/install.py
+++ b/src/helperFunctions/install.py
@@ -270,10 +270,10 @@ def install_pip_packages(package_file: Path):
             run_cmd_with_logging(command, silent=True)
         except CalledProcessError as error:
             # don't fail if a package is already installed using apt and can't be upgraded
-            if 'distutils installed' in error.stderr:
+            if error.stderr is not None and 'distutils installed' in error.stderr:
                 logging.warning(f'Pip package {package} is already installed with distutils. This may Cause problems:\n{error.stderr}')
                 continue
-            logging.error(f'Pip package {package} could not be installed:\n{error.stderr}')
+            logging.error(f'Pip package {package} could not be installed:\n{error.stderr or error.stdout}')
             raise
 
 


### PR DESCRIPTION
Fix for pip package installation error handling when `CalledProcessError.stderr` is `None`