### PR TITLE
Copyright, Social and bye-bye BCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,15 @@ We've been happy to show FACT in a number of BlackHat Arsenal sessions.
 - [Pass the salt 2019](https://2019.pass-the-salt.org/talks/71.html) / [Slides](https://2019.pass-the-salt.org/files/slides/04-FACT.pdf) / [Video](https://passthesalt.ubicast.tv/videos/improving-your-firmware-security-analysis-process-with-fact/)
 - [Hardwear.io 2019](https://hardwear.io/netherlands-2019/speakers/johannes-vom-dorp-and-peter-weidenbach.php)
 
+## Social
+
+- <a rel="me" href="https://infosec.exchange/@fact">Mastodon</a>
+- [Twitter](https://twitter.com/FAandCTool)
+
 ## License
 ```
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2022  Fraunhofer FKIE
+    Copyright (C) 2015-2023  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 # The Firmware Analysis and Comparison Tool (FACT)
 
 [![codecov](https://codecov.io/gh/fkie-cad/FACT_core/branch/master/graph/badge.svg)](https://codecov.io/gh/fkie-cad/FACT_core)
-[![BCH compliance](https://bettercodehub.com/edge/badge/fkie-cad/FACT_core?branch=master)](https://bettercodehub.com/)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/d3910401cb58498a8c2d00be80092080)](https://www.codacy.com/gh/fkie-cad/FACT_core/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fkie-cad/FACT_core&amp;utm_campaign=Badge_Grade)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/FACT_core/community)
 

--- a/docsrc/conf.py
+++ b/docsrc/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, str(FACT_SRC))
 
 # pylint: disable=redefined-builtin,invalid-name
 project = 'FACT'
-copyright = '2020-2022  Fraunhofer FKIE'
+copyright = '2020-2023  Fraunhofer FKIE'
 author = 'jstucke'
 
 

--- a/src/check_signatures.py
+++ b/src/check_signatures.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2022 Fraunhofer FKIE
+    Copyright (C) 2015-2023 Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/compile_yara_signatures.py
+++ b/src/compile_yara_signatures.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2022  Fraunhofer FKIE
+    Copyright (C) 2015-2023  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/flask_app_wrapper.py
+++ b/src/flask_app_wrapper.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2022  Fraunhofer FKIE
+    Copyright (C) 2015-2023  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/install.py
+++ b/src/install.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     FACT Installer
-    Copyright (C) 2015-2022  Fraunhofer FKIE
+    Copyright (C) 2015-2023  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/start_fact.py
+++ b/src/start_fact.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2022  Fraunhofer FKIE
+    Copyright (C) 2015-2023  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/start_fact_backend.py
+++ b/src/start_fact_backend.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2022  Fraunhofer FKIE
+    Copyright (C) 2015-2023  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/start_fact_db.py
+++ b/src/start_fact_db.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2022  Fraunhofer FKIE
+    Copyright (C) 2015-2023  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/start_fact_frontend.py
+++ b/src/start_fact_frontend.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2022  Fraunhofer FKIE
+    Copyright (C) 2015-2023  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/update_statistic.py
+++ b/src/update_statistic.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2022  Fraunhofer FKIE
+    Copyright (C) 2015-2023  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/version.py
+++ b/src/version.py
@@ -1,6 +1,6 @@
 '''
     Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2022  Fraunhofer FKIE
+    Copyright (C) 2015-2023  Fraunhofer FKIE
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/web_interface/templates/about.html
+++ b/src/web_interface/templates/about.html
@@ -21,7 +21,7 @@
                 <h3 class="card-title">License Information</h3>
                 <h6 class="card-subtitle mb-2 text-muted">
                     Firmware Analysis and Comparison Tool (FACT)<br />
-                    Copyright (C) 2015-2022  Fraunhofer FKIE
+                    Copyright (C) 2015-2023  Fraunhofer FKIE
                 </h6>
                 <p class="card-text">
                     This program is free software: you can redistribute it and/or modify

--- a/src/web_interface/templates/base.html
+++ b/src/web_interface/templates/base.html
@@ -251,7 +251,7 @@
     <div class="row justify-content-center mb-2">
         <div class="col-md-4 text-center">
             powered by <a href="https://fkie-cad.github.io/FACT_core/">FACT {{ "" | print_program_version }}</a><br/>
-            &copy; <a href="http://www.fkie.fraunhofer.de">Fraunhofer FKIE</a> 2015-2022
+            &copy; <a href="http://www.fkie.fraunhofer.de">Fraunhofer FKIE</a> 2015-2023
         </div>
     </div>
 </div>


### PR DESCRIPTION
- Better Code Hub was deprecated at the end of 2022
- All-ish copyright strings replaced
- Added social links to Twitter & Mastodon