### PR TITLE
App wrapper setup bugfix

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import configparser
 from configparser import ConfigParser
 from pathlib import Path
@@ -120,8 +122,8 @@ def _parse_dict(sections):
     """
     Parses the section of the config file given as a dictionary.
     The following things are parsed:
-        * Entrys whose value is an empty string just are removed.
-        * Comma separeted lists are changed to actual lists.
+        * Entries whose value is an empty string just are removed.
+        * Comma separated lists are changed to actual lists.
     """
     # hyphens may not be contained in identifiers
     # plugin names may also not contain hyphens, so this is fine
@@ -147,7 +149,7 @@ def _parse_dict(sections):
                 sections[section_name].pop(entry)
 
 
-def load(path=None):
+def load(path: str | None = None):
     # pylint: disable=global-statement
     """Load the config file located at ``path``.
     The file must be an ini file and is read into an `config.Config` instance.

--- a/src/fact_base.py
+++ b/src/fact_base.py
@@ -42,7 +42,7 @@ class FactBase:
             signal.signal(signal.SIGINT, self.shutdown_listener)
             signal.signal(signal.SIGTERM, self.shutdown_listener)
 
-        self.args, _ = program_setup(self.PROGRAM_NAME, self.PROGRAM_DESCRIPTION, self.COMPONENT)
+        self.args = program_setup(self.PROGRAM_NAME, self.PROGRAM_DESCRIPTION, self.COMPONENT)
         self.work_load_stat = WorkLoadStatistic(component=self.COMPONENT)
 
     def shutdown_listener(self, signum, _):

--- a/src/flask_app_wrapper.py
+++ b/src/flask_app_wrapper.py
@@ -17,13 +17,13 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-import configparser
 import logging
 import pickle
 import sys
 from pathlib import Path
 
-from helperFunctions.program_setup import setup_logging
+import config
+from helperFunctions.program_setup import set_logging_cfg_from_args, setup_logging
 from web_interface.frontend_main import WebFrontEnd
 
 
@@ -33,23 +33,15 @@ def _get_console_output_level(debug_flag):
     return logging.INFO
 
 
-def _load_config(args):
-    config = configparser.ConfigParser()
-    config.read(args.config_file)
-    if args.log_file is not None:
-        config['logging']['logfile'] = args.log_file
-    if args.log_level is not None:
-        config['logging']['loglevel'] = args.log_level
-    return config
-
-
 def create_web_interface():
     args_path = Path(sys.argv[-1])
+    args = None
     if args_path.is_file():
         args = pickle.loads(args_path.read_bytes())
-        config = _load_config(args)
-        setup_logging(config, args, component='frontend')
-        return WebFrontEnd(config=config)
+        config_file = getattr(args, 'config_file', None)
+        config.load(config_file)
+        set_logging_cfg_from_args(args)
+    setup_logging(args, component='frontend')
     return WebFrontEnd()
 
 

--- a/src/helperFunctions/program_setup.py
+++ b/src/helperFunctions/program_setup.py
@@ -19,7 +19,6 @@
 import argparse
 import logging
 import sys
-from argparse import ArgumentParser
 from pathlib import Path
 
 from common_helper_files import create_dir_for_file
@@ -45,7 +44,7 @@ def program_setup(name, description, component=None, version=__VERSION__, comman
     return args
 
 
-def set_logging_cfg_from_args(args: ArgumentParser):
+def set_logging_cfg_from_args(args: argparse.Namespace):
     """Command line parameters will overwrite values from the config file"""
     if args.log_file is not None:
         cfg.logging.logfile = args.log_file

--- a/src/start_fact.py
+++ b/src/start_fact.py
@@ -98,7 +98,7 @@ signal.signal(signal.SIGTERM, shutdown)
 if __name__ == '__main__':
     process_list = []
     run = True
-    args, _ = program_setup(PROGRAM_NAME, PROGRAM_DESCRIPTION)
+    args = program_setup(PROGRAM_NAME, PROGRAM_DESCRIPTION)
 
     db_process = _start_component('db', args)
     sleep(2)

--- a/src/start_fact.py
+++ b/src/start_fact.py
@@ -16,7 +16,9 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 '''
+from __future__ import annotations
 
+import argparse
 import logging
 import os
 import signal
@@ -39,7 +41,7 @@ PROGRAM_NAME = 'FACT Starter'
 PROGRAM_DESCRIPTION = 'This script starts all installed FACT components'
 
 
-def _evaluate_optional_args(args):
+def _evaluate_optional_args(args: argparse.Namespace):
     optional_args = ''
     if args.debug:
         optional_args += ' -d'
@@ -50,18 +52,15 @@ def _evaluate_optional_args(args):
     return optional_args
 
 
-def _start_component(component, args):
+def _start_component(component: str, args: argparse.Namespace) -> Popen | None:
     script_path = Path(get_src_dir()) / f'../start_fact_{component}'
     if not script_path.exists():
         logging.debug(f'{component} not installed')
         return None
     logging.info(f'starting {component}')
     optional_args = _evaluate_optional_args(args)
-    command = '{} -l {} -L {} -C {} {}'.format(
-        script_path, cfg.logging.logfile, cfg.logging.loglevel, args.config_file, optional_args
-    )
-    p = Popen(split(command))
-    return p
+    command = f'{script_path} -l {cfg.logging.logfile} -L {cfg.logging.loglevel} -C {args.config_file} {optional_args}'
+    return Popen(split(command))
 
 
 def _terminate_process(process: Popen):
@@ -77,9 +76,8 @@ def _terminate_process(process: Popen):
 
 
 def shutdown(*_):
-    global run
     logging.info('shutting down...')
-    run = False
+    fact.run = False
 
 
 def _process_is_running(process: Popen) -> bool:
@@ -95,30 +93,36 @@ def _process_is_running(process: Popen) -> bool:
 signal.signal(signal.SIGINT, shutdown)
 signal.signal(signal.SIGTERM, shutdown)
 
+
+class FactStarter:
+    run = False
+
+    def main(self):
+        self.run = True
+        args = program_setup(PROGRAM_NAME, PROGRAM_DESCRIPTION)
+        db_process = _start_component('db', args)
+        sleep(2)
+        frontend_process = _start_component('frontend', args)
+        backend_process = _start_component('backend', args)
+        sleep(2)
+        if backend_process is not None and not _process_is_running(backend_process):
+            logging.critical('Backend did not start. Shutting down...')
+            self.run = False
+
+        while self.run:
+            sleep(1)
+            if args.testing:
+                break
+
+        logging.debug('shutdown backend')
+        _terminate_process(backend_process)
+        logging.debug('shutdown frontend')
+        _terminate_process(frontend_process)
+        logging.debug('shutdown db')
+        _terminate_process(db_process)
+
+
 if __name__ == '__main__':
-    process_list = []
-    run = True
-    args = program_setup(PROGRAM_NAME, PROGRAM_DESCRIPTION)
-
-    db_process = _start_component('db', args)
-    sleep(2)
-    frontend_process = _start_component('frontend', args)
-    backend_process = _start_component('backend', args)
-    sleep(2)
-    if backend_process is not None and not _process_is_running(backend_process):
-        logging.critical('Backend did not start. Shutting down...')
-        run = False
-
-    while run:
-        sleep(1)
-        if args.testing:
-            break
-
-    logging.debug('shutdown backend')
-    _terminate_process(backend_process)
-    logging.debug('shutdown frontend')
-    _terminate_process(frontend_process)
-    logging.debug('shutdown db')
-    _terminate_process(db_process)
-
-    sys.exit()
+    fact = FactStarter()
+    fact.main()
+    sys.exit(0)

--- a/src/test/unit/helperFunctions/test_program_setup.py
+++ b/src/test/unit/helperFunctions/test_program_setup.py
@@ -2,37 +2,34 @@ import logging
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-import pytest
-
-from helperFunctions.program_setup import _get_console_output_level, program_setup, setup_logging
+from helperFunctions.program_setup import program_setup, set_logging_cfg_from_args, setup_logging
 from test.common_helper import get_test_data_dir  # pylint: disable=wrong-import-order
 
 
 class ArgumentMock:
-
     config_file = get_test_data_dir() + '/load_cfg_test'
-    log_file = '/log/file/path'
     log_level = 'DEBUG'
     silent = False
     debug = False
+
+    def __init__(self, tmp_dir):
+        self.log_file = str(Path(tmp_dir, 'log/file/path'))
 
 
 config_mock = {'logging': {'logfile': '/tmp/fact_test.log', 'loglevel': 'DEBUG'}}
 
 
-@pytest.mark.parametrize('input_data, expected_output', [(True, logging.DEBUG), (False, logging.INFO)])
-def test_get_console_output_level(input_data, expected_output):
-    assert _get_console_output_level(input_data) == expected_output
-
-
 def test_setup_logging():
-    args = ArgumentMock
-    setup_logging(config_mock, args)
-    logger = logging.getLogger('')
-    assert logger.getEffectiveLevel() == logging.DEBUG
+    with TemporaryDirectory() as tmp_dir:
+        args = ArgumentMock(tmp_dir)
+        set_logging_cfg_from_args(args)
+        setup_logging(args)
+        logger = logging.getLogger('')
+        assert logger.getEffectiveLevel() == logging.DEBUG
 
 
-def test_program_setup():
+def test_program_setup(cfg_tuple):
+    cfg, _ = cfg_tuple
     with TemporaryDirectory(prefix='fact_test_') as tmp_dir:
         log_file_path = Path(tmp_dir) / 'folder' / 'log_file'
         options = [
@@ -44,8 +41,8 @@ def test_program_setup():
             '--log_level',
             'DEBUG',
         ]
-        args, config = program_setup('test', 'test description', command_line_options=options)
+        args = program_setup('test', 'test description', command_line_options=options)
         assert args.debug is False
-        assert config['logging']['logfile'] == str(log_file_path)
-        assert config['logging']['loglevel'] == 'DEBUG'
+        assert cfg.logging.logfile == str(log_file_path)
+        assert cfg.logging.loglevel == 'DEBUG'
         assert log_file_path.exists()

--- a/src/update_statistic.py
+++ b/src/update_statistic.py
@@ -29,7 +29,7 @@ PROGRAM_DESCRIPTION = 'Initialize or update FACT statistic'
 def main(command_line_options=None):
     if command_line_options is None:
         command_line_options = sys.argv
-    _, config = program_setup(PROGRAM_NAME, PROGRAM_DESCRIPTION, command_line_options=command_line_options)
+    _ = program_setup(PROGRAM_NAME, PROGRAM_DESCRIPTION, command_line_options=command_line_options)
 
     updater = StatsUpdater()
     updater.update_all_stats()


### PR DESCRIPTION
Fixed a bug that was introduced in #867 that was causing an exception in the flask app wrapper module during startup
```python
Traceback (most recent call last):
  File "flask_app_wrapper.py", line 56, in <module>
    web_interface = create_web_interface()
  File "flask_app_wrapper.py", line 51, in create_web_interface
    setup_logging(config, args, component='frontend')
  File "src/./helperFunctions/program_setup.py", line 89, in setup_logging
    log_file = get_log_file_for_component(component)
  File "src/./helperFunctions/program_setup.py", line 104, in get_log_file_for_component
    log_file = Path(cfg.logging.logfile)
AttributeError: 'NoneType' object has no attribute 'logging'
```

Also refactored the `start_fact.py` script which e.g. used `global`