### PR TITLE
pinned versions of flask-wtf and setuptools

### DIFF
--- a/src/install/requirements_common.txt
+++ b/src/install/requirements_common.txt
@@ -1,7 +1,8 @@
 # General build stuff
 testresources==2.0.1
 
-setuptools
+# FixMe: remove pinned version as soon as installation of ssdeep works again
+setuptools<66
 
 # General python dependencies
 appdirs==1.4.4

--- a/src/install/requirements_frontend.txt
+++ b/src/install/requirements_frontend.txt
@@ -3,6 +3,7 @@ email-validator==1.3.0
 flask-login==0.6.2
 flask-paginate==2022.1.8
 flask-security-too==5.0.2
+flask-wtf==1.0.1
 flask==2.2.2
 flask_restx==1.0.3
 flask_sqlalchemy==3.0.2


### PR DESCRIPTION
pinned versions of flask-wtf and setuptools to fix recent issues on the CI
- setuptools: to fix recent installation issues (should be unpinned as soon as possible)
- flask-wtf: incompatible to flask-security-too 5.0.2