### PR TITLE
add time based ci build at 03:00am UTC each night

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -3,6 +3,8 @@ run-name: Build CI
 on:
   pull_request:
     branches: [ master ]
+  schedule:
+    - cron: "0 3 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
`schedule` only affects the latest commit of the `default` branch