### PR TITLE
storage/db_connection: Fix engine url

### DIFF
--- a/src/storage/db_connection.py
+++ b/src/storage/db_connection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from sqlalchemy import create_engine
+from sqlalchemy.engine import URL
 from sqlalchemy.orm import sessionmaker
 
 from config import cfg
@@ -17,7 +18,14 @@ class DbConnection:
         password = getattr(cfg.data_storage, password)
 
         database = db_name if db_name else cfg.data_storage.postgres_database
-        engine_url = f'postgresql://{user}:{password}@{address}:{port}/{database}'
+        engine_url = URL.create(
+            'postgresql',
+            username=user,
+            password=password,
+            host=address,
+            port=port,
+            database=database,
+        )
         self.engine = create_engine(engine_url, pool_size=100, future=True, **kwargs)
         self.session_maker = sessionmaker(bind=self.engine, future=True)  # future=True => sqlalchemy 2.0 support
 


### PR DESCRIPTION
We did not properly escape special characters.
This is exactly what `sqlalchemy.URL` is for.

Closes #958 