### PR TITLE
add sensible defaults for anaylsis db entries

### DIFF
--- a/src/storage/entry_conversion.py
+++ b/src/storage/entry_conversion.py
@@ -149,7 +149,7 @@ def analysis_entry_to_dict(entry: AnalysisEntry) -> dict:
         'analysis_date': entry.analysis_date,
         'plugin_version': entry.plugin_version,
         'system_version': entry.system_version,
-        'summary': entry.summary,
+        'summary': entry.summary or [],
         'tags': entry.tags or {},
-        **entry.result,
+        **(entry.result or {}),
     }

--- a/src/storage/schema.py
+++ b/src/storage/schema.py
@@ -23,9 +23,9 @@ class AnalysisEntry(Base):
     plugin_version = Column(VARCHAR(16), nullable=False)
     system_version = Column(VARCHAR)
     analysis_date = Column(Float, nullable=False)
-    summary = Column(ARRAY(VARCHAR, dimensions=1))
+    summary = Column(ARRAY(VARCHAR, dimensions=1), default=[])
     tags = Column(MutableDict.as_mutable(JSONB))
-    result = Column(MutableDict.as_mutable(JSONB))
+    result = Column(MutableDict.as_mutable(JSONB), default={})
 
     file_object = relationship('FileObjectEntry', back_populates='analyses')
 


### PR DESCRIPTION
the DB schema allows `null` values for `AnalysisEntry.result`
While there shouldn't be a Null entries at the moment, such entries would cause errors for stats updates. This is because the stats generation functions use PostgreSQL functions which generally don't work on Null values.
This modification adds a reasonable default value, which should prevent such problems in the future.