### PR TITLE
yara plugin system version bugfix

### DIFF
--- a/src/analysis/YaraPluginBase.py
+++ b/src/analysis/YaraPluginBase.py
@@ -26,8 +26,10 @@ class YaraBasePlugin(AnalysisBasePlugin):
         '''
         self.signature_path = self._get_signature_file(self.FILE) if self.FILE else None
         if self.signature_path and not Path(self.signature_path).exists():
-            logging.error(f'Signature file {self.signature_path} not found. Did you run "compile_yara_signatures.py"?')
-            raise PluginInitException(plugin=self)
+            raise PluginInitException(
+                f'Signature file {self.signature_path} not found. Did you run "compile_yara_signatures.py"?',
+                plugin=self,
+            )
         self.SYSTEM_VERSION = self.get_yara_system_version()  # pylint: disable=invalid-name
         super().__init__(view_updater=view_updater)
 

--- a/src/analysis/YaraPluginBase.py
+++ b/src/analysis/YaraPluginBase.py
@@ -36,7 +36,7 @@ class YaraBasePlugin(AnalysisBasePlugin):
             yara_version = process.stdout.readline().decode().strip()
 
         access_time = int(Path(self.signature_path).stat().st_mtime)
-        return f'{yara_version}_{access_time}'
+        return f'{yara_version}-{access_time}'
 
     def process_object(self, file_object):
         if self.signature_path is not None:

--- a/src/scheduler/analysis.py
+++ b/src/scheduler/analysis.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import Queue, Value
@@ -334,10 +336,14 @@ class AnalysisScheduler:  # pylint: disable=too-many-instance-attributes
         return self._dependencies_are_up_to_date(db_entry, analysis_plugin, uid)
 
     @staticmethod
-    def _current_version_is_newer(current_plugin_version: str, current_system_version: str, db_entry: dict) -> bool:
-        return parse_version(current_plugin_version) > parse_version(db_entry['plugin_version']) or parse_version(
-            current_system_version or '0'
-        ) > parse_version(db_entry['system_version'] or '0')
+    def _current_version_is_newer(
+        current_plugin_version: str, current_system_version: str | None, db_entry: dict[str, str | None]
+    ) -> bool:
+        plugin_version_is_newer = parse_version(current_plugin_version) > parse_version(db_entry['plugin_version'])
+        system_version_is_newer = parse_version(_fix_system_version(current_system_version)) > parse_version(
+            _fix_system_version(db_entry.get('system_version'))
+        )
+        return plugin_version_is_newer or system_version_is_newer
 
     def _dependencies_are_up_to_date(self, db_entry: dict, analysis_plugin: AnalysisBasePlugin, uid: str) -> bool:
         for dependency in analysis_plugin.DEPENDENCIES:
@@ -487,3 +493,9 @@ class AnalysisScheduler:  # pylint: disable=too-many-instance-attributes
             if plugin.check_exceptions():
                 return True
         return check_worker_exceptions([self.schedule_process, self.result_collector_process], 'Scheduler')
+
+
+def _fix_system_version(system_version: str | None) -> str:
+    # the system version is optional -> return '0' if it is '' or None
+    # YARA plugins used an invalid system version x.y_z (may still be in DB) -> replace all underscores with dashes
+    return system_version.replace('_', '-') if system_version else '0'

--- a/src/start_fact_backend.py
+++ b/src/start_fact_backend.py
@@ -51,7 +51,7 @@ class FactBackend(FactBase):
         try:
             self.analysis_service = AnalysisScheduler(unpacking_locks=unpacking_lock_manager)
         except PluginInitException as error:
-            logging.critical(f'Error during initialization of plugin {error.plugin.NAME}. Shutting down FACT backend')
+            logging.critical(f'Error during initialization of plugin {error.plugin.NAME}: {error}.')
             complete_shutdown()
         self.unpacking_service = UnpackingScheduler(
             post_unpack=self.analysis_service.start_analysis_of_object,


### PR DESCRIPTION
the system version in `YaraBasePlugin` is no valid version according to [PEP 440](https://peps.python.org/pep-0440/) because it contains an underscore. This in turn causes an `InvalidVersion` exception in newer versions of packaging. This PR replaces the underscore with a dash (which makes it valid). Also fixes this in the analysis scheduler where old versions from the DB are checked (which may still contain underscores).