### PR TITLE
added link to live progress after upload

### DIFF
--- a/src/web_interface/templates/upload/upload_successful.html
+++ b/src/web_interface/templates/upload/upload_successful.html
@@ -6,6 +6,7 @@
     <div class="alert alert-success mt-4">
         <h3 class="alert-heading">Upload Successful</h3>
         <hr />
-        The analysis will be available <a href="/analysis/{{ uid | safe }}">here</a> once it is finished
+        The analysis results will be available <a href="/analysis/{{ uid | safe }}">here</a> when ready.
+        You can monitor the analysis and unpacking progress <a href="/system_health">here</a>.
     </div>
 {% endblock %}


### PR DESCRIPTION
- added link to live progress (system health) to the message you receive after a successful upload
- changed text slightly to better reflect, that you can access the analysis page earlier (since the files and results are added immediately when they are ready now in contrast to when the text was written)