### PR TITLE
fixed bugs that may occur if summary entries contain NULL bytes

### DIFF
--- a/src/plugins/analysis/architecture_detection/internal/dt.py
+++ b/src/plugins/analysis/architecture_detection/internal/dt.py
@@ -67,7 +67,7 @@ def _get_compatible_entry(dts: str) -> Union[str, None]:
     if compatible is None:
         return None
 
-    return compatible[0]
+    return compatible[0].replace('\0', ' ')
 
 
 def construct_result(file_object):

--- a/src/storage/entry_conversion.py
+++ b/src/storage/entry_conversion.py
@@ -129,12 +129,13 @@ def _sanitize_key(analysis_data: dict, key: str):
         analysis_data[key.replace('\0', '')] = analysis_data.pop(key)
 
 
-def _sanitize_list(value: list):
+def _sanitize_list(value: list) -> list:
     for index, element in enumerate(value):
         if isinstance(element, dict):
             sanitize(element)
         elif isinstance(element, str) and '\0' in element:
             value[index] = element.replace('\0', '')
+    return value
 
 
 def create_analysis_entries(file_object: FileObject, fo_backref: FileObjectEntry) -> List[AnalysisEntry]:
@@ -145,7 +146,7 @@ def create_analysis_entries(file_object: FileObject, fo_backref: FileObjectEntry
             plugin_version=analysis_data.get('plugin_version'),
             system_version=analysis_data.get('system_version'),
             analysis_date=analysis_data.get('analysis_date'),
-            summary=analysis_data.get('summary'),
+            summary=_sanitize_list(analysis_data.get('summary', [])),
             tags=analysis_data.get('tags'),
             result=get_analysis_without_meta(analysis_data),
             file_object=fo_backref,

--- a/src/test/unit/storage/test_entry_conversion.py
+++ b/src/test/unit/storage/test_entry_conversion.py
@@ -10,6 +10,7 @@ from storage.entry_conversion import get_analysis_without_meta, sanitize
     ({'nested': {'key': 'a\0b\0c'}}, {'nested': {'key': 'abc'}}),
     ({'ille\0gal': 'abc'}, {'illegal': 'abc'}),
     ({'nested': {'key\0': 'abc'}}, {'nested': {'key': 'abc'}}),
+    ({'list': ['item\x001', {'list_in_dict': ['item2\0']}]}, {'list': ['item1', {'list_in_dict': ['item2']}]}),
 ])
 def test_sanitize(input_dict, expected):
     sanitize(input_dict)


### PR DESCRIPTION
There may still be errors when storing analysis results in the DB if summary entries contain NULL bytes. This PR should fix this.