### PR TITLE
fix for older versions of the icon-theme not providing a inode-symlink icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ docsrc/_build/
 docs/.buildinfo/
 src/bin
 src/web_interface/static/node_modules
+src/web_interface/static/file_icons
 
 # pytest
 .pytest_cache

--- a/src/install/frontend.py
+++ b/src/install/frontend.py
@@ -130,6 +130,7 @@ def _copy_mime_icons():
         ('devices/media-floppy.svg', 'filesystem.svg'),
         ('places/folder-brown.svg', 'folder.svg'),
         ('status/dialog-error.svg', 'not_analyzed.svg'),
+        ('emblems/emblem-symbolic-link.svg', 'mimetypes/inode-symlink.svg'),
     ]:
         run_cmd_with_logging(f'cp -rL {ICON_THEME_INSTALL_PATH / source} {MIME_ICON_DIR / target}')
 

--- a/src/web_interface/file_tree/file_tree.py
+++ b/src/web_interface/file_tree/file_tree.py
@@ -142,18 +142,6 @@ def get_icon_for_mime(mime_type: str | None) -> str:
     return MIME_TO_ICON_PATH['unknown']
 
 
-def _find_icon_for_suffix(file_name: str) -> str | None:
-    suffix = Path(file_name).suffix.lstrip('.').lower()
-    if not suffix:
-        return None
-    if suffix in MIME_TO_ICON_PATH:
-        return MIME_TO_ICON_PATH[suffix]
-    for prefix in ['text', 'text-x', 'application', 'application-x']:
-        if f'{prefix}-{suffix}' in MIME_TO_ICON_PATH:
-            return MIME_TO_ICON_PATH[f'{prefix}-{suffix}']
-    return None
-
-
 def _get_partial_virtual_paths(virtual_path: dict[str, list[str]], new_root: str) -> list[str]:
     '''
     Returns a list of new partial virtual paths with ``new_root`` as the new root element.


### PR DESCRIPTION
older versions (<jammy) of the papirus-icon-theme package don't include a dedicated inode-symlink icon, which leads to symlinks being displayed as empty files. This PR fixes this and uses the emblem link icon instead (which is included in all versions from [bionic](https://packages.ubuntu.com/bionic/all/papirus-icon-theme/filelist) to [lunar](https://packages.ubuntu.com/lunar/all/papirus-icon-theme/filelist))

If the icons are already installed, the `src/web_interface/static/file_icons/mimetypes` folder needs to be deleted for the installation to replace the files.

Also removes an unused function that slipped through the review.