### PR TITLE
removed `register_plugin` construct

### DIFF
--- a/src/analysis/PluginBase.py
+++ b/src/analysis/PluginBase.py
@@ -52,7 +52,6 @@ class AnalysisBasePlugin(BasePlugin):  # pylint: disable=too-many-instance-attri
         self.workers = []
         self.thread_count = int(self.config[self.NAME]['threads'])
         self.active = [Value('i', 0) for _ in range(self.thread_count)]
-        self.register_plugin()
         if not offline_testing:
             self.start_worker()
 
@@ -60,7 +59,6 @@ class AnalysisBasePlugin(BasePlugin):  # pylint: disable=too-many-instance-attri
         '''
         This function can be implemented by the plugin to do initialization
         '''
-        pass
 
     def _check_plugin_attributes(self):
         for attribute in ['FILE', 'NAME', 'VERSION']:

--- a/src/analysis/PluginBase.py
+++ b/src/analysis/PluginBase.py
@@ -39,10 +39,8 @@ class AnalysisBasePlugin(BasePlugin):  # pylint: disable=too-many-instance-attri
     MIME_BLACKLIST = []
     MIME_WHITELIST = []
 
-    def __init__(
-        self, plugin_administrator, config=None, no_multithread=False, offline_testing=False, view_updater=None
-    ):
-        super().__init__(plugin_administrator, config=config, plugin_path=self.FILE, view_updater=view_updater)
+    def __init__(self, config=None, no_multithread=False, offline_testing=False, view_updater=None):
+        super().__init__(config=config, plugin_path=self.FILE, view_updater=view_updater)
         self._check_plugin_attributes()
         self.check_config(no_multithread)
         self.additional_setup()

--- a/src/analysis/YaraPluginBase.py
+++ b/src/analysis/YaraPluginBase.py
@@ -19,7 +19,7 @@ class YaraBasePlugin(AnalysisBasePlugin):
     VERSION = '0.0'
     FILE = None
 
