### PR TITLE
imphash: replaced lief with readelf

### DIFF
--- a/src/test/unit/helperFunctions/test_hash.py
+++ b/src/test/unit/helperFunctions/test_hash.py
@@ -43,7 +43,7 @@ def test_imphash():
 def test_imphash_bad_file():
     fo = create_test_file_object()
     fo.processed_analysis = {'file_type': {'mime': 'application/x-executable'}}
-    assert not get_imphash(fo)
+    assert get_imphash(fo) is None
 
 
 def test_normalize_items_from_strings():


### PR DESCRIPTION
lief is used for imp(ort) hash calculation but can crash with a segfault on broken ELF files which is ... unfortunate during an analysis of the mandatory "hash" plugin and shouldn't happen. This PR replaces lief with the more robust `readelf` which is included in the `binutils` package (which is already installed for the backend). The output should be identical in most cases (so that new hashes should match old ones).

Also removed the now unnecessary `_suppress_stdout` function.