### PR TITLE
linux kernel yara rule: exchange [1-5] limit on major release to \d

### DIFF
--- a/src/plugins/analysis/software_components/signatures/os.yara
+++ b/src/plugins/analysis/software_components/signatures/os.yara
@@ -71,7 +71,7 @@ rule LinuxKernel
 		website = "http://www.kernel.org"
 		description = "The Linux Kernel"
     strings:
-		$safe_condition = /Linux version [2-5]\.\d{1,2}\.\d{1,3}(-[\d\w.-]+)?/ nocase ascii wide
+		$safe_condition = /Linux version \d\.\d{1,2}\.\d{1,3}(-[\d\w.-]+)?/ nocase ascii wide
 		
 	condition:
 		$safe_condition and no_text_file


### PR DESCRIPTION
Major release 6 is around the corner - we better future-proof our YARA rule :-)