### PR TITLE
fix multiple newly discovered postgres DB migration issues

### DIFF
--- a/src/config/migration.cfg
+++ b/src/config/migration.cfg
@@ -3,6 +3,7 @@
 mongo-server = localhost
 mongo-port = 27018
 main-database = fact_main
+sanitize-database = faf_sanitize
 
 # Authentication
 db-admin-user = fact_admin


### PR DESCRIPTION
fixed some postgres migration issues:
- wrong "sanitize-db" name and respective gridfs exception handling
- `KeyError` in analysis result migration
- handled error that may occur when trying to migrate comparisons of deleted firmware entries