### PR TITLE
file diff optimization and bugfixes

### DIFF
--- a/src/intercom/front_end_binding.py
+++ b/src/intercom/front_end_binding.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from time import sleep, time
 from typing import Any, Optional
@@ -37,6 +39,9 @@ class InterComFrontEndBinding(InterComRedisInterface):
     def get_binary_and_filename(self, uid):
         return self._request_response_listener(uid, 'raw_download_task', 'raw_download_task_resp')
 
+    def get_file_diff(self, uid_pair: tuple[str, str]) -> str | None:
+        return self._request_response_listener(uid_pair, 'file_diff_task', 'file_diff_task_resp')
+
     def peek_in_binary(self, uid: str, offset: int, length: int) -> bytes:
         return self._request_response_listener((uid, offset, length), 'binary_peek_task', 'binary_peek_task_resp')
 
@@ -59,7 +64,6 @@ class InterComFrontEndBinding(InterComRedisInterface):
         request_id = generate_task_id(input_data)
         self._add_to_redis_queue(request_connection, input_data, request_id)
         logging.debug(f'Request sent: {request_connection} -> {request_id}')
-        sleep(1)
         return self._response_listener(response_connection, request_id)
 
     def _response_listener(self, response_connection, request_id, timeout=None):
@@ -72,7 +76,7 @@ class InterComFrontEndBinding(InterComRedisInterface):
                 logging.debug(f'Response received: {response_connection} -> {request_id}')
                 break
             logging.debug(f'No response yet: {response_connection} -> {request_id}')
-            sleep(1)
+            sleep(0.1)
         return output_data
 
     def _add_to_redis_queue(self, key: str, data: Any, task_id: Optional[str] = None):

--- a/src/test/integration/intercom/test_backend_scheduler.py
+++ b/src/test/integration/intercom/test_backend_scheduler.py
@@ -9,7 +9,7 @@ from intercom.back_end_binding import InterComBackEndBinding
 from test.common_helper import get_config_for_testing  # pylint: disable=wrong-import-order
 
 # This number must be changed, whenever a listener is added or removed
-NUMBER_OF_LISTENERS = 11
+NUMBER_OF_LISTENERS = 12
 
 
 class ServiceMock:

