### PR TITLE
Add 'plugin_version' key to plugin result when unpacker hits max unpacking depth

### DIFF
--- a/src/storage/entry_conversion.py
+++ b/src/storage/entry_conversion.py
@@ -136,7 +136,7 @@ def create_analysis_entries(file_object: FileObject, fo_backref: FileObjectEntry
             system_version=analysis_data.get('system_version', '0.0'),
             analysis_date=analysis_data.get('analysis_date', '1970-01-01'),
             summary=analysis_data.get('summary', ''),
-            tags=analysis_data.get('tags', []),
+            tags=analysis_data.get('tags', {}),
             result=get_analysis_without_meta(analysis_data),
             file_object=fo_backref,
         )

--- a/src/storage/entry_conversion.py
+++ b/src/storage/entry_conversion.py
@@ -132,11 +132,11 @@ def create_analysis_entries(file_object: FileObject, fo_backref: FileObjectEntry
         AnalysisEntry(
             uid=file_object.uid,
             plugin=plugin_name,
-            plugin_version=analysis_data['plugin_version'],
-            system_version=analysis_data.get('system_version'),
-            analysis_date=analysis_data['analysis_date'],
-            summary=analysis_data.get('summary'),
-            tags=analysis_data.get('tags'),
+            plugin_version=analysis_data.get('plugin_version', '0.0'),
+            system_version=analysis_data.get('system_version', '0.0'),
+            analysis_date=analysis_data.get('analysis_date', '1970-01-01'),
+            summary=analysis_data.get('summary', ''),
+            tags=analysis_data.get('tags', []),
             result=get_analysis_without_meta(analysis_data),
             file_object=fo_backref,
         )

--- a/src/storage/entry_conversion.py
+++ b/src/storage/entry_conversion.py
@@ -132,11 +132,11 @@ def create_analysis_entries(file_object: FileObject, fo_backref: FileObjectEntry
         AnalysisEntry(
             uid=file_object.uid,
             plugin=plugin_name,
-            plugin_version=analysis_data.get('plugin_version', '0.0'),
-            system_version=analysis_data.get('system_version', '0.0'),
-            analysis_date=analysis_data.get('analysis_date', '1970-01-01'),
-            summary=analysis_data.get('summary', ''),
-            tags=analysis_data.get('tags', {}),
+            plugin_version=analysis_data.get('plugin_version'),
+            system_version=analysis_data.get('system_version'),
+            analysis_date=analysis_data.get('analysis_date'),
+            summary=analysis_data.get('summary'),
+            tags=analysis_data.get('tags'),
             result=get_analysis_without_meta(analysis_data),
             file_object=fo_backref,
         )

--- a/src/unpacker/unpack.py
+++ b/src/unpacker/unpack.py
@@ -46,7 +46,7 @@ class Unpacker(UnpackBase):
     @staticmethod
     def _store_unpacking_depth_skip_info(file_object: FileObject):
         file_object.processed_analysis['unpacker'] = {
-            'plugin_used': 'None', 'number_of_unpacked_files': 0,
+            'plugin_used': 'None', 'number_of_unpacked_files': 0, 'plugin_version': '0.0',
             'info': 'Unpacking stopped because maximum unpacking depth was reached',
         }
         tag_dict = {'unpacker': {'depth reached': {'value': 'unpacking depth reached', 'color': TagColor.ORANGE, 'propagate': False}}}

--- a/src/unpacker/unpack.py
+++ b/src/unpacker/unpack.py
@@ -47,7 +47,7 @@ class Unpacker(UnpackBase):
     @staticmethod
     def _store_unpacking_depth_skip_info(file_object: FileObject):
         file_object.processed_analysis['unpacker'] = {
-            'plugin_used': 'None', 'number_of_unpacked_files': 0, 'plugin_version': '0.0', 'analysis_date': time.time(),
+            'plugin_used': 'None', 'number_of_unpacked_files': 0, 'plugin_version': '0.0', 'analysis_date': time(),
             'info': 'Unpacking stopped because maximum unpacking depth was reached',
         }
         tag_dict = {'unpacker': {'depth reached': {'value': 'unpacking depth reached', 'color': TagColor.ORANGE, 'propagate': False}}}

--- a/src/unpacker/unpack.py
+++ b/src/unpacker/unpack.py
@@ -2,6 +2,7 @@ import json
 import logging
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from time import time
 from typing import List
 
 from fact_helper_file import get_file_type_from_path
@@ -46,7 +47,7 @@ class Unpacker(UnpackBase):
     @staticmethod
     def _store_unpacking_depth_skip_info(file_object: FileObject):
         file_object.processed_analysis['unpacker'] = {
-            'plugin_used': 'None', 'number_of_unpacked_files': 0, 'plugin_version': '0.0',
+            'plugin_used': 'None', 'number_of_unpacked_files': 0, 'plugin_version': '0.0', 'analysis_date': time.time(),
             'info': 'Unpacking stopped because maximum unpacking depth was reached',
         }
         tag_dict = {'unpacker': {'depth reached': {'value': 'unpacking depth reached', 'color': TagColor.ORANGE, 'propagate': False}}}


### PR DESCRIPTION
```python
[2022-07-26 11:25:34][process][ERROR]: Exception in Scheduler process:
Traceback (most recent call last):
  File "/home/testbed/tools/FACT_core/src/helperFunctions/process.py", line 51, in run
    Process.run(self)
  File "/usr/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/home/testbed/tools/FACT_core/src/scheduler/analysis.py", line 267, in _task_runner
    self._process_next_analysis_task(task)
  File "/home/testbed/tools/FACT_core/src/scheduler/analysis.py", line 271, in _process_next_analysis_task
    self.pre_analysis(fw_object)
  File "/home/testbed/tools/FACT_core/src/storage/db_interface_backend.py", line 26, in add_object
    self.insert_object(fw_object)
  File "/home/testbed/tools/FACT_core/src/storage/db_interface_backend.py", line 32, in insert_object
    self.insert_file_object(fw_object)
  File "/home/testbed/tools/FACT_core/src/storage/db_interface_backend.py", line 38, in insert_file_object
    analyses = create_analysis_entries(file_object, fo_entry)
  File "/home/testbed/tools/FACT_core/src/storage/entry_conversion.py", line 131, in create_analysis_entries
    return [
  File "/home/testbed/tools/FACT_core/src/storage/entry_conversion.py", line 135, in <listcomp>
    plugin_version=analysis_data['plugin_version'],
KeyError: 'plugin_version'
```

When the unpacker hits its depth limit, it does not unpack the file object any further. It emits the following info as processed unpacker analysis:

```python
        file_object.processed_analysis['unpacker'] = {
            'plugin_used': 'None', 'number_of_unpacked_files': 0,
            'info': 'Unpacking stopped because maximum unpacking depth was reached',
        }
```
Unfortunately, it misses to insert a `plugin_version` key. Once the information is written into our `postgres` database, the `create_analysis_entries` function in our entry conversion fails to access the key and kills the backend due to an exception.

This PR adds the `plugin_version` key to said unpacker results and introduces default values in `create_analysis_entries` when keys are missing to add robustness.