### PR TITLE
Added indicator to signify that unpacking is halted

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,8 +34,8 @@ repos:
     -   id: trailing-whitespace
         types: [python]
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
     -   id: flake8
 

--- a/src/config/main.cfg
+++ b/src/config/main.cfg
@@ -120,7 +120,7 @@ ssdeep-ignore = 1
 # Defaults to 60
 communication-timeout =
 unpack-threshold = 0.8
-unpack-throttle-limit = 50
+unpack-throttle-limit = 100
 throw-exceptions = false
 authentication = false
 nginx = false

--- a/src/scheduler/unpacking_scheduler.py
+++ b/src/scheduler/unpacking_scheduler.py
@@ -50,7 +50,7 @@ class UnpackingScheduler:  # pylint: disable=too-many-instance-attributes
         self.in_queue.put(fo)
 
     def get_scheduled_workload(self):
-        return {'unpacking_queue': self.in_queue.qsize()}
+        return {'unpacking_queue': self.in_queue.qsize(), 'is_throttled': self.throttle_condition.value == 1}
 
     # ---- internal functions ----
 

--- a/src/web_interface/static/js/system_health.js
+++ b/src/web_interface/static/js/system_health.js
@@ -32,8 +32,19 @@ async function updateSystemHealth() {
             const queueElement = document.getElementById("backend-unpacking-queue");
             if (entry.unpacking.unpacking_queue > 500) {
                 queueElement.classList.add("text-warning");
+            } else {
+                queueElement.classList.remove("text-warning");
             }
             queueElement.innerText = entry.unpacking.unpacking_queue.toString();
+
+            const throttleElement = document.getElementById("backend-unpacking-throttle-indicator");
+            if (entry.unpacking.is_throttled) {
+                throttleElement.innerText = '<i class="fa-regular fa-circle-pause"></i>';
+            }
+            else {
+                throttleElement.innerHTML = '';
+             }
+
             Object.entries(entry.analysis.plugins).map(([pluginName, pluginData], index) => {
                 if (!pluginName.includes("dummy")){
                     updatePluginCard(pluginName, pluginData);

--- a/src/web_interface/static/js/system_health.js
+++ b/src/web_interface/static/js/system_health.js
@@ -39,7 +39,7 @@ async function updateSystemHealth() {
 
             const throttleElement = document.getElementById("backend-unpacking-throttle-indicator");
             if (entry.unpacking.is_throttled) {
-                throttleElement.innerText = '<i class="fa-regular fa-circle-pause"></i>';
+                throttleElement.innerHTML = '<i class="far fa-pause-circle fa-lg"></i>';
             }
             else {
                 throttleElement.innerHTML = '';

--- a/src/web_interface/templates/system_health.html
+++ b/src/web_interface/templates/system_health.html
@@ -58,7 +58,8 @@
                 {% if component == "backend" %}
                     <tr>
                         {{ icon_tooltip_desk('box-open', 'Pending items for extraction') }}
-                        <td colspan="5" id="backend-unpacking-queue"></td>
+                        <td colspan="4" id="backend-unpacking-queue"></td>
+                        <td class="text-danger" id="backend-unpacking-throttle-indicator" data-toggle="tooltip" data-placement="bottom" title="Pause indicates that unpacking is halted until analysis queue is under throttle limit again."></td>
                     </tr>
                 {% endif %}
             </table>

--- a/src/web_interface/templates/system_health.html
+++ b/src/web_interface/templates/system_health.html
@@ -59,7 +59,7 @@
                     <tr>
                         {{ icon_tooltip_desk('box-open', 'Pending items for extraction') }}
                         <td colspan="4" id="backend-unpacking-queue"></td>
-                        <td class="text-danger" id="backend-unpacking-throttle-indicator" data-toggle="tooltip" data-placement="bottom" title="Pause indicates that unpacking is halted until analysis queue is under throttle limit again."></td>
+                        <td class="text-danger text-center" id="backend-unpacking-throttle-indicator" data-toggle="tooltip" data-placement="bottom" title="Pause indicates that unpacking is halted until analysis queue is under throttle limit again."></td>
                     </tr>
                 {% endif %}
             </table>


### PR DESCRIPTION
- Unpacking is throttle for larger analysis queues. That was not transparent before
- Fixed pre-commit path for flake8 as sideeffect