### PR TITLE
disable fail-fast for ci build matrix

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-ci:
     strategy:
+      fail-fast: false
       matrix:
         os: [ focal, jammy, buster, bullseye ]
     runs-on: [ self-hosted, linux, x64, "${{ matrix.os }}" ]


### PR DESCRIPTION
do not abort all jobs of the matrix when one failed