-    def __init__(self, plugin_administrator, config=None, view_updater=None):
+    def __init__(self, config=None, view_updater=None):
         '''
         recursive flag: If True recursively analyze included files
         propagate flag: If True add analysis result of child to parent object
@@ -30,7 +30,7 @@ class YaraBasePlugin(AnalysisBasePlugin):
             logging.error(f'Signature file {self.signature_path} not found. Did you run "compile_yara_signatures.py"?')
             raise PluginInitException(plugin=self)
         self.SYSTEM_VERSION = self.get_yara_system_version()  # pylint: disable=invalid-name
-        super().__init__(plugin_administrator, config=config, view_updater=view_updater)
+        super().__init__(config=config, view_updater=view_updater)
 
     def get_yara_system_version(self):
         with subprocess.Popen(['yara', '--version'], stdout=subprocess.PIPE) as process:

--- a/src/compare/PluginBase.py
+++ b/src/compare/PluginBase.py
@@ -16,7 +16,6 @@ class CompareBasePlugin(BasePlugin):
     def __init__(self, plugin_administrator, config=None, db_interface=None, view_updater=None):
         super().__init__(plugin_administrator, config=config, plugin_path=self.FILE, view_updater=view_updater)
         self.database = db_interface
-        self.register_plugin()
 
     @abstractmethod
     def compare_function(self, fo_list):

--- a/src/compare/PluginBase.py
+++ b/src/compare/PluginBase.py
@@ -13,8 +13,8 @@ class CompareBasePlugin(BasePlugin):
     # must be set by the plugin:
     FILE = None
 
-    def __init__(self, plugin_administrator, config=None, db_interface=None, view_updater=None):
-        super().__init__(plugin_administrator, config=config, plugin_path=self.FILE, view_updater=view_updater)
+    def __init__(self, config=None, db_interface=None, view_updater=None):
+        super().__init__(config=config, plugin_path=self.FILE, view_updater=view_updater)
         self.database = db_interface
 
     @abstractmethod

--- a/src/compare/compare.py
+++ b/src/compare/compare.py
@@ -88,7 +88,7 @@ class Compare:
                 logging.error(f'Could not import plugin {plugin_name} due to exception', exc_info=True)
             else:
                 self.compare_plugins[plugin.ComparePlugin.NAME] = plugin.ComparePlugin(
-                    self, config=self.config, db_interface=self.db_interface
+                    config=self.config, db_interface=self.db_interface
                 )
 
     def _execute_compare_plugins(self, fo_list):

--- a/src/compare/compare.py
+++ b/src/compare/compare.py
@@ -26,12 +26,12 @@ class Compare:
 
     def compare(self, uid_list):
         logging.info(f'Compare in progress: {uid_list}')
-        bs = BinaryService(config=self.config)
+        binary_service = BinaryService(config=self.config)
 
         fo_list = []
         for uid in uid_list:
             fo = self.db_interface.get_complete_object_including_all_summaries(uid)
-            fo.binary = bs.get_binary_and_file_name(fo.uid)[0]
+            fo.binary = binary_service.get_binary_and_file_name(fo.uid)[0]
             fo_list.append(fo)
 
         return self.compare_objects(fo_list)
@@ -87,10 +87,9 @@ class Compare:
                 # For why this exception can occur see Analysis.AnalysisScheduler.load_plugins
                 logging.error(f'Could not import plugin {plugin_name} due to exception', exc_info=True)
             else:
-                plugin.ComparePlugin(self, config=self.config, db_interface=self.db_interface)
-
-    def register_plugin(self, name, compare_plugin_instance):
-        self.compare_plugins[name] = compare_plugin_instance
+                self.compare_plugins[plugin.ComparePlugin.NAME] = plugin.ComparePlugin(
+                    self, config=self.config, db_interface=self.db_interface
+                )
 
     def _execute_compare_plugins(self, fo_list):
         return {name: plugin.compare(fo_list) for name, plugin in self.compare_plugins.items()}

--- a/src/plugins/analysis/architecture_detection/code/architecture_detection.py
+++ b/src/plugins/analysis/architecture_detection/code/architecture_detection.py
@@ -42,10 +42,10 @@ class AnalysisPlugin(AnalysisBasePlugin):
         'video',
     ]
 
-    def __init__(self, plugin_administrator, config=None):
+    def __init__(self, config=None):
         self.config = config
         self._fs_organizer = FSOrganizer(config)
-        super().__init__(plugin_administrator, config=config)
+        super().__init__(config=config)
 
     def process_object(self, file_object):
         arch_dict = construct_result(file_object, self._fs_organizer)

--- a/src/plugins/analysis/cve_lookup/test/test_cve_lookup.py
+++ b/src/plugins/analysis/cve_lookup/test/test_cve_lookup.py
@@ -212,11 +212,6 @@ def test_search_cve_summary(monkeypatch):
         assert MATCHED_SUMMARY == actual_match
 
 
-class MockAdmin:
-    def register_plugin(self, name, administrator):
-        pass
-
-
 @pytest.fixture(scope='function')
 def test_config():
     return get_config_for_testing()
@@ -225,7 +220,7 @@ def test_config():
 @pytest.fixture(scope='function')
 def stub_plugin(test_config, monkeypatch):
     monkeypatch.setattr('plugins.base.BasePlugin._sync_view', lambda self, plugin_path: None)
-    return lookup.AnalysisPlugin(MockAdmin(), test_config, offline_testing=True)
+    return lookup.AnalysisPlugin(test_config, offline_testing=True)
 
 
 def test_process_object(stub_plugin):

--- a/src/plugins/analysis/elf_analysis/test/test_plugin_elf_analysis.py
+++ b/src/plugins/analysis/elf_analysis/test/test_plugin_elf_analysis.py
@@ -15,11 +15,6 @@ TEST_DATA = Path(get_test_data_dir(), 'test_data_file.bin')
 TEST_DATA_DIR = Path(__file__).parent / 'data'
 
 
-class MockAdmin:
-    def register_plugin(self, name, administrator):
-        pass
-
-
 LiefResult = namedtuple(
     'LiefResult', ['symbols_version', 'libraries', 'imported_functions', 'exported_functions', 'sections']
 )
@@ -57,7 +52,7 @@ def stub_object():
 @pytest.fixture(scope='function')
 def stub_plugin(test_config, monkeypatch):
     monkeypatch.setattr('plugins.base.BasePlugin._sync_view', lambda self, plugin_path: None)
-    return AnalysisPlugin(MockAdmin(), test_config, offline_testing=True)
+    return AnalysisPlugin(test_config, offline_testing=True)
 
 
 @pytest.mark.parametrize(

--- a/src/plugins/analysis/file_system_metadata/test/test_plugin_file_system_metadata.py
+++ b/src/plugins/analysis/file_system_metadata/test/test_plugin_file_system_metadata.py
@@ -64,7 +64,7 @@ class TestFileSystemMetadata(AnalysisPluginTest):
         self.test_file_fs = TEST_DATA_DIR / 'squashfs.img'
 
     def setup_plugin(self):
-        return AnalysisPlugin(self, config=self.config, view_updater=CommonDatabaseMock(), db_interface=DbMock())
+        return AnalysisPlugin(config=self.config, view_updater=CommonDatabaseMock(), db_interface=DbMock())
 
     def _extract_metadata_from_archive_mock(self, _):
         self.result = 'archive'

--- a/src/plugins/analysis/hashlookup/test/test_hashlookup.py
+++ b/src/plugins/analysis/hashlookup/test/test_hashlookup.py
@@ -8,11 +8,6 @@ from ..code.hashlookup import AnalysisPlugin
 KNOWN_ZSH_HASH = 'A6F2177402114FC8B5E7ECF924FFA61A2AC25BD347BC3370FB92E07B76E0B44C'
 
 
-class MockAdmin:
-    def register_plugin(self, name, administrator):
-        pass
-
-
 @pytest.fixture(scope='function')
 def test_config():
     return get_config_for_testing()
@@ -21,7 +16,7 @@ def test_config():
 @pytest.fixture(scope='function')
 def stub_plugin(test_config, monkeypatch):
     monkeypatch.setattr('plugins.base.BasePlugin._sync_view', lambda self, plugin_path: None)
-    return AnalysisPlugin(MockAdmin(), test_config, offline_testing=True)
+    return AnalysisPlugin(test_config, offline_testing=True)
 
 
 @pytest.fixture(scope='function')

--- a/src/plugins/analysis/linter/test/test_source_code_analysis.py
+++ b/src/plugins/analysis/linter/test/test_source_code_analysis.py
@@ -12,11 +12,6 @@ from ..code.source_code_analysis import AnalysisPlugin
 PYLINT_TEST_FILE = Path(__file__).parent / 'data' / 'linter_test_file'
 
 
-class MockAdmin:
-    def register_plugin(self, name, administrator):
-        pass
-
-
 @pytest.fixture(scope='function')
 def test_config():
     return get_config_for_testing()
@@ -29,7 +24,7 @@ def test_object():
 
 @pytest.fixture(scope='function')
 def stub_plugin(test_config, monkeypatch):
-    return AnalysisPlugin(MockAdmin(), test_config, offline_testing=True, view_updater=CommonDatabaseMock())
+    return AnalysisPlugin(test_config, offline_testing=True, view_updater=CommonDatabaseMock())
 
 
 def test_process_object_not_supported(stub_plugin, test_object, monkeypatch):

--- a/src/plugins/analysis/qemu_exec/test/test_plugin_qemu_exec.py
+++ b/src/plugins/analysis/qemu_exec/test/test_plugin_qemu_exec.py
@@ -96,7 +96,7 @@ class TestPluginQemuExec(AnalysisPluginTest):
     PLUGIN_CLASS = AnalysisPlugin
 
     def setup_plugin(self):
-        return AnalysisPlugin(self, config=self.config, unpacker=MockUnpacker(), view_updater=CommonDatabaseMock())
+        return AnalysisPlugin(config=self.config, unpacker=MockUnpacker(), view_updater=CommonDatabaseMock())
 
     def test_has_relevant_type(self):
         assert self.analysis_plugin._has_relevant_type(None) is False

--- a/src/plugins/analysis/tlsh/test/test_plugin_tlsh.py
+++ b/src/plugins/analysis/tlsh/test/test_plugin_tlsh.py
@@ -9,11 +9,6 @@ HASH_0 = '9A355C07B5A614FDC5A2847046EF92B7693174A642327DBF3C88D6303F42E746B1ABE1
 HASH_1 = '0CC34B06B1B258BCC16689308A67D671AB747E5053223B3E3684F7342F56E6F1F0DAB1'
 
 
-class MockAdmin:
-    def register_plugin(self, name, administrator):
-        pass
-
-
 class MockDb:
     def get_all_tlsh_hashes(self):  # pylint: disable=no-self-use
         return [('test_uid', HASH_1)]
@@ -34,7 +29,7 @@ def test_object():
 @pytest.fixture(scope='function')
 def stub_plugin(test_config):
     return AnalysisPlugin(
-        MockAdmin(), config=test_config, offline_testing=True, view_updater=CommonDatabaseMock(), db_interface=MockDb()
+        config=test_config, offline_testing=True, view_updater=CommonDatabaseMock(), db_interface=MockDb()
     )
 
 

--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -9,8 +9,7 @@ class BasePlugin:
     NAME = 'base'
     DEPENDENCIES = []
 
-    def __init__(self, plugin_administrator, config=None, plugin_path=None, view_updater=None):
-        self.plugin_administrator = plugin_administrator
+    def __init__(self, config=None, plugin_path=None, view_updater=None):
         self.config = config
         self.view_updater = view_updater if view_updater is not None else ViewUpdater(config)
         if plugin_path:

--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -32,6 +32,3 @@ class BasePlugin:
         if len(view_files) > 1:
             logging.warning(f'{cls.NAME}: Plug-in provides more than one view! \'{view_files[0]}\' is used!')
         return view_files[0]
-
-    def register_plugin(self):
-        self.plugin_administrator.register_plugin(self.NAME, self)

--- a/src/plugins/compare/file_coverage/test/test_plugin_file_coverage.py
+++ b/src/plugins/compare/file_coverage/test/test_plugin_file_coverage.py
@@ -25,7 +25,7 @@ class TestComparePluginFileCoverage(ComparePluginTest):
         This function must be overwritten by the test instance.
         In most cases it is sufficient to copy this function.
         '''
