### PR TITLE
removed (some) files from info_leaks summary

### DIFF
--- a/src/plugins/analysis/information_leaks/test/data/path_test_file
+++ b/src/plugins/analysis/information_leaks/test/data/path_test_file
@@ -1,6 +1,8 @@
 /home/user/test/urandom
 /home/user/urandom
 /home/%s/%s/some_file
+/home/multiple/file.a
+/home/multiple/file.b
 /proc/athversion
 /proc/simple_config/simple_config_led
 /sys/class/net/%s/brport/bridge

--- a/src/plugins/analysis/information_leaks/test/test_plugin_information_leaks.py
+++ b/src/plugins/analysis/information_leaks/test/test_plugin_information_leaks.py
@@ -23,6 +23,8 @@ class TestAnalysisPluginInformationLeaks(AnalysisPluginTest):
 
         assert 'user_paths' in fo.processed_analysis[self.PLUGIN_NAME]
         assert fo.processed_analysis[self.PLUGIN_NAME]['user_paths'] == [
+            '/home/multiple/file.a',
+            '/home/multiple/file.b',
             '/home/user/test/urandom',
             '/home/user/urandom',
         ]
@@ -35,6 +37,7 @@ class TestAnalysisPluginInformationLeaks(AnalysisPluginTest):
 
         assert 'summary' in fo.processed_analysis[self.PLUGIN_NAME]
         assert fo.processed_analysis[self.PLUGIN_NAME]['summary'] == [
+            '/home/multiple',
             '/home/user/test/urandom',
             '/home/user/urandom',
             '/root/user_name/this_directory',


### PR DESCRIPTION
- Removed (some) files from info_leaks summary to reduce 'spammyness' of the summary for files containing many matched paths:
    - A summary entry is created for each matching path but for some files containing lots of paths this can mean a lot of (mostly) redundant summary entries. This PR tries to reduce this a bit by filtering out file paths obviously ending with a file and only using the parent folder as result
- improved regexes