### PR TITLE
add CLI option to skip radare startup

### DIFF
--- a/src/helperFunctions/program_setup.py
+++ b/src/helperFunctions/program_setup.py
@@ -72,6 +72,7 @@ def _setup_argparser(name, description, command_line_options, version=__VERSION_
     parser.add_argument(
         '-t', '--testing', default=False, action='store_true', help='shutdown system after one iteration'
     )
+    parser.add_argument('--no-radare', default=False, action='store_true', help='don\'t start radare server')
     return parser.parse_args(command_line_options[1:])
 
 

--- a/src/start_fact.py
+++ b/src/start_fact.py
@@ -49,6 +49,8 @@ def _evaluate_optional_args(args: argparse.Namespace):
         optional_args += ' -s'
     if args.testing:
         optional_args += ' -t'
+    if args.no_radare:
+        optional_args += ' --no-radare'
     return optional_args
 
 

--- a/src/start_fact_frontend.py
+++ b/src/start_fact_frontend.py
@@ -64,7 +64,8 @@ class FactFrontend(FactBase):
     def __init__(self):
         super().__init__()
         self.server = None
-        run_cmd_with_logging(f'docker-compose -f {COMPOSE_YAML} up -d')
+        if not self.args.no_radare:
+            run_cmd_with_logging(f'docker-compose -f {COMPOSE_YAML} up -d')
 
     def main(self):
         with tempfile.NamedTemporaryFile() as fp:
@@ -79,7 +80,8 @@ class FactFrontend(FactBase):
         super().shutdown()
         if self.server:
             self.server.shutdown()
-        run_cmd_with_logging(f'docker-compose -f {COMPOSE_YAML} down')
+        if not self.args.no_radare:
+            run_cmd_with_logging(f'docker-compose -f {COMPOSE_YAML} down')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- added CLI option to skip radare startup (so radare web GUI won't be available when using this option)
- if radare is not used, this can free up valuable resources
- during development this can speed up startup and shutdown times of FACT significantly