### PR TITLE
Migration bugfixes

### DIFF
--- a/src/migrate_db_to_postgresql.py
+++ b/src/migrate_db_to_postgresql.py
@@ -203,7 +203,7 @@ class MigrationMongoInterface(MongoInterface):
                 if tmp is not None:
                     try:
                         report = pickle.loads(tmp.read())
-                    except ModuleNotFoundError:
+                    except ModuleNotFoundError:  # sanitized result contains pickled class that cannot be loaded
                         logging.error(f'Could not load sanitized dict: {sanitized_dict[key][analysis_key]}')
                         report = {}
                 else:

--- a/src/migrate_db_to_postgresql.py
+++ b/src/migrate_db_to_postgresql.py
@@ -201,9 +201,13 @@ class MigrationMongoInterface(MongoInterface):
                 logging.debug(f'Retrieving {analysis_key}')
                 tmp = self.sanitize_fs.get_last_version(sanitized_dict[key][analysis_key])
                 if tmp is not None:
-                    report = pickle.loads(tmp.read())
+                    try:
+                        report = pickle.loads(tmp.read())
+                    except ModuleNotFoundError:
+                        logging.error(f'Could not load sanitized dict: {sanitized_dict[key][analysis_key]}')
+                        report = {}
                 else:
-                    logging.error(f'sanitized file not found: {sanitized_dict[key][analysis_key]}')
+                    logging.error(f'Sanitized file not found: {sanitized_dict[key][analysis_key]}')
                     report = {}
                 tmp_dict[analysis_key] = report
         return tmp_dict

--- a/src/storage/entry_conversion.py
+++ b/src/storage/entry_conversion.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from time import time
 
@@ -115,6 +116,12 @@ def _sanitize_value(analysis_data: dict, key: str, value):
         analysis_data[key] = value.replace('\0', '')
     elif isinstance(value, list):
         _sanitize_list(value)
+    elif isinstance(value, bytes):
+        logging.warning(
+            f'Plugin result contains bytes entry. '
+            f'Plugin results should only contain JSON compatible data structures!:\n\t{repr(value)}'
+        )
+        analysis_data[key] = value.decode(errors='replace')
 
 
 def _sanitize_key(analysis_data: dict, key: str):


### PR DESCRIPTION
- fixed a bug with tuples in analysis results not being sanatized
- added exception handling for custom classes occurring in pickled ("sanitized") results
- split migration of `FileObject`s and analyses
  - the migration should continue if single analyses cannot be migrated

resolves #964 