### PR TITLE
reduce false negative matches in information leaks plugin path matching

### DIFF
--- a/src/plugins/analysis/information_leaks/code/information_leaks.py
+++ b/src/plugins/analysis/information_leaks/code/information_leaks.py
@@ -7,7 +7,7 @@ from objects.file import FileObject
 PATH_REGEX = {
     'user_paths': re.compile(rb'/home/[^%\n \x00]+'),
     'root_path': re.compile(rb'/root/[^%\n \x00]+'),
-    'www_path': re.compile(rb'/var/www/[^/%]+/[^\n \x00]+')
+    'www_path': re.compile(rb'/var/www/[^\n \x00]+')
 }
 
 FILES_REGEX = {

--- a/src/plugins/analysis/information_leaks/code/information_leaks.py
+++ b/src/plugins/analysis/information_leaks/code/information_leaks.py
@@ -67,7 +67,7 @@ class AnalysisPlugin(AnalysisBasePlugin):
     DEPENDENCIES = []
     DESCRIPTION = 'Find leaked information like compilation artifacts'
     MIME_WHITELIST = ['application/x-executable', 'application/x-object', 'application/x-sharedlib', 'text/plain']
-    VERSION = '0.1'
+    VERSION = '0.1.1'
     FILE = __file__
 
     def process_object(self, file_object: FileObject):

--- a/src/plugins/analysis/information_leaks/code/information_leaks.py
+++ b/src/plugins/analysis/information_leaks/code/information_leaks.py
@@ -5,8 +5,8 @@ from analysis.PluginBase import AnalysisBasePlugin
 from objects.file import FileObject
 
 PATH_REGEX = {
-    'user_paths': re.compile(rb'/home/[^/%]+/[^\n \x00]+'),
-    'root_path': re.compile(rb'/root/[^/%]+/[^\n \x00]+'),
+    'user_paths': re.compile(rb'/home/[^%\n \x00]+'),
+    'root_path': re.compile(rb'/root/[^%\n \x00]+'),
     'www_path': re.compile(rb'/var/www/[^/%]+/[^\n \x00]+')
 }
 


### PR DESCRIPTION
The current regular expressions in the `information_leaks` path matching fail when the path hierarchy ends after level two, e.g. `/root/.ssh`. Depending on the follow-up characters, the expressions then match either nothing or include non-printable characters. The first edge case is a false-negative. The second edge case parse a corrupted path including non-printable bytes. Since the postgres database doesn't accept such data on `string`-type columns, the backend crashes once analysis results are written to the database. As our old DBMS `mongodb` just swallowed those values, nobody noticed.