### PR TITLE
text file comparison from url instead of session

### DIFF
--- a/src/test/unit/web_interface/test_app_comparison_text_files.py
+++ b/src/test/unit/web_interface/test_app_comparison_text_files.py
@@ -63,4 +63,4 @@ class TestAppComparisonTextFiles(WebInterfaceTest):
                     TEST_TEXT_FILE2.uid: 'file_2_root_uid',
                 }
                 test_session.modified = True
-            return self.test_client.get('/comparison/text_files').data
+            return self.test_client.get('/comparison/text_files', follow_redirects=True).data


### PR DESCRIPTION
- the text file diff page did not support reloading/bookmarking/etc. because the comparison UIDs were taken from the session instead of the URL
- this PR splits the initiation of a text file diff from showing the actual page to fix those problems