--- a/src/test/integration/intercom/test_task_communication.py
+++ b/src/test/integration/intercom/test_task_communication.py
@@ -10,6 +10,7 @@ from intercom.back_end_binding import (
     InterComBackEndAnalysisPlugInsPublisher,
     InterComBackEndAnalysisTask,
     InterComBackEndCompareTask,
+    InterComBackEndFileDiffTask,
     InterComBackEndPeekBinaryTask,
     InterComBackEndRawDownloadTask,
     InterComBackEndReAnalyzeTask,
@@ -26,6 +27,19 @@ class AnalysisServiceMock:
 
     def get_plugin_dict(self):  # pylint: disable=no-self-use
         return {'dummy': 'dummy description'}
+
+
+class BinaryServiceMock:
+    def __init__(self, *_, **__):
+        pass
+
+    @staticmethod
+    def get_binary_and_file_name(uid: str) -> tuple[bytes, str]:
+        if uid == 'uid1':
+            return b'binary content 1', 'file_name_1'
+        if uid == 'uid2':
+            return b'binary content 2', 'file_name_2'
+        assert False, 'if this line reached something went wrong'
 
 
 class TestInterComTaskCommunication(unittest.TestCase):
@@ -109,6 +123,20 @@ class TestInterComTaskCommunication(unittest.TestCase):
         self.assertEqual(task, 'valid_uid', 'task not correct')
         result = self.frontend.get_binary_and_filename('valid_uid_0.0')
         self.assertEqual(result, (b'test', 'test.txt'), 'retrieved binary not correct')
+
+    @mock.patch('intercom.front_end_binding.generate_task_id', new=lambda _: 'valid_uid_0.0')
+    @mock.patch('intercom.back_end_binding.BinaryService', new=BinaryServiceMock)
+    def test_file_diff_task(self):
+
+        result = self.frontend.get_file_diff(('uid1', 'uid2'))
+        assert result is None, 'should be None because of timeout'
+
+        self.backend = InterComBackEndFileDiffTask(config=self.config)
+        task = self.backend.get_next_task()
+        assert task == ('uid1', 'uid2'), 'task not correct'
+        result = self.frontend.get_file_diff(('uid1', 'uid2'))
+        expected_diff = '--- file_name_1\n+++ file_name_2\n@@ -1 +1 @@\n-binary content 1+binary content 2'
+        assert result == expected_diff, 'file diff not correct'
 
     @mock.patch('intercom.front_end_binding.generate_task_id')
     @mock.patch('intercom.back_end_binding.BinaryService')

--- a/src/test/unit/web_interface/test_app_comparison_text_files.py
+++ b/src/test/unit/web_interface/test_app_comparison_text_files.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from test.common_helper import (
     TEST_TEXT_FILE,
     TEST_TEXT_FILE2,
@@ -10,11 +12,9 @@ from test.unit.web_interface.base import WebInterfaceTest
 
 class MockInterCom(CommonIntercomMock):
     @staticmethod
-    def get_binary_and_filename(uid: str):
-        if uid == TEST_TEXT_FILE.uid:
-            return b'file content\nfirst', TEST_TEXT_FILE.file_name
-        if uid == TEST_TEXT_FILE2.uid:
-            return b'file content\nsecond', TEST_TEXT_FILE2.file_name
+    def get_file_diff(uid_pair: tuple[str, str]) -> str | None:
+        if TEST_TEXT_FILE.uid in uid_pair:
+            return f'file diff {TEST_TEXT_FILE.file_name}'
         assert False, 'if this point was reached, something went wrong'
 
 

--- a/src/web_interface/components/compare_routes.py
+++ b/src/web_interface/components/compare_routes.py
@@ -194,7 +194,6 @@ class CompareRoutes(ComponentBase):
             diff_str = intercom.get_file_diff((uid_1, uid_2))
         if diff_str is None:
             return render_template('compare/error.html', error='File(s) not found.')
-        diff_str = diff_str.replace('\\', '\\\\').replace('`', '\\`').replace('${', '\\$\\{')
 
         return render_template(
             'compare/text_files.html', diffstr=diff_str, hid0=diff_files[0].fw_hid, hid1=diff_files[1].fw_hid

--- a/src/web_interface/components/compare_routes.py
+++ b/src/web_interface/components/compare_routes.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import difflib
 import logging
 from contextlib import suppress
 from typing import NamedTuple, Optional
@@ -24,8 +23,6 @@ from web_interface.security.privileges import PRIVILEGES
 
 class FileDiffData(NamedTuple):
     uid: str
-    content: str
-    file_name: str
     mime: str
     fw_hid: str
 
@@ -167,6 +164,7 @@ class CompareRoutes(ComponentBase):
             )
         (uid_1, root_uid_1), (uid_2, root_uid_2) = list(uids_dict.items())
         uids_dict.clear()
+        session.modified = True  # pylint: disable=assigning-non-slot
         return redirect(
             url_for('compare_text_files', uid_1=uid_1, uid_2=uid_2, root_uid_1=root_uid_1, root_uid_2=root_uid_2)
         )
@@ -192,34 +190,24 @@ class CompareRoutes(ComponentBase):
                 error=f'Can\'t compare non-text mimetypes. ({diff_files[0].mime} vs {diff_files[1].mime})',
             )
 
-        diffstr = self._get_file_diff(*diff_files)
+        with ConnectTo(self.intercom, self._config) as intercom:
+            diff_str = intercom.get_file_diff((uid_1, uid_2))
+        if diff_str is None:
+            return render_template('compare/error.html', error='File(s) not found.')
+        diff_str = diff_str.replace('\\', '\\\\').replace('`', '\\`').replace('${', '\\$\\{')
 
-        session.modified = True  # pylint: disable=assigning-non-slot
         return render_template(
-            'compare/text_files.html', diffstr=diffstr, hid0=diff_files[0].fw_hid, hid1=diff_files[1].fw_hid
+            'compare/text_files.html', diffstr=diff_str, hid0=diff_files[0].fw_hid, hid1=diff_files[1].fw_hid
         )
-
-    @staticmethod
-    def _get_file_diff(file1: FileDiffData, file2: FileDiffData) -> str:
-        diff_list = difflib.unified_diff(
-            file1.content.splitlines(keepends=True),
-            file2.content.splitlines(keepends=True),
-            fromfile=f'{file1.file_name}',
-            tofile=f'{file2.file_name}',
-        )
-        return ''.join(diff_list)
 
     def _get_data_for_file_diff(self, uid: str, root_uid: Optional[str]) -> FileDiffData:
-        with ConnectTo(self.intercom, self._config) as intercom:
-            content, _ = intercom.get_binary_and_filename(uid)
-
         with get_shared_session(self.db.frontend) as frontend_db:
             fo = frontend_db.get_object(uid)
             if root_uid in [None, 'None']:
                 root_uid = fo.get_root_uid()
             fw_hid = frontend_db.get_object(root_uid).get_hid()
         mime = fo.processed_analysis.get('file_type', {}).get('mime')
-        return FileDiffData(uid, content.decode(errors='replace'), fo.file_name, mime, fw_hid)
+        return FileDiffData(uid, mime, fw_hid)
 
 
 def _get_compare_view(plugin_views):

--- a/src/web_interface/templates/compare/text_files.html
+++ b/src/web_interface/templates/compare/text_files.html
@@ -21,7 +21,7 @@
 <script>
 document.addEventListener('DOMContentLoaded', () => {
     // This string is made safe by the python code rendering this template
-    const diffString = $('<textarea />').html(`{{ diffstr }}`).text();
+    const diffString = {{ diffstr | tojson }};
     const targetElement = document.getElementById('diff-element');
     const configuration = {
         drawFileList: false,

--- a/src/web_interface/templates/compare/text_files.html
+++ b/src/web_interface/templates/compare/text_files.html
@@ -20,7 +20,6 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', () => {
-    // This string is made safe by the python code rendering this template
     const diffString = {{ diffstr | tojson }};
     const targetElement = document.getElementById('diff-element');
     const configuration = {


### PR DESCRIPTION
- moved file_diff functionality from the frontend to the backend (where the files are located)
    - this way only one intercom task is needed instead of two and also less data is transmitted (the diff string instead of the contents of the two files)
    - added intercom listener for that
-  adjusted intercom response poll delay to stop wasting lots of time
- file_diff load times should be a lot faster (at least twice as fast)
- fixed and added tests
- added escape for three elements that caused errors in the file_diff template:
    - str format variables (`${var}`)
    - backslashes
    - backticks