### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,105 @@
+name: Bug Report
+description: File a bug report
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        If you use FACT in docker please file the issue at [FACT_docker](https://github.com/fkie-cad/FACT_docker/issues)
+  - type: input
+    id: fact-version
+    attributes:
+      label: FACT version
+      description: |
+        The FACT version you are using.
+        Output of `git rev-parse HEAD` in the `FACT_core` directory.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        The general setup you are using to run FACT.
+        E.g. distribution and whether or not you run in an python venv.
+
+        Your distribution is the output of `lsb_release -sd`.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: What did you do to get the described behavior
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expeced Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: installation-logs
+    attributes:
+      label: Installation logs
+      description: |
+        Please paste the installer logs (`install.log`) here.
+        If you are sure this is not an installer problem you can omit it.
+
+        If the logs are too long, the last 100 lines should be sufficient.
+      value: |
+        <details>
+            <summary>install.log</summary>
+
+        ```
+        PASTE HERE
+        ```
+        </details>
+  - type: textarea
+    id: backend-logs
+    attributes:
+      label: Backend logs
+      description: |
+        Make sure to enable debug logging by starting with `-L DEBUG`!
+
+        Please paste the backend logs (by default stored at `/tmp/fact_main_backend.log`) here.
+        If you are sure this is not a backend problem you can omit it.
+
+        If the logs are too long, the last 100 lines should be sufficient.
+      value: |
+        <details>
+            <summary>fact_main_backend.log</summary>
+
+        ```
+        PASTE HERE
+        ```
+        </details>
+  - type: textarea
+    id: frontend-logs
+    attributes:
+      label: Frontend logs
+      description: |
+        Make sure to enable debug logging by starting with `-L DEBUG`!
+
+        Please paste the frontend logs (by default stored at `/tmp/fact_main_frontend.log`) here.
+        If you are sure this is not a frontend problem you can omit it.
+
+        If the logs are too long, the last 100 lines should be sufficient.
+      value: |
+        <details>
+            <summary>fact_main_frontend.log</summary>
+
+        ```
+        PASTE HERE
+        ```
+        </details>
+  - type: textarea
+    id: other
+    attributes:
+      label: Other information
+      description: |
+        Please share any other information that you think is relevant for describing/fixing the bug.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,16 @@
+name: Feature Request
+description: Reqeust a feature
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for your interest in improving FACT.
+  - type: textarea
+    id: feature
+    attributes:
+      label: Feature description
+      description: |
+        Please describe what feature you miss and why it is useful.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,26 @@
+name: Question
+description: Ask a question
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Make sure you have read and followed the [installation guide](https://github.com/fkie-cad/FACT_core/blob/master/INSTALL.md)
+        If something does not work but it should you probably want to [file a bug report](https://github.com/fkie-cad/FACT_core/issues/new?assignees=&labels=bug&template=bug-report.yml).
+  - type: input
+    id: fact-version
+    attributes:
+      label: The FACT version you are using
+      description: |
+        Output of `git rev-parse HEAD` in the `FACT_core` directory.
+    validations:
+      required: false
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: |
+        Please formulate a detailed question.
+        If you provide more context it is more probable that we can help you.
+    validations:
+      required: true


### PR DESCRIPTION
You can try them out at [my fork](https://github.com/maringuu/FACT_core/issues).

Blank issues are still allowed, I'm not sure if the templates contain everything we need.
Closes #893