### PR TITLE
plugins/analysis/input_vectors: Fix test name

### DIFF
--- a/src/plugins/analysis/input_vectors/test/test_input_vectors.py
+++ b/src/plugins/analysis/input_vectors/test/test_input_vectors.py
@@ -10,7 +10,7 @@ TEST_FILE_DIR = Path(__file__).parent / 'data'
 
 
 @pytest.mark.AnalysisPluginClass.with_args(AnalysisPlugin)
-class AnalysisPluginTestInputVectors:
+class TestAnalysisPluginInputVectors:
     def test_process_object_inputs(self, analysis_plugin):
         result = self.assert_process_object(analysis_plugin, 'test_fgets.elf')
         assert 'file' in result['full']['inputs']


### PR DESCRIPTION
The Tests were not actually run before as pytest only auto-discovers tests in classes prefixed with `Test`. [1]

[1] https://docs.pytest.org/en/7.2.x/explanation/goodpractices.html#test-discovery