### PR TITLE
missing files in file tree w/o root_uid fix

### DIFF
--- a/src/web_interface/file_tree/file_tree.py
+++ b/src/web_interface/file_tree/file_tree.py
@@ -148,11 +148,22 @@ class VirtualPathFileTree:
 
     def __init__(self, root_uid: str, parent_uid: str, fo_data: FileTreeData, whitelist: list[str] | None = None):
         self.uid = fo_data.uid
-        self.root_uid = root_uid if root_uid else list(fo_data.virtual_file_path)[0]
+        self.root_uid = root_uid if root_uid else self._find_root_uid(parent_uid, fo_data)
         self.parent_uid = parent_uid
         self.fo_data: FileTreeData = fo_data
         self.whitelist = whitelist
         self.virtual_file_paths = self._get_virtual_file_paths()
+
+    @staticmethod
+    def _find_root_uid(parent_uid: str, fo_data: FileTreeData) -> str:
+        '''
+        If we don't have a rood_uid, we must find a root_uid that contains the parent_uid (we can't just take a
+        random one because then the files could be missing from the file tree).
+        '''
+        for root_uid, vfp_list in fo_data.virtual_file_path.items():
+            if any(parent_uid in vfp for vfp in vfp_list):
+                return root_uid
+        return list(fo_data.virtual_file_path)[0]  # safety fallback: this should not occur under normal circumstances
 
     def _get_virtual_file_paths(self) -> list[str]:
         if self._file_tree_is_for_file_object():


### PR DESCRIPTION
There can still be files missing from the file tree on the analysis page under certain circumstances:
- if no root_uid is provided (e.g. when coming to the analysis page from a file search)
- and if the file in the file tree is also contained in another FW (i.e. if there are multiple keys in the virtual file path dict)
- and if any of the other FWs does not contain the parent file in the file tree we are looking at
because the root_uid is selected at random if it is missing. 

This PR adds an "educated guess" to make sure that we select a root_uid from a FW that contains the parent file from the file tree we are currently looking at.