### PR TITLE
fix slow pytest test discovery by ignoring more paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,16 @@ known_first_party = ["analysis", "compare", "helperFunctions", "install", "inter
     "statistic", "storage", "test", "unpacker", "version", "web_interface"]
 known_third_party = "docker"
 profile = "black"
+
+[tool.pytest.ini_options]
+addopts = "-v"
+testpaths = [
+    "src/test",
+    "src/plugins/**/test",
+]
+markers = [
+    "AnalysisPluginClass: Set the Class of the analysis_plugin fixture",
+    "plugin_init_kwargs: Keyword arguments to pass to AnalysisPluginClass",
+    "plugin_start_worker: Whether or not to start actual workers",
+    "cfg_defaults: Overwrite defaults for the testing config",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,0 @@
-[pytest]
-addopts = -v
-norecursedirs = */cwe_checker/internal/*
-
-markers =
-    AnalysisPluginClass: Set the Class of the analysis_plugin fixture
-    plugin_init_kwargs: Keyword arguments to pass to AnalysisPluginClass
-    plugin_start_worker: Whether or not to start actual workers
-    cfg_defaults: Overwrite defaults for the testing config


### PR DESCRIPTION
a fully populated installation directory with (compose-env, john, node_modules, etc.) can make pytest test discovery slow -> ignore more paths