-        return ComparePlugin(self, config=self.config, db_interface=DbMock(), view_updater=CommonDatabaseMock())
+        return ComparePlugin(config=self.config, db_interface=DbMock(), view_updater=CommonDatabaseMock())
 
     def test_get_intersection_of_files(self):
         self.fw_one.list_of_all_included_files.append('foo')

--- a/src/scheduler/analysis.py
+++ b/src/scheduler/analysis.py
@@ -184,18 +184,7 @@ class AnalysisScheduler:  # pylint: disable=too-many-instance-attributes
                 # be missing dependencies. So if anything goes wrong we want to inform the user about it
                 logging.error(f'Could not import plugin {plugin_name} due to exception', exc_info=True)
             else:
-                plugin.AnalysisPlugin(self, config=self.config)
-
-    def register_plugin(self, name: str, plugin_instance: AnalysisBasePlugin):
-        '''
-        This function is used by analysis plugins to register themselves with this scheduler. During initialization the
-        plugins will call this functions giving their name and a reference to their object to allow the scheduler to
-        address them for running analyses.
-
-        :param name: The plugin name for addressing in runner and collector
-        :param plugin_instance: A reference to the plugin object
-        '''
-        self.analysis_plugins[name] = plugin_instance
+                self.analysis_plugins[plugin.AnalysisPlugin.NAME] = plugin.AnalysisPlugin(self, config=self.config)
 
     def _get_plugin_sets_from_config(self):
         try:

--- a/src/scheduler/analysis.py
+++ b/src/scheduler/analysis.py
@@ -184,7 +184,7 @@ class AnalysisScheduler:  # pylint: disable=too-many-instance-attributes
                 # be missing dependencies. So if anything goes wrong we want to inform the user about it
                 logging.error(f'Could not import plugin {plugin_name} due to exception', exc_info=True)
             else:
-                self.analysis_plugins[plugin.AnalysisPlugin.NAME] = plugin.AnalysisPlugin(self, config=self.config)
+                self.analysis_plugins[plugin.AnalysisPlugin.NAME] = plugin.AnalysisPlugin(config=self.config)
 
     def _get_plugin_sets_from_config(self):
         try:

--- a/src/test/unit/analysis/analysis_plugin_test_class.py
+++ b/src/test/unit/analysis/analysis_plugin_test_class.py
@@ -1,5 +1,6 @@
 import unittest.mock
 from configparser import ConfigParser
+from typing import Callable
 
 from test.common_helper import (  # pylint: disable=wrong-import-order
     CommonDatabaseMock,
@@ -15,7 +16,7 @@ class AnalysisPluginTest(unittest.TestCase):
 
     # must be set by individual plugin test class
     PLUGIN_NAME = 'plugin_test'
-    PLUGIN_CLASS = None
+    PLUGIN_CLASS: Callable = None
 
     def setUp(self):
         self.docker_mount_base_dir = create_docker_mount_base_dir()
@@ -28,9 +29,7 @@ class AnalysisPluginTest(unittest.TestCase):
 
     def setup_plugin(self):
         # overwrite in plugin tests if necessary
-        return self.PLUGIN_CLASS(
-            self, config=self.config, view_updater=CommonDatabaseMock()
-        )  # pylint: disable=not-callable
+        return self.PLUGIN_CLASS(config=self.config, view_updater=CommonDatabaseMock())
 
     def tearDown(self):
         self.analysis_plugin.shutdown()  # pylint: disable=no-member
@@ -50,13 +49,3 @@ class AnalysisPluginTest(unittest.TestCase):
         config.set('data-storage', 'postgres-database', 'fact-test')
 
         return config
-
-    def register_plugin(self, name, plugin_object):
-        '''
-        This is a mock checking if the plugin registers correctly
-        '''
-        self.assertEqual(name, self.PLUGIN_NAME, 'plugin registers with wrong name')
-        self.assertEqual(plugin_object.NAME, self.PLUGIN_NAME, 'plugin object has wrong name')
-        self.assertIsInstance(plugin_object.DESCRIPTION, str)
-        self.assertIsInstance(plugin_object.VERSION, str)
-        self.assertNotEqual(plugin_object.VERSION, 'not set', 'Plug-in version not set')

--- a/src/test/unit/analysis/test_plugin_base.py
+++ b/src/test/unit/analysis/test_plugin_base.py
@@ -21,7 +21,7 @@ class TestPluginBase(unittest.TestCase):
     @mock.patch('plugins.base.ViewUpdater', lambda *_: None)
     def setUp(self):
         self.config = self.set_up_base_config()
-        self.base_plugin = DummyPlugin(self, self.config)
+        self.base_plugin = DummyPlugin(self.config)
 
     @staticmethod
     def set_up_base_config():
@@ -36,19 +36,12 @@ class TestPluginBase(unittest.TestCase):
         self.base_plugin.shutdown()
         gc.collect()
 
-    def register_plugin(self, name, plugin_object):  # pylint: disable=no-self-use
-        '''
-        This is a mock checking if the plugin registers correctly
-        '''
-        assert name == 'dummy_plugin_for_testing_only', 'plugin registers with wrong name'
-        assert plugin_object.NAME == 'dummy_plugin_for_testing_only', 'plugin object has wrong name'
-
 
 class TestPluginBaseCore(TestPluginBase):
     @mock.patch('plugins.base.ViewUpdater', lambda *_: None)
     def test_attribute_check(self):
         with pytest.raises(PluginInitException):
-            AnalysisBasePlugin(self, config=self.config)
+            AnalysisBasePlugin(config=self.config)
 
     @staticmethod
     def test_start_stop_workers():
@@ -134,7 +127,7 @@ class TestPluginNotRunning(TestPluginBase):
     @mock.patch('plugins.base.ViewUpdater', lambda *_: None)
     def multithread_config_test(self, multithread_flag, threads_in_config, threads_wanted):
         self.config.set('dummy_plugin_for_testing_only', 'threads', threads_in_config)
-        self.p_base = DummyPlugin(self, self.config, no_multithread=multithread_flag)
+        self.p_base = DummyPlugin(self.config, no_multithread=multithread_flag)
         self.assertEqual(
             self.p_base.config[self.p_base.NAME]['threads'], threads_wanted, 'number of threads not correct'
         )
@@ -148,7 +141,7 @@ class TestPluginNotRunning(TestPluginBase):
 
     @mock.patch('plugins.base.ViewUpdater', lambda *_: None)
     def test_init_result_dict(self):
-        self.p_base = DummyPlugin(self, self.config)
+        self.p_base = DummyPlugin(self.config)
         resultdict = self.p_base.init_dict()
         self.assertIn('analysis_date', resultdict, 'analysis date missing')
         self.assertEqual(resultdict['plugin_version'], '0.0', 'plugin version field not correct')
@@ -166,12 +159,9 @@ class TestPluginTimeout(TestPluginBase):
     @mock.patch('plugins.base.ViewUpdater', lambda *_: None)
     @mock.patch('plugins.analysis.dummy.code.dummy.AnalysisPlugin.TIMEOUT', 0)
     def test_timeout(self):
-        self.p_base = DummyPlugin(self, self.config)
+        self.p_base = DummyPlugin(self.config)
         fo_in = FileObject(binary=b'test', scheduled_analysis=[])
         self.p_base.add_job(fo_in)
         fo_out = self.p_base.out_queue.get(timeout=5)
         self.p_base.shutdown()
         self.assertNotIn('summary', fo_out.processed_analysis['dummy_plugin_for_testing_only'])
-
-    def register_plugin(self, name, plugin_object):
-        pass

--- a/src/test/unit/compare/compare_plugin_test_class.py
+++ b/src/test/unit/compare/compare_plugin_test_class.py
@@ -26,23 +26,13 @@ class ComparePluginTest:
         '''
         This function can be overwritten by the test instance.
         '''
-        return self.PLUGIN_CLASS(self, config=self.config, view_updater=CommonDatabaseMock())
+        return self.PLUGIN_CLASS(config=self.config, view_updater=CommonDatabaseMock())
 
     def generate_config(self):  # pylint: disable=no-self-use
         '''
         This function can be overwritten by the test instance if a special config is needed
         '''
         return ConfigParser()
-
-    def test_init(self):
-        assert len(self.compare_plugins) == 1, 'number of registered plugins not correct'
-        assert self.compare_plugins[self.PLUGIN_NAME].NAME == self.PLUGIN_NAME, 'plugin instance not correct'
-
-    def register_plugin(self, plugin_name, plugin_instance):
-        '''
-        Callback Function Mock
-        '''
-        self.compare_plugins[plugin_name] = plugin_instance
 
     def setup_test_fw(self):
         self.fw_one = create_test_firmware(device_name='dev_1', all_files_included_set=True)

--- a/src/test/unit/compare/test_plugin_base.py
+++ b/src/test/unit/compare/test_plugin_base.py
@@ -18,7 +18,7 @@ class TestComparePluginBase(ComparePluginTest):
         This function must be overwritten by the test instance.
         In most cases it is sufficient to copy this function.
         """
-        return ComparePlugin(self, config=self.config)
+        return ComparePlugin(config=self.config)
 
     def test_compare_missing_dep(self):
         self.c_plugin.DEPENDENCIES = ['test_ana']


### PR DESCRIPTION
Removed `register_plugin` and `plugin_administrator` constructs where the scheduler class is passed to the plugin so that the plugin can write itself into the list of plugins inside the scheduler, which is both unnecessarily complicated and generally unnecessary.
Instead, this can be done directly inside the scheduler (where the plugins are initialized anyway).