### PR TITLE
installer: Documentation AbstractPluginInstaller

### DIFF
--- a/docsrc/index.rst
+++ b/docsrc/index.rst
@@ -28,6 +28,7 @@ Contents
    modules/conftest
    modules/helperFunctions
    modules/objects
+   modules/plugins
    modules/scheduler
    modules/web_interface
 

--- a/docsrc/modules/plugins.installer.rst
+++ b/docsrc/modules/plugins.installer.rst
@@ -1,0 +1,7 @@
+plugins.installer module
+=================================
+
+.. automodule:: plugins.installer
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docsrc/modules/plugins.rst
+++ b/docsrc/modules/plugins.rst
@@ -1,0 +1,8 @@
+plugins
+=======
+
+.. toctree::
+   :maxdepth: 4
+
+   plugins.installer
+

--- a/src/install/backend.py
+++ b/src/install/backend.py
@@ -116,7 +116,8 @@ def _install_plugins(distribution, skip_docker, only_docker=False):
         if not only_docker:
             plugin_installer.install()
         else:
-            plugin_installer.install_docker_images()
+            with OperateInDirectory(plugin_installer.base_path):
+                plugin_installer.install_docker_images()
         logging.info(f'Finished installing {plugin_name} plugin.\n')
 
 

--- a/src/plugins/installer.py
+++ b/src/plugins/installer.py
@@ -11,21 +11,31 @@ from helperFunctions.install import (
 
 
 class AbstractPluginInstaller:
+    """A class that is used to handle plugin installation.
+    Any class subclassing it may overwrite any public method except :py:func:`install`.
+    You may assume that the cwd is ``self.base_path``.
+    If any other method than :py:func:`install` is called, then the caller has to ensure this.
+
+    :param distribution: The distribution on which the installer is executed. See :py:func:`~helperFunctions.install.check_distribution`
+    :param skip_docker: Whether or not to do anything docker related.
+    """
+
     # Even if some functions don't need self we want to have them nicely
     # grouped in this class
     # pylint:disable=no-self-use
 
-    skip_docker_env = os.getenv('FACT_INSTALLER_SKIP_DOCKER') is not None
-    # The base directory of the plugin
-    # Must be overwritten by a class variable of a child class
+    _skip_docker_env = os.getenv('FACT_INSTALLER_SKIP_DOCKER') is not None
+    #: The base directory of the plugin
+    #: Must be overwritten by a class variable of a child class
     base_path = None
 
-    def __init__(self, distribution: Optional[str] = None, skip_docker: bool = skip_docker_env):
+    def __init__(self, distribution: Optional[str] = None, skip_docker: bool = _skip_docker_env):
         self.distribution = distribution or check_distribution()
         self.build_path = self.base_path / 'build'
         self.skip_docker = skip_docker
 
     def install(self):
+        """Completely install the plugin."""
         cwd = os.getcwd()
         os.chdir(self.base_path)
         self.install_system_packages()

--- a/src/plugins/installer.py
+++ b/src/plugins/installer.py
@@ -45,8 +45,6 @@ class AbstractPluginInstaller:
         if not self.skip_docker:
             self.install_docker_images()
 
-        self.do_last()
-
         os.chdir(cwd)
 
     def install_docker_images(self):
@@ -83,9 +81,6 @@ class AbstractPluginInstaller:
         '''
         Install packages with package managers other than pip/dnf/apt.
         '''
-
-    def do_last(self):
-        pass
 
     def install_files(self):
         '''


### PR DESCRIPTION
The assumption about the cwd was not clear.
Before this commit running `./src/install.py --backend-docker-images` would not succeed because of the relative path in the software_components plugin.