### PR TITLE
improved cve_lookup version comparison

### DIFF
--- a/src/plugins/analysis/cve_lookup/code/cve_lookup.py
+++ b/src/plugins/analysis/cve_lookup/code/cve_lookup.py
@@ -6,12 +6,11 @@ import re
 import sys
 from collections import namedtuple
 from collections.abc import Callable
-from distutils.version import Version
 from itertools import combinations
 from pathlib import Path
 from typing import NamedTuple
 
-from packaging.version import InvalidVersion
+from packaging.version import InvalidVersion, Version
 from packaging.version import parse as parse_version
 from pyxdameraulevenshtein import damerau_levenshtein_distance as distance  # pylint: disable=no-name-in-module
 
@@ -145,11 +144,11 @@ def generate_search_terms(product_name: str) -> list[str]:
 
 def find_matching_cpe_product(cpe_matches: list[Product], requested_version: str) -> Product:
     if requested_version.isdigit() or is_valid_dotted_version(requested_version):
-        version_numbers = [t.version_number for t in cpe_matches]
+        version_numbers = [t.version_number for t in cpe_matches if t.version_number not in ['N/A', 'ANY']]
         if requested_version in version_numbers:
             return find_cpe_product_with_version(cpe_matches, requested_version)
         version_numbers.append(requested_version)
-        version_numbers.sort(key=parse_version)
+        version_numbers.sort(key=lambda v: parse_version(v.replace('\\', '')))
         next_closest_version = find_next_closest_version(version_numbers, requested_version)
         return find_cpe_product_with_version(cpe_matches, next_closest_version)
     if requested_version == 'ANY':

--- a/src/plugins/analysis/cve_lookup/code/cve_lookup.py
+++ b/src/plugins/analysis/cve_lookup/code/cve_lookup.py
@@ -148,7 +148,7 @@ def find_matching_cpe_product(cpe_matches: list[Product], requested_version: str
         if requested_version in version_numbers:
             return find_cpe_product_with_version(cpe_matches, requested_version)
         version_numbers.append(requested_version)
-        version_numbers.sort(key=lambda v: parse_version(v.replace('\\', '')))
+        version_numbers.sort(key=lambda v: coerce_version(unescape(v)))
         next_closest_version = find_next_closest_version(version_numbers, requested_version)
         return find_cpe_product_with_version(cpe_matches, next_closest_version)
     if requested_version == 'ANY':
@@ -247,10 +247,10 @@ def coerce_version(version: str) -> Version:
         match = VALID_VERSION_REGEX.match(fixed_version)
         if match:
             valid_version = match.group()
-            rest = re.sub('[^a-zA-Z0-9._-]', '', fixed_version[len(valid_version) :]).lstrip('._-')
+            rest = re.sub(r'[^\w.-]', '', fixed_version[len(valid_version) :]).lstrip('._-')
             return parse_version(f'{valid_version}+{rest}')
         # try to throw away revisions and other stuff at the end as a final measure
-        return parse_version(re.split('[^v.0-9]', fixed_version)[0])
+        return parse_version(re.split(r'[^v.\d]', fixed_version)[0])
 
 
 def compare_version(version1: str, version2: str, comp_operator: Callable) -> bool:

--- a/src/plugins/analysis/cve_lookup/internal/helper_functions.py
+++ b/src/plugins/analysis/cve_lookup/internal/helper_functions.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from re import finditer, match
+import re
 from typing import NamedTuple
+
+NON_ALPHANUM_REGEX = re.compile(r'^.*[^a-zA-Z0-9_\\:].*$')
+SPECIAL_CHAR_REGEX = re.compile(r'[^.]((?<!\\)[*?])[^.]|((?<!\\)[^a-zA-Z0-9\s?*_\\])')
 
 
 class CveEntry(NamedTuple):
@@ -19,7 +22,7 @@ class CveSummaryEntry(NamedTuple):
 def escape_special_characters(attribute: str) -> str:
     # a counter is incremented every time an escape character is added because it alters the string length
     index_shift = 0
-    for characters in finditer(r'[^.]((?<!\\)[*?])[^.]|((?<!\\)[^a-zA-Z0-9\s?*_\\])', attribute):
+    for characters in SPECIAL_CHAR_REGEX.finditer(attribute):
         group = 2 if characters.span(1)[0] == -1 else 1
         start = characters.span(group)[0] + index_shift
         if start:
@@ -36,7 +39,7 @@ def replace_characters_and_wildcards(attributes: list[str]) -> list[str]:
         elif attribute == '-':
             attributes[index] = 'N/A'
         # if there are non-alphanumeric characters apart from underscore and escaped colon, escape them
-        elif match(r'^.*[^a-zA-Z0-9_\\:].*$', attribute):
+        elif NON_ALPHANUM_REGEX.match(attribute):
             attributes[index] = escape_special_characters(attribute)
     return attributes
 


### PR DESCRIPTION
Improved cve_lookup version comparison which was somewhat broken after the update to the 'packaging' module (which removed the `LegacyVersion` and forced versions to be PEP 440 compliant).

Also reduced log spam if the version cannot be parsed (which looked kind of confusing because the errors were logged with `logging.exception()` which prints traces even though the exception was actually caught).