### PR TITLE
web_interface: Fix analysis presets

### DIFF
--- a/src/web_interface/components/io_routes.py
+++ b/src/web_interface/components/io_routes.py
@@ -46,7 +46,7 @@ class IORoutes(ComponentBase):
             device_classes=device_class_list,
             vendors=vendor_list,
             error=error,
-            analysis_presets=list(cfg.default_plugins),
+            analysis_presets=[preset for preset, _ in cfg.default_plugins],
             device_names=json.dumps(device_name_dict, sort_keys=True),
             analysis_plugin_dict=analysis_plugins,
             plugin_set='default',


### PR DESCRIPTION
pydantic populates the class `config.data_storage`. Iterating over it will yield tuples rather than the dictionary keys as before.