### PR TITLE
tests: Introduce AnalysisPluginTestConfig

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,8 +3,6 @@ addopts = -v
 norecursedirs = */cwe_checker/internal/*
 
 markers =
-    AnalysisPluginClass: Set the Class of the analysis_plugin fixture
-    plugin_init_kwargs: Keyword arguments to pass to AnalysisPluginClass
-    plugin_start_worker: Whether or not to start actual workers
+    AnalysisPluginTestConfig: Configure the analysis_plugin fixture
     cfg_defaults: Overwrite defaults for the testing config
     WebInterfaceUnitTestConfig: Configure the web_interface fixture

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -206,11 +206,9 @@ def analysis_plugin(request, monkeypatch, patch_cfg):
         .. code-block::
 
             @pytest.mark.AnalysisPluginTestConfig(
-                AnalysisPluginTestConfig(
-                    plugin_class=MyFancyPlugin,
-                    # Actually don't start the processes in the fixture
-                    start_processes = False,
-                ),
+                plugin_class=MyFancyPlugin,
+                # Actually don't start the processes in the fixture
+                start_processes=False,
             )
             def my_fancy_test(analysis_plugin, monkeypatch):
                 # Undo the patching of MyFancyPlugin.start_worker

--- a/src/plugins/analysis/binwalk/test/test_plugin_binwalk.py
+++ b/src/plugins/analysis/binwalk/test/test_plugin_binwalk.py
@@ -19,7 +19,7 @@ DECIMAL       HEXADECIMAL     DESCRIPTION
 '''
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestPluginBinwalk:
     def test_signature_analysis(self, analysis_plugin):
         test_file = FileObject(file_path=f'{get_test_data_dir()}/container/test.zip')

--- a/src/plugins/analysis/binwalk/test/test_plugin_binwalk.py
+++ b/src/plugins/analysis/binwalk/test/test_plugin_binwalk.py
@@ -19,7 +19,7 @@ DECIMAL       HEXADECIMAL     DESCRIPTION
 '''
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestPluginBinwalk:
     def test_signature_analysis(self, analysis_plugin):
         test_file = FileObject(file_path=f'{get_test_data_dir()}/container/test.zip')

--- a/src/plugins/analysis/checksec/test/test_plugin_checksec.py
+++ b/src/plugins/analysis/checksec/test/test_plugin_checksec.py
@@ -33,7 +33,7 @@ FILE_PATH_EXE_RPATH = PLUGIN_DIR / 'test/data/Hallo_rpath'
 FILE_PATH_EXE_STRIPPED = PLUGIN_DIR / 'test/data/Hallo_stripped'
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 def test_check_mitigations(analysis_plugin):
     test_file = FileObject(file_path=str(FILE_PATH_EXE))
     test_file.processed_analysis['file_type'] = {'full': 'ELF 64-bit LSB shared object, x86-64, dynamically linked'}

--- a/src/plugins/analysis/checksec/test/test_plugin_checksec.py
+++ b/src/plugins/analysis/checksec/test/test_plugin_checksec.py
@@ -33,7 +33,7 @@ FILE_PATH_EXE_RPATH = PLUGIN_DIR / 'test/data/Hallo_rpath'
 FILE_PATH_EXE_STRIPPED = PLUGIN_DIR / 'test/data/Hallo_stripped'
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 def test_check_mitigations(analysis_plugin):
     test_file = FileObject(file_path=str(FILE_PATH_EXE))
     test_file.processed_analysis['file_type'] = {'full': 'ELF 64-bit LSB shared object, x86-64, dynamically linked'}

--- a/src/plugins/analysis/crypto_hints/test/test_crypto_hints.py
+++ b/src/plugins/analysis/crypto_hints/test/test_crypto_hints.py
@@ -9,7 +9,7 @@ from ..code.crypto_hints import AnalysisPlugin
 TEST_DATA_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 def test_additional_rules(analysis_plugin):
     test_file = FileObject(file_path=str(TEST_DATA_DIR / 'additional_rules_test_file'))
     processed_file = analysis_plugin.process_object(test_file)
@@ -25,7 +25,7 @@ def test_additional_rules(analysis_plugin):
         assert rule in result
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 def test_basic_scan_feature(analysis_plugin):
     test_file = FileObject(file_path=str(TEST_DATA_DIR / 'CRC32_table'))
     processed_file = analysis_plugin.process_object(test_file)

--- a/src/plugins/analysis/crypto_hints/test/test_crypto_hints.py
+++ b/src/plugins/analysis/crypto_hints/test/test_crypto_hints.py
@@ -9,7 +9,7 @@ from ..code.crypto_hints import AnalysisPlugin
 TEST_DATA_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 def test_additional_rules(analysis_plugin):
     test_file = FileObject(file_path=str(TEST_DATA_DIR / 'additional_rules_test_file'))
     processed_file = analysis_plugin.process_object(test_file)
@@ -25,7 +25,7 @@ def test_additional_rules(analysis_plugin):
         assert rule in result
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 def test_basic_scan_feature(analysis_plugin):
     test_file = FileObject(file_path=str(TEST_DATA_DIR / 'CRC32_table'))
     processed_file = analysis_plugin.process_object(test_file)

--- a/src/plugins/analysis/crypto_material/test/test_plugin_crypto_material.py
+++ b/src/plugins/analysis/crypto_material/test/test_plugin_crypto_material.py
@@ -24,7 +24,7 @@ def _rule_match(analysis_plugin, filename, expected_rule_name, expected_number_o
         ), f'Expected rule {expected_rule_name} missing'
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestCryptoMaterial:
     # pylint:disable=no-self-use
     def test_gnupg(self, analysis_plugin):

--- a/src/plugins/analysis/crypto_material/test/test_plugin_crypto_material.py
+++ b/src/plugins/analysis/crypto_material/test/test_plugin_crypto_material.py
@@ -24,7 +24,7 @@ def _rule_match(analysis_plugin, filename, expected_rule_name, expected_number_o
         ), f'Expected rule {expected_rule_name} missing'
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestCryptoMaterial:
     # pylint:disable=no-self-use
     def test_gnupg(self, analysis_plugin):

--- a/src/plugins/analysis/cve_lookup/test/test_cve_lookup.py
+++ b/src/plugins/analysis/cve_lookup/test/test_cve_lookup.py
@@ -214,7 +214,7 @@ def test_search_cve_summary(monkeypatch):
         assert MATCHED_SUMMARY == actual_match
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestCveLookup:
     def test_process_object(self, analysis_plugin):
         TEST_FW.processed_analysis['software_components'] = SOFTWARE_COMPONENTS_ANALYSIS_RESULT

--- a/src/plugins/analysis/cve_lookup/test/test_cve_lookup.py
+++ b/src/plugins/analysis/cve_lookup/test/test_cve_lookup.py
@@ -214,7 +214,7 @@ def test_search_cve_summary(monkeypatch):
         assert MATCHED_SUMMARY == actual_match
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestCveLookup:
     def test_process_object(self, analysis_plugin):
         TEST_FW.processed_analysis['software_components'] = SOFTWARE_COMPONENTS_ANALYSIS_RESULT

--- a/src/plugins/analysis/cwe_checker/test/test_cwe_checker.py
+++ b/src/plugins/analysis/cwe_checker/test/test_cwe_checker.py
@@ -5,7 +5,7 @@ from objects.file import FileObject
 from ..code.cwe_checker import AnalysisPlugin
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestCweCheckerFunctions:
     def test_parse_cwe_checker_output(self, analysis_plugin):
         test_data = """[

--- a/src/plugins/analysis/cwe_checker/test/test_cwe_checker.py
+++ b/src/plugins/analysis/cwe_checker/test/test_cwe_checker.py
@@ -5,7 +5,7 @@ from objects.file import FileObject
 from ..code.cwe_checker import AnalysisPlugin
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestCweCheckerFunctions:
     def test_parse_cwe_checker_output(self, analysis_plugin):
         test_data = """[

--- a/src/plugins/analysis/device_tree/test/test_device_tree.py
+++ b/src/plugins/analysis/device_tree/test/test_device_tree.py
@@ -15,7 +15,7 @@ TEST_FP = TEST_DATA / 'false_positive.rnd'
 TEST_BROKEN = TEST_DATA / 'broken.dtb'
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 def test_process_object(analysis_plugin):
     test_object = FileObject()
     test_object.processed_analysis['file_type'] = {'mime': 'linux/device-tree'}

--- a/src/plugins/analysis/device_tree/test/test_device_tree.py
+++ b/src/plugins/analysis/device_tree/test/test_device_tree.py
@@ -15,7 +15,7 @@ TEST_FP = TEST_DATA / 'false_positive.rnd'
 TEST_BROKEN = TEST_DATA / 'broken.dtb'
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 def test_process_object(analysis_plugin):
     test_object = FileObject()
     test_object.processed_analysis['file_type'] = {'mime': 'linux/device-tree'}

--- a/src/plugins/analysis/elf_analysis/test/test_plugin_elf_analysis.py
+++ b/src/plugins/analysis/elf_analysis/test/test_plugin_elf_analysis.py
@@ -44,7 +44,7 @@ def stub_object():
     return test_object
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestElfAnalysis:
     @pytest.mark.parametrize(
         'tag, tag_color',

--- a/src/plugins/analysis/elf_analysis/test/test_plugin_elf_analysis.py
+++ b/src/plugins/analysis/elf_analysis/test/test_plugin_elf_analysis.py
@@ -44,7 +44,7 @@ def stub_object():
     return test_object
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestElfAnalysis:
     @pytest.mark.parametrize(
         'tag, tag_color',

--- a/src/plugins/analysis/file_system_metadata/test/test_plugin_file_system_metadata.py
+++ b/src/plugins/analysis/file_system_metadata/test/test_plugin_file_system_metadata.py
@@ -58,7 +58,7 @@ def file_system_metadata_plugin(analysis_plugin):
     yield analysis_plugin
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestFileSystemMetadata:
     test_file_tar = TEST_DATA_DIR / 'test.tar'
     test_file_fs = TEST_DATA_DIR / 'squashfs.img'

--- a/src/plugins/analysis/file_system_metadata/test/test_plugin_file_system_metadata.py
+++ b/src/plugins/analysis/file_system_metadata/test/test_plugin_file_system_metadata.py
@@ -58,7 +58,7 @@ def file_system_metadata_plugin(analysis_plugin):
     yield analysis_plugin
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestFileSystemMetadata:
     test_file_tar = TEST_DATA_DIR / 'test.tar'
     test_file_fs = TEST_DATA_DIR / 'squashfs.img'

--- a/src/plugins/analysis/file_type/test/test_plugin_file_type.py
+++ b/src/plugins/analysis/file_type/test/test_plugin_file_type.py
@@ -6,7 +6,7 @@ from test.common_helper import get_test_data_dir  # pylint: disable=wrong-import
 from ..code.file_type import AnalysisPlugin
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 def test_detect_type_of_file(analysis_plugin):
     test_file = FileObject(file_path=f'{get_test_data_dir()}/container/test.zip')
     test_file = analysis_plugin.process_object(test_file)

--- a/src/plugins/analysis/file_type/test/test_plugin_file_type.py
+++ b/src/plugins/analysis/file_type/test/test_plugin_file_type.py
@@ -6,7 +6,7 @@ from test.common_helper import get_test_data_dir  # pylint: disable=wrong-import
 from ..code.file_type import AnalysisPlugin
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 def test_detect_type_of_file(analysis_plugin):
     test_file = FileObject(file_path=f'{get_test_data_dir()}/container/test.zip')
     test_file = analysis_plugin.process_object(test_file)

--- a/src/plugins/analysis/hardware_analysis/test/test_hardware_analysis.py
+++ b/src/plugins/analysis/hardware_analysis/test/test_hardware_analysis.py
@@ -10,7 +10,7 @@ from ..code.hardware_analysis import AnalysisPlugin
 TEST_DATA = Path(get_test_data_dir())
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestHardwareAnalysis:
     def test_cpu_architecture_found(self, analysis_plugin):
         test_object = FileObject()

--- a/src/plugins/analysis/hardware_analysis/test/test_hardware_analysis.py
+++ b/src/plugins/analysis/hardware_analysis/test/test_hardware_analysis.py
@@ -10,7 +10,7 @@ from ..code.hardware_analysis import AnalysisPlugin
 TEST_DATA = Path(get_test_data_dir())
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestHardwareAnalysis:
     def test_cpu_architecture_found(self, analysis_plugin):
         test_object = FileObject()

--- a/src/plugins/analysis/hash/test/test_plugin_hash.py
+++ b/src/plugins/analysis/hash/test/test_plugin_hash.py
@@ -17,7 +17,7 @@ TEST_DATA_DIR = os.path.join(get_dir_of_file(__file__), 'data')
         }
     },
 )
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestAnalysisPluginHash:
     def test_all_hashes(self, analysis_plugin):
         result = analysis_plugin.process_object(MockFileObject()).processed_analysis[analysis_plugin.NAME]

--- a/src/plugins/analysis/hash/test/test_plugin_hash.py
+++ b/src/plugins/analysis/hash/test/test_plugin_hash.py
@@ -17,7 +17,7 @@ TEST_DATA_DIR = os.path.join(get_dir_of_file(__file__), 'data')
         }
     },
 )
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestAnalysisPluginHash:
     def test_all_hashes(self, analysis_plugin):
         result = analysis_plugin.process_object(MockFileObject()).processed_analysis[analysis_plugin.NAME]

--- a/src/plugins/analysis/hashlookup/test/test_hashlookup.py
+++ b/src/plugins/analysis/hashlookup/test/test_hashlookup.py
@@ -15,7 +15,7 @@ def file_object(monkeypatch):
     return test_file
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestHashlookup:
     def test_process_object_unknown_hash(self, analysis_plugin, file_object):
         file_object.processed_analysis['file_hashes'] = {'sha256': file_object.sha256}

--- a/src/plugins/analysis/hashlookup/test/test_hashlookup.py
+++ b/src/plugins/analysis/hashlookup/test/test_hashlookup.py
@@ -15,7 +15,7 @@ def file_object(monkeypatch):
     return test_file
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestHashlookup:
     def test_process_object_unknown_hash(self, analysis_plugin, file_object):
         file_object.processed_analysis['file_hashes'] = {'sha256': file_object.sha256}

--- a/src/plugins/analysis/information_leaks/test/test_plugin_information_leaks.py
+++ b/src/plugins/analysis/information_leaks/test/test_plugin_information_leaks.py
@@ -9,7 +9,7 @@ from ..code.information_leaks import AnalysisPlugin, _check_file_path, _check_fo
 TEST_DATA_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestAnalysisPluginInformationLeaks:
     def test_find_path(self, analysis_plugin):
         fo = MockFileObject()

--- a/src/plugins/analysis/information_leaks/test/test_plugin_information_leaks.py
+++ b/src/plugins/analysis/information_leaks/test/test_plugin_information_leaks.py
@@ -9,7 +9,7 @@ from ..code.information_leaks import AnalysisPlugin, _check_file_path, _check_fo
 TEST_DATA_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestAnalysisPluginInformationLeaks:
     def test_find_path(self, analysis_plugin):
         fo = MockFileObject()

--- a/src/plugins/analysis/init_systems/test/test_plugin_init_system.py
+++ b/src/plugins/analysis/init_systems/test/test_plugin_init_system.py
@@ -20,7 +20,7 @@ def _get_fo(path):
     return fo
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestAnalysisPluginInit:
     test_file_not_text = FileObject(file_path=f'{_test_init_dir}etc/systemd/system/foobar')
     test_file_not_text.processed_analysis['file_type'] = {'mime': 'application/zip'}

--- a/src/plugins/analysis/init_systems/test/test_plugin_init_system.py
+++ b/src/plugins/analysis/init_systems/test/test_plugin_init_system.py
@@ -20,7 +20,7 @@ def _get_fo(path):
     return fo
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestAnalysisPluginInit:
     test_file_not_text = FileObject(file_path=f'{_test_init_dir}etc/systemd/system/foobar')
     test_file_not_text.processed_analysis['file_type'] = {'mime': 'application/zip'}

--- a/src/plugins/analysis/input_vectors/test/test_input_vectors.py
+++ b/src/plugins/analysis/input_vectors/test/test_input_vectors.py
@@ -9,7 +9,7 @@ from ..code.input_vectors import AnalysisPlugin
 TEST_FILE_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class AnalysisPluginTestInputVectors:
     def test_process_object_inputs(self, analysis_plugin):
         result = self.assert_process_object(analysis_plugin, 'test_fgets.elf')

--- a/src/plugins/analysis/input_vectors/test/test_input_vectors.py
+++ b/src/plugins/analysis/input_vectors/test/test_input_vectors.py
@@ -9,7 +9,7 @@ from ..code.input_vectors import AnalysisPlugin
 TEST_FILE_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class AnalysisPluginTestInputVectors:
     def test_process_object_inputs(self, analysis_plugin):
         result = self.assert_process_object(analysis_plugin, 'test_fgets.elf')

--- a/src/plugins/analysis/interesting_uris/test/test_interesting_uris.py
+++ b/src/plugins/analysis/interesting_uris/test/test_interesting_uris.py
@@ -32,7 +32,7 @@ def test_white_ip_and_uris(input_list, whitelist, expected_output):
     assert sorted(AnalysisPlugin.whitelist_ip_and_uris(whitelist, input_list)) == expected_output
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestAnalysisPluginInterestingUris:
     def test_process_object(self, analysis_plugin):
         fo = create_test_file_object()

--- a/src/plugins/analysis/interesting_uris/test/test_interesting_uris.py
+++ b/src/plugins/analysis/interesting_uris/test/test_interesting_uris.py
@@ -32,7 +32,7 @@ def test_white_ip_and_uris(input_list, whitelist, expected_output):
     assert sorted(AnalysisPlugin.whitelist_ip_and_uris(whitelist, input_list)) == expected_output
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestAnalysisPluginInterestingUris:
     def test_process_object(self, analysis_plugin):
         fo = create_test_file_object()

--- a/src/plugins/analysis/ip_and_uri_finder/test/test_ip_and_uri_finder.py
+++ b/src/plugins/analysis/ip_and_uri_finder/test/test_ip_and_uri_finder.py
@@ -48,7 +48,7 @@ def ip_and_uri_finder_plugin(analysis_plugin):
     yield analysis_plugin
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestAnalysisPluginIpAndUriFinder:
     def test_process_object_ips(self, ip_and_uri_finder_plugin):
         with tempfile.NamedTemporaryFile() as tmp:

--- a/src/plugins/analysis/ip_and_uri_finder/test/test_ip_and_uri_finder.py
+++ b/src/plugins/analysis/ip_and_uri_finder/test/test_ip_and_uri_finder.py
@@ -48,7 +48,7 @@ def ip_and_uri_finder_plugin(analysis_plugin):
     yield analysis_plugin
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestAnalysisPluginIpAndUriFinder:
     def test_process_object_ips(self, ip_and_uri_finder_plugin):
         with tempfile.NamedTemporaryFile() as tmp:

--- a/src/plugins/analysis/ipc/test/test_ipc_analyzer.py
+++ b/src/plugins/analysis/ipc/test/test_ipc_analyzer.py
@@ -9,7 +9,7 @@ from ..code.ipc_analyzer import AnalysisPlugin
 TEST_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestAnalysisPluginIpcAnalyzer:
     def test_ipc_system(self, analysis_plugin):
         expected_result = {

--- a/src/plugins/analysis/ipc/test/test_ipc_analyzer.py
+++ b/src/plugins/analysis/ipc/test/test_ipc_analyzer.py
@@ -9,7 +9,7 @@ from ..code.ipc_analyzer import AnalysisPlugin
 TEST_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestAnalysisPluginIpcAnalyzer:
     def test_ipc_system(self, analysis_plugin):
         expected_result = {

--- a/src/plugins/analysis/kernel_config/test/test_kernel_config.py
+++ b/src/plugins/analysis/kernel_config/test/test_kernel_config.py
@@ -24,7 +24,7 @@ except ImportError:
 TEST_DATA_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class ExtractIKConfigTest:
     def test_probably_kernel_config_true(self, analysis_plugin):
         test_file = FileObject(file_path=str(TEST_DATA_DIR / 'configs/CONFIG'))

--- a/src/plugins/analysis/kernel_config/test/test_kernel_config.py
+++ b/src/plugins/analysis/kernel_config/test/test_kernel_config.py
@@ -24,7 +24,7 @@ except ImportError:
 TEST_DATA_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class ExtractIKConfigTest:
     def test_probably_kernel_config_true(self, analysis_plugin):
         test_file = FileObject(file_path=str(TEST_DATA_DIR / 'configs/CONFIG'))

--- a/src/plugins/analysis/known_vulnerabilities/test/test_known_vulnerabilities.py
+++ b/src/plugins/analysis/known_vulnerabilities/test/test_known_vulnerabilities.py
@@ -11,7 +11,7 @@ from plugins.analysis.known_vulnerabilities.code.known_vulnerabilities import An
 TEST_DATA_DIR = os.path.join(get_dir_of_file(__file__), 'data')
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestAnalysisPluginsKnownVulnerabilities:
     _software_components_result = json.loads((Path(TEST_DATA_DIR) / 'sc.json').read_text())
 

--- a/src/plugins/analysis/known_vulnerabilities/test/test_known_vulnerabilities.py
+++ b/src/plugins/analysis/known_vulnerabilities/test/test_known_vulnerabilities.py
@@ -11,7 +11,7 @@ from plugins.analysis.known_vulnerabilities.code.known_vulnerabilities import An
 TEST_DATA_DIR = os.path.join(get_dir_of_file(__file__), 'data')
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestAnalysisPluginsKnownVulnerabilities:
     _software_components_result = json.loads((Path(TEST_DATA_DIR) / 'sc.json').read_text())
 

--- a/src/plugins/analysis/linter/test/test_source_code_analysis.py
+++ b/src/plugins/analysis/linter/test/test_source_code_analysis.py
@@ -16,7 +16,7 @@ def test_object():
     return create_test_file_object()
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestSourceCodeAnalysis:
     def test_process_object_not_supported(self, analysis_plugin, test_object, monkeypatch):
         monkeypatch.setattr(

--- a/src/plugins/analysis/linter/test/test_source_code_analysis.py
+++ b/src/plugins/analysis/linter/test/test_source_code_analysis.py
@@ -16,7 +16,7 @@ def test_object():
     return create_test_file_object()
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestSourceCodeAnalysis:
     def test_process_object_not_supported(self, analysis_plugin, test_object, monkeypatch):
         monkeypatch.setattr(

--- a/src/plugins/analysis/qemu_exec/test/test_plugin_qemu_exec.py
+++ b/src/plugins/analysis/qemu_exec/test/test_plugin_qemu_exec.py
@@ -10,6 +10,7 @@ from common_helper_files import get_dir_of_file
 from requests.exceptions import ConnectionError as RequestConnectionError
 from requests.exceptions import ReadTimeout
 
+from conftest import AnalysisPluginTestConfig
 from test.common_helper import TEST_FW, create_test_firmware, get_test_data_dir
 from test.mock import mock_patch
 
@@ -83,8 +84,12 @@ def execute_docker_error(monkeypatch):
     monkeypatch.setattr('docker.client.from_env', DockerClientMock)
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
-@pytest.mark.plugin_init_kwargs(unpacker=MockUnpacker())
+@pytest.mark.AnalysisPluginTestConfig(
+    AnalysisPluginTestConfig(
+        plugin_class=AnalysisPlugin,
+        init_kwargs={'unpacker': MockUnpacker()},
+    ),
+)
 class TestPluginQemuExec:
     def test_has_relevant_type(self, analysis_plugin):
         assert analysis_plugin._has_relevant_type(None) is False

--- a/src/plugins/analysis/qemu_exec/test/test_plugin_qemu_exec.py
+++ b/src/plugins/analysis/qemu_exec/test/test_plugin_qemu_exec.py
@@ -10,7 +10,6 @@ from common_helper_files import get_dir_of_file
 from requests.exceptions import ConnectionError as RequestConnectionError
 from requests.exceptions import ReadTimeout
 
-from conftest import AnalysisPluginTestConfig
 from test.common_helper import TEST_FW, create_test_firmware, get_test_data_dir
 from test.mock import mock_patch
 
@@ -85,10 +84,8 @@ def execute_docker_error(monkeypatch):
 
 
 @pytest.mark.AnalysisPluginTestConfig(
-    AnalysisPluginTestConfig(
-        plugin_class=AnalysisPlugin,
-        init_kwargs={'unpacker': MockUnpacker()},
-    ),
+    plugin_class=AnalysisPlugin,
+    init_kwargs={'unpacker': MockUnpacker()},
 )
 class TestPluginQemuExec:
     def test_has_relevant_type(self, analysis_plugin):

--- a/src/plugins/analysis/software_components/test/test_plugin_software_components.py
+++ b/src/plugins/analysis/software_components/test/test_plugin_software_components.py
@@ -10,7 +10,7 @@ from ..code.software_components import AnalysisPlugin
 TEST_DATA_DIR = os.path.join(get_dir_of_file(__file__), 'data')
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestAnalysisPluginsSoftwareComponents:
     def test_process_object(self, analysis_plugin):
         test_file = FileObject(file_path=os.path.join(TEST_DATA_DIR, 'yara_test_file'))

--- a/src/plugins/analysis/software_components/test/test_plugin_software_components.py
+++ b/src/plugins/analysis/software_components/test/test_plugin_software_components.py
@@ -10,7 +10,7 @@ from ..code.software_components import AnalysisPlugin
 TEST_DATA_DIR = os.path.join(get_dir_of_file(__file__), 'data')
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestAnalysisPluginsSoftwareComponents:
     def test_process_object(self, analysis_plugin):
         test_file = FileObject(file_path=os.path.join(TEST_DATA_DIR, 'yara_test_file'))

--- a/src/plugins/analysis/string_evaluation/test/test_plugin.py
+++ b/src/plugins/analysis/string_evaluation/test/test_plugin.py
@@ -5,7 +5,7 @@ from test.common_helper import create_test_file_object
 from ..code.string_eval import AnalysisPlugin
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 def test_find_strings(analysis_plugin):
     fo = create_test_file_object()
     fo.processed_analysis['printable_strings'] = dict(

--- a/src/plugins/analysis/string_evaluation/test/test_plugin.py
+++ b/src/plugins/analysis/string_evaluation/test/test_plugin.py
@@ -5,7 +5,7 @@ from test.common_helper import create_test_file_object
 from ..code.string_eval import AnalysisPlugin
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 def test_find_strings(analysis_plugin):
     fo = create_test_file_object()
     fo.processed_analysis['printable_strings'] = dict(

--- a/src/plugins/analysis/strings/test/test_plugin_strings.py
+++ b/src/plugins/analysis/strings/test/test_plugin_strings.py
@@ -18,7 +18,7 @@ TEST_DATA_DIR = os.path.join(get_dir_of_file(__file__), 'data')
         }
     },
 )
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestAnalysisPlugInPrintableStrings:
     strings = ['first string', 'second<>_$tring!', 'third:?-+012345/\\string']
     offsets = [(3, strings[0]), (21, strings[1]), (61, strings[2])]

--- a/src/plugins/analysis/strings/test/test_plugin_strings.py
+++ b/src/plugins/analysis/strings/test/test_plugin_strings.py
@@ -18,7 +18,7 @@ TEST_DATA_DIR = os.path.join(get_dir_of_file(__file__), 'data')
         }
     },
 )
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestAnalysisPlugInPrintableStrings:
     strings = ['first string', 'second<>_$tring!', 'third:?-+012345/\\string']
     offsets = [(3, strings[0]), (21, strings[1]), (61, strings[2])]

--- a/src/plugins/analysis/tlsh/test/test_plugin_tlsh.py
+++ b/src/plugins/analysis/tlsh/test/test_plugin_tlsh.py
@@ -27,7 +27,7 @@ def tlsh_plugin(analysis_plugin, monkeypatch):
     yield analysis_plugin
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestTlsh:
     def test_one_matching_file(self, tlsh_plugin, test_object):
 

--- a/src/plugins/analysis/tlsh/test/test_plugin_tlsh.py
+++ b/src/plugins/analysis/tlsh/test/test_plugin_tlsh.py
@@ -27,7 +27,7 @@ def tlsh_plugin(analysis_plugin, monkeypatch):
     yield analysis_plugin
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestTlsh:
     def test_one_matching_file(self, tlsh_plugin, test_object):
 

--- a/src/plugins/analysis/users_and_passwords/test/test_plugin_password_file_analyzer.py
+++ b/src/plugins/analysis/users_and_passwords/test/test_plugin_password_file_analyzer.py
@@ -9,7 +9,7 @@ from ..code.password_file_analyzer import AnalysisPlugin, crack_hash, parse_john
 TEST_DATA_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestAnalysisPluginPasswordFileAnalyzer:
     def test_process_object_shadow_file(self, analysis_plugin):
         test_file = FileObject(file_path=str(TEST_DATA_DIR / 'passwd_test'))

--- a/src/plugins/analysis/users_and_passwords/test/test_plugin_password_file_analyzer.py
+++ b/src/plugins/analysis/users_and_passwords/test/test_plugin_password_file_analyzer.py
@@ -9,7 +9,7 @@ from ..code.password_file_analyzer import AnalysisPlugin, crack_hash, parse_john
 TEST_DATA_DIR = Path(__file__).parent / 'data'
 
 
-@pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=AnalysisPlugin))
 class TestAnalysisPluginPasswordFileAnalyzer:
     def test_process_object_shadow_file(self, analysis_plugin):
         test_file = FileObject(file_path=str(TEST_DATA_DIR / 'passwd_test'))

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -6,34 +6,42 @@ import pytest
 from storage.db_setup import DbSetup
 from test.common_helper import clear_test_tables, setup_test_tables
 
-
 T = TypeVar('T')
 
 
 def merge_markers(request, name: str, dtype: Type[T]) -> T:
     """Merge all markers from closest to farthest. Closer markers overwrite markers that are farther away.
 
-    Optionally a dict with keys matching the ones in ``dtype`` can be used.
-    The constructor of ``dtype`` must accept all possible values as kwargs.
+    The marker must either get an instance of ``dtype`` as an argument or have one or more keyword arguments.
+    The keyword arguments must be accepted by the ``dtype.__init__``.``
 
     :param request: The pytest request where the markers will be taken from.
     :param name: The name of the marker.
-    :param dtype: The type that the marker should have. Must be a ``pydantic.dataclasses.dataclass``.
+    :param dtype: The type that the marker should have. Must be a ``pydantic.dataclasses.dataclass`` or ``dict``.
 
     :return: An instance of ``dtype``.
     """
+    _err = ValueError(
+        f'The argument(s) to marker {name} must be either an instance of {dtype} or keyword arguments, not both.'
+    )
     # Not well documented but iter_markers iterates from closest to farthest
     # https://docs.pytest.org/en/7.1.x/reference/reference.html?highlight=iter_markers#custom-marks
     marker_dict = {}
     for marker in reversed(list(request.node.iter_markers(name))):
-        dict_or_dtype = marker.args[0]
-        if isinstance(dict_or_dtype, dict):
-            marker_dict.update(dict_or_dtype)
-        elif isinstance(dict_or_dtype, dtype):
-            marker_dict.update(dataclasses.asdict(dict_or_dtype))
-        else:
-            raise ValueError(f'The argument to marker {name} must be either a dict or an instance of {dtype}.')
+        if marker.kwargs and marker.args:
+            raise _err
 
+        if marker.kwargs:
+            marker_dict.update(marker.kwargs)
+        elif marker.args:
+            argument = marker.args[0]
+            assert isinstance(argument, dtype)
+            if isinstance(argument, dict):
+                marker_dict.update(argument)
+            else:
+                marker_dict.update(dataclasses.asdict(argument))
+        else:
+            raise _err
     return dtype(**marker_dict)
 
 

--- a/src/test/unit/analysis/test_plugin_base.py
+++ b/src/test/unit/analysis/test_plugin_base.py
@@ -53,7 +53,7 @@ class TestPluginBaseCore:
         assert child_object.uid in root_object.files_included, 'child object not in processed file'
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=DummyPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=DummyPlugin)
 class TestPluginBaseAddJob:
     def test_analysis_depth_not_reached_yet(self, analysis_plugin):
         fo = FileObject(binary=b'test', scheduled_analysis=[])
@@ -74,7 +74,7 @@ class TestPluginBaseAddJob:
         analysis_plugin.RECURSIVE = True
         assert analysis_plugin._analysis_depth_not_reached_yet(fo)
 
-    @pytest.mark.AnalysisPluginTestConfig(dict(start_processes=True))
+    @pytest.mark.AnalysisPluginTestConfig(start_processes=True)
     def test__add_job__recursive_is_set(self, analysis_plugin):
         fo = FileObject(binary=b'test', scheduled_analysis=[])
         fo.depth = 1
@@ -131,7 +131,7 @@ class TestPluginNotRunning:
         self.p_base.shutdown()
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=DummyPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=DummyPlugin)
 def test_timeout(analysis_plugin, monkeypatch):
     # See the note in the docs of analysis_pluing fixture for why this is necessary
     monkeypatch.undo()

--- a/src/test/unit/analysis/test_plugin_base.py
+++ b/src/test/unit/analysis/test_plugin_base.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from analysis.PluginBase import AnalysisBasePlugin, PluginInitException
+from conftest import AnalysisPluginTestConfig
 from helperFunctions.fileSystem import get_src_dir
 from objects.file import FileObject
 from plugins.analysis.dummy.code.dummy import AnalysisPlugin as DummyPlugin
@@ -22,8 +23,12 @@ PLUGIN_PATH = Path(get_src_dir()) / 'plugins' / 'analysis'
         },
     }
 )
-@pytest.mark.AnalysisPluginClass.with_args(DummyPlugin)
-@pytest.mark.plugin_start_worker
+@pytest.mark.AnalysisPluginTestConfig(
+    AnalysisPluginTestConfig(
+        plugin_class=DummyPlugin,
+        start_processes=True,
+    ),
+)
 class TestPluginBaseCore:
     def test_object_processing_no_children(self, analysis_plugin):
         root_object = FileObject(binary=b'root_file')
@@ -48,7 +53,7 @@ class TestPluginBaseCore:
         assert child_object.uid in root_object.files_included, 'child object not in processed file'
 
 
-@pytest.mark.AnalysisPluginClass.with_args(DummyPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=DummyPlugin))
 class TestPluginBaseAddJob:
     def test_analysis_depth_not_reached_yet(self, analysis_plugin):
         fo = FileObject(binary=b'test', scheduled_analysis=[])
@@ -69,7 +74,7 @@ class TestPluginBaseAddJob:
         analysis_plugin.RECURSIVE = True
         assert analysis_plugin._analysis_depth_not_reached_yet(fo)
 
-    @pytest.mark.plugin_start_worker
+    @pytest.mark.AnalysisPluginTestConfig(dict(start_processes=True))
     def test__add_job__recursive_is_set(self, analysis_plugin):
         fo = FileObject(binary=b'test', scheduled_analysis=[])
         fo.depth = 1
@@ -126,7 +131,7 @@ class TestPluginNotRunning:
         self.p_base.shutdown()
 
 
-@pytest.mark.AnalysisPluginClass.with_args(DummyPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=DummyPlugin))
 def test_timeout(analysis_plugin, monkeypatch):
     # See the note in the docs of analysis_pluing fixture for why this is necessary
     monkeypatch.undo()

--- a/src/test/unit/analysis/test_plugin_base.py
+++ b/src/test/unit/analysis/test_plugin_base.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytest
 
 from analysis.PluginBase import AnalysisBasePlugin, PluginInitException
-from conftest import AnalysisPluginTestConfig
 from helperFunctions.fileSystem import get_src_dir
 from objects.file import FileObject
 from plugins.analysis.dummy.code.dummy import AnalysisPlugin as DummyPlugin
@@ -24,10 +23,8 @@ PLUGIN_PATH = Path(get_src_dir()) / 'plugins' / 'analysis'
     }
 )
 @pytest.mark.AnalysisPluginTestConfig(
-    AnalysisPluginTestConfig(
-        plugin_class=DummyPlugin,
-        start_processes=True,
-    ),
+    plugin_class=DummyPlugin,
+    start_processes=True,
 )
 class TestPluginBaseCore:
     def test_object_processing_no_children(self, analysis_plugin):

--- a/src/test/unit/analysis/test_yara_plugin_base.py
+++ b/src/test/unit/analysis/test_yara_plugin_base.py
@@ -18,7 +18,7 @@ class YaraPlugin(YaraBasePlugin):
     FILE = '/foo/bar/Yara_Base_Plugin/code/test.py'
 
 
-@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=YaraPlugin))
+@pytest.mark.AnalysisPluginTestConfig(plugin_class=YaraPlugin)
 class TestAnalysisYaraBasePlugin:
     def test_get_signature_paths(self, analysis_plugin):
         intended_signature_path = os.path.join(get_src_dir(), 'analysis/signatures', analysis_plugin.NAME)

--- a/src/test/unit/analysis/test_yara_plugin_base.py
+++ b/src/test/unit/analysis/test_yara_plugin_base.py
@@ -18,7 +18,7 @@ class YaraPlugin(YaraBasePlugin):
     FILE = '/foo/bar/Yara_Base_Plugin/code/test.py'
 
 
-@pytest.mark.AnalysisPluginClass.with_args(YaraPlugin)
+@pytest.mark.AnalysisPluginTestConfig(dict(plugin_class=YaraPlugin))
 class TestAnalysisYaraBasePlugin:
     def test_get_signature_paths(self, analysis_plugin):
         intended_signature_path = os.path.join(get_src_dir(), 'analysis/signatures', analysis_plugin.NAME)

--- a/src/test/unit/web_interface/rest/test_rest_file_object.py
+++ b/src/test/unit/web_interface/rest/test_rest_file_object.py
@@ -11,7 +11,7 @@ class DbMock(CommonDatabaseMock):
         return []
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=DbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 class TestRestFileObject:
     def test_empty_uid(self, test_client):
         result = test_client.get('/rest/file_object/').data

--- a/src/test/unit/web_interface/rest/test_rest_firmware.py
+++ b/src/test/unit/web_interface/rest/test_rest_firmware.py
@@ -35,7 +35,7 @@ class DbMock(CommonDatabaseMock):
         return fw if uid == fw.uid else None
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=DbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 class TestRestFirmware:
     def test_successful_request(self, test_client):
         response = test_client.get('/rest/firmware').json

--- a/src/test/unit/web_interface/rest/test_rest_missing.py
+++ b/src/test/unit/web_interface/rest/test_rest_missing.py
@@ -13,7 +13,7 @@ class DbMock(CommonDatabaseMock):
         return {'plugin': ['missing_child_uid']}
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=DbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 def test_missing(test_client):
     result = test_client.get('/rest/missing').json
 

--- a/src/test/unit/web_interface/rest/test_rest_status.py
+++ b/src/test/unit/web_interface/rest/test_rest_status.py
@@ -12,7 +12,7 @@ class StatisticDbViewerMock(CommonDatabaseMock):
         return None if self.down or identifier != 'backend' else BACKEND_STATS
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=StatisticDbViewerMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=StatisticDbViewerMock)
 class TestRestFirmware:
     def test_empty_uid(self, test_client):
         StatisticDbViewerMock.down = False

--- a/src/test/unit/web_interface/test_app_add_comment.py
+++ b/src/test/unit/web_interface/test_app_add_comment.py
@@ -9,7 +9,7 @@ class DbMock(CommonDatabaseMock):
         TEST_FW.comments.append({'time': str(time), 'author': author, 'comment': comment})
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=DbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 class TestAppAddComment:
     def test_app_add_comment_get_not_in_db(self, test_client):
         rv = test_client.get('/comment/abc_123')

--- a/src/test/unit/web_interface/test_app_advanced_search.py
+++ b/src/test/unit/web_interface/test_app_advanced_search.py
@@ -36,7 +36,7 @@ class DbMock(CommonDatabaseMock):
         },
     }
 )
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=DbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 class TestAppAdvancedSearch:
     def test_advanced_search(self, test_client):
         response = _do_advanced_search(test_client, {'advanced_search': '{}'})

--- a/src/test/unit/web_interface/test_app_ajax_routes.py
+++ b/src/test/unit/web_interface/test_app_ajax_routes.py
@@ -38,7 +38,7 @@ class DbMock(CommonDatabaseMock):
         return None
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=DbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 class TestAppAjaxRoutes:
     def test_ajax_get_summary(self, test_client):
         result = test_client.get(f'/ajax_get_summary/{TEST_FW.uid}/foobar').data

--- a/src/test/unit/web_interface/test_app_binary_search.py
+++ b/src/test/unit/web_interface/test_app_binary_search.py
@@ -27,7 +27,7 @@ class DbMock(CommonDatabaseMock):
         return None
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=DbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 class TestAppBinarySearch:
     def test_app_binary_search_get(self, test_client):
         response = test_client.get('/database/binary_search').data.decode()

--- a/src/test/unit/web_interface/test_app_browse_binary_search_history.py
+++ b/src/test/unit/web_interface/test_app_browse_binary_search_history.py
@@ -13,7 +13,7 @@ class DbMock(CommonDatabaseMock):
         return 1
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=DbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 def test_browse_binary_search_history(test_client):
     rv = test_client.get('/database/browse_binary_search_history')
     assert b'search_title' in rv.data

--- a/src/test/unit/web_interface/test_app_dependency_graph.py
+++ b/src/test/unit/web_interface/test_app_dependency_graph.py
@@ -13,7 +13,7 @@ class DbMock(CommonDatabaseMock):
         return []
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=DbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 def test_app_dependency_graph(test_client):
     result = test_client.get(f'/dependency-graph/testgraph/{TEST_FW.uid}')
     assert b'<strong>UID:</strong> testgraph' in result.data

--- a/src/test/unit/web_interface/test_app_find_logs.py
+++ b/src/test/unit/web_interface/test_app_find_logs.py
@@ -13,7 +13,7 @@ class MockIntercom(CommonIntercomMock):
         return ['String1', 'String2', 'String3']
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(intercom_mock_class=MockIntercom))
+@pytest.mark.WebInterfaceUnitTestConfig(intercom_mock_class=MockIntercom)
 class TestShowLogs:
     @pytest.mark.cfg_defaults(
         {

--- a/src/test/unit/web_interface/test_app_missing_analyses.py
+++ b/src/test/unit/web_interface/test_app_missing_analyses.py
@@ -13,7 +13,7 @@ class DbMock(CommonDatabaseMock):
         return self.result
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=DbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 class TestAppMissingAnalyses:
     def test_app_no_missing_analyses(self, test_client):
         DbMock.result = {}

--- a/src/test/unit/web_interface/test_app_show_analysis.py
+++ b/src/test/unit/web_interface/test_app_show_analysis.py
@@ -10,7 +10,7 @@ class IntercomMock(CommonIntercomMock):
         self.task_list.append(task)
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(intercom_mock_class=IntercomMock))
+@pytest.mark.WebInterfaceUnitTestConfig(intercom_mock_class=IntercomMock)
 class TestAppShowAnalysis:
     def test_app_show_analysis_get_valid_fw(self, test_client):
         result = test_client.get(f'/analysis/{TEST_FW.uid}').data

--- a/src/test/unit/web_interface/test_app_show_statistic.py
+++ b/src/test/unit/web_interface/test_app_show_statistic.py
@@ -12,7 +12,7 @@ class DbMock(CommonDatabaseMock):
         return self.result if identifier == 'general' else None
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=DbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 class TestShowStatistic:
     def test_no_stats_available(self, test_client):
         DbMock.result = None

--- a/src/test/unit/web_interface/test_app_user_management_routes.py
+++ b/src/test/unit/web_interface/test_app_user_management_routes.py
@@ -75,7 +75,7 @@ def current_user_fixture(monkeypatch):
     monkeypatch.setattr(user_management_routes, 'current_user', UserMock('foobar', 'test'))
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=UserDbInterfaceMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=UserDbInterfaceMock)
 class TestAppUpload:
     def test_app_manage_users(self, test_client):
         response = test_client.get('/admin/manage_users', follow_redirects=True)

--- a/src/test/unit/web_interface/test_comparison_routes.py
+++ b/src/test/unit/web_interface/test_comparison_routes.py
@@ -18,7 +18,7 @@ class TemplateDbMock(CommonDatabaseMock):
         return None
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=TemplateDbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=TemplateDbMock)
 def test_get_compare_plugin_views(web_frontend):
     compare_result = {'plugins': {}}
     result = CompareRoutes._get_compare_plugin_views(web_frontend, compare_result)

--- a/src/test/unit/web_interface/test_quick_search.py
+++ b/src/test/unit/web_interface/test_quick_search.py
@@ -44,7 +44,7 @@ class DbMock(CommonDatabaseMock):
         },
     }
 )
-@pytest.mark.WebInterfaceUnitTestConfig(dict(database_mock_class=DbMock))
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 class TestAppQuickSearch:
     def test_quick_search_file_name(self, test_client):
         assert TEST_FW_2.uid in _start_quick_search(test_client, TEST_FW_2.file_name)


### PR DESCRIPTION
In the same way that #922 lets test-cases configure the fixtures this PR will do the same for the AnalysisPlugin tests.