### PR TITLE
assure that pinned werkzeug version is not overwritten

### DIFF
--- a/src/install/requirements_frontend.txt
+++ b/src/install/requirements_frontend.txt
@@ -1,5 +1,3 @@
-werkzeug==2.1.2
-
 bcrypt==3.2.2
 email-validator==1.2.1
 flask-login==0.6.1
@@ -16,6 +14,7 @@ python-dateutil==2.8.2
 si-prefix==1.2.2
 uwsgi==2.0.20
 virtualenv
+werkzeug==2.1.2
 
 # Used for username validation by flask-security
 bleach==5.0.0

--- a/src/install/requirements_frontend.txt
+++ b/src/install/requirements_frontend.txt
@@ -14,6 +14,8 @@ python-dateutil==2.8.2
 si-prefix==1.2.2
 uwsgi==2.0.20
 virtualenv
+
+# must be below dependent packages (flask, flask-login, flask-restx)
 werkzeug==2.1.2
 
 # Used for username validation by flask-security


### PR DESCRIPTION
assure that pinned werkzeug version is not overwritten during installation of other dependencies (flask, flask-login, flask-restx) by putting it right at the bottom of the list