### PR TITLE
updated current analyses design

### DIFF
--- a/src/web_interface/static/js/system_health.js
+++ b/src/web_interface/static/js/system_health.js
@@ -52,8 +52,7 @@ function updateProgressBarElement(elementId, percent, used, total) {
 function getProgressBar(percentage, labelCurrent, labelMax, unit) {
     const value = `${labelCurrent} ${unit} / ${labelMax} ${unit}`;
     return `
-        <div class="progress-bar text-center${percentage > 80 ? " bg-warning" : ""}" role="progressbar" style="width: ${percentage}%">
-        </div>
+        <div class="progress-bar text-center${percentage > 80 ? " bg-warning" : ""}" role="progressbar" style="width: ${percentage}%"></div>
         <div class="justify-content-center d-flex position-absolute w-100" style="margin-top: 10px;">
             ${value}
         </div>
@@ -128,61 +127,82 @@ function updatePluginCard(pluginName, pluginData) {
 }
 
 function updateCurrentAnalyses(analysisData) {
-    const currentAnalyses = analysisData.current_analyses;
     const currentAnalysesElement = document.getElementById("current-analyses");
     const currentAnalysesHTML = [].concat(
         Object.entries(analysisData.current_analyses)
-            .map(([uid, analysisStats], index) => createCurrentAnalysisItem(uid, analysisStats)),
+            .map(([uid, analysisStats]) => createCurrentAnalysisItem(analysisStats, uid, false)),
         Object.entries(analysisData.recently_finished_analyses)
-            .map(([uid, analysisStats], index) => createFinishedAnalysisItem(uid, analysisStats)),
+            .map(([uid, analysisStats]) => createCurrentAnalysisItem(analysisStats, uid, true)),
     ).join("\n");
     currentAnalysesElement.innerHTML = currentAnalysesHTML !== "" ? currentAnalysesHTML : "No analysis in progress";
+    document.querySelectorAll('div[role=tooltip]').forEach((element) => {element.remove();});
+    $("body").tooltip({selector: '[data-toggle="tooltip"]'});  // update tooltips for dynamically created elements
 }
 
-function createCurrentAnalysisItem(uid, data) {
-    const currentAnalysisProgress = data.analyzed_count / data.total_count;
-    const currentUnpackingProgress = (data.unpacked_count - data.analyzed_count) / data.total_count;
-    const analysisProgressString = `${data.analyzed_count} / ${data.total_count} (Elapsed: ${getDuration(data.start_time)})`;
+function createCurrentAnalysisItem(data, uid, isFinished) {
+    const timeString = isFinished ? `Finished in ${getDuration(null, data.duration)}` : `${getDuration(data.start_time)}`;
+    const total = isFinished ? data.total_files_count : data.total_count;
     return `
-        <div class="card clickable mt-2" onclick="location.href='/analysis/${uid}/ro/${uid}'">
-            <h6 class="card-title p-2" style="margin-bottom: 0 !important; padding-bottom: 0 !important;">${data.hid}</h6>
-            <div class="card-body p-2">
-                ${getProgressParagraph(analysisProgressString)}
-                <div class="progress" style="height: 20px;">
-                    <div
-                        class="progress-bar progress-bar-striped progress-bar-animated text-center"
-                        role="progressbar"
-                        style="width: ${currentAnalysisProgress * 100}%"
-                    >
-                    </div>
-                    <div
-                        class="progress-bar progress-bar-striped progress-bar-animated bg-warning text-center"
-                        role="progressbar"
-                        style="width: ${currentUnpackingProgress * 100}%"
-                    ></div>
+        <a href='/analysis/${uid}/ro/${uid}' style="color: black;">
+            <div class="card clickable mt-2">
+                <h6 class="card-title p-2" style="margin-bottom: 0 !important; padding-bottom: 0 !important;">${data.hid}</h6>
+                <div class="card-body p-2">
+                    <table class="table table-borderless table-sm mb-0">
+                        <tr>
+                            ${createIconCell("box-open", "Unpacking Progress")}
+                            ${createProgressBarCell(isFinished ? data.total_files_count : data.unpacked_count, total)}
+                        </tr>
+                        <tr>
+                            ${createIconCell("microscope", "Analysis Progress")}
+                            ${createProgressBarCell(isFinished ? data.total_files_count : data.analyzed_count, total)}
+                        </tr>
+                        <tr>
+                            ${createIconCell("clock", "Elapsed Time")}
+                            <td>
+                                <p class="card-text">${timeString}</p>
+                            </td>
+                        </tr>
+                    </table>
                 </div>
             </div>
-        </div>
+        </a>
     `;
 }
 
-function createFinishedAnalysisItem(uid, data) {
-    const progressString = `${data.total_files_count} / ${data.total_files_count} (Finished in: ${getDuration(null, data.duration)})`;
+function createProgressBarCell(count, total) {
+    const progress = count / total * 100;
+    const progressString = `${count} / ${total} (${progress.toFixed(1)}%)`;
+    const divClass = (progress >= 100.0) ? "progress-bar bg-success text-center" : "progress-bar text-center";
+    const pStyle = {
+        "color": "white",
+        "font-size": "0.75rem",
+        "position": "absolute",
+        "z-index": "3",
+        "width": "100%",
+        "margin-top": "1px",
+        "text-align": "center",
+        "padding-right": "83px",
+    };
     return `
-        <div class="card clickable mt-2" onclick="location.href='/analysis/${uid}/ro/${uid}'">
-            <h6 class="card-title p-2" style="margin-bottom: 0 !important; padding-bottom: 0 !important;">${data.hid}</h6>
-            <div class="card-body p-2">
-                ${getProgressParagraph(progressString)}
-                <div class="progress" style="height: 20px;">
-                    <div class="progress-bar progress-bar-striped bg-success text-center" role="progressbar" style="width: 100%"></div>
-                </div>
+        <td class="align-middle">
+            <p style="${objectToStyle(pStyle)}">${progressString}</p>
+            <div class="progress" style="height: 20px;">
+                <div class="${divClass}" role="progressbar" style="width: ${progress}%"></div>
             </div>
-        </div>
+        </td>
     `;
 }
 
-function getProgressParagraph(progressText) {
-    return `<p style="color: white; position: absolute; z-index: 3; width: 100%; margin-top: -3px; text-align: center; padding-right: 15px;"><small>${progressText}</small></p>`;
+function objectToStyle(obj) {
+    return Object.entries(obj).map(([k, v]) => `${k}: ${v};`).join(" ");
+}
+
+function createIconCell(icon, tooltip) {
+    return `
+        <td class="align-middle text-center" style="width: 30px;" data-toggle="tooltip" data-placement="bottom" title="${tooltip}">
+            <i class="fas fa-${icon}"></i>
+        </td>
+    `;
 }
 
 function getDuration(start=null, duration=null) {

--- a/src/web_interface/templates/system_health.html
+++ b/src/web_interface/templates/system_health.html
@@ -30,7 +30,7 @@
             <h6 class="card-subtitle mb-2" id="{{ component }}-status">
                 unknown
             </h6>
-            <table class="table table-borderless mb-0">
+            <table class="table table-borderless table-sm mb-0">
                 <tr>
                     {{ icon_tooltip_desk('linux', 'Operating system', icon_class='fab') }}
                     <td id="{{ component }}-os"></td>
@@ -91,7 +91,7 @@
                 <span class="card-text">
                     {{ description }}
                 </span>
-                <table class="table table-borderless mb-0">
+                <table class="table table-borderless mb-0 table-sm">
                     <tr>
                         {{ icon_tooltip_desk('project-diagram', 'Plugin dependencies') }}
                         <td>{{ dependencies | list_group_collapse | safe}}</td>
@@ -135,45 +135,9 @@
         <div class="card-body">
             <div class="d-flex justify-content-between align-items-center" style="width: 100%">
                 <h5 class="card-title">Currently analyzed firmware</h5>
-                <button type="button" class="btn btn-outline-primary btn-sm" data-toggle="modal" data-target="#currentAnalysesLegend" style="margin-top: -15px; margin-right: -5px">
-                    <i class="fa fa-question-circle" aria-hidden="true"></i>
-                </button>
             </div>
             <div id="current-analyses">
                 <!-- Filled with JavaScript -->
-            </div>
-        </div>
-    </div>
-</div>
-
-
-
-<div class="modal" id="currentAnalysesLegend"  tabindex="-1" role="dialog">
-    <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title"><i class="fa fa-question-circle" aria-hidden="true"></i> Currently Analyzed Firmware</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="progress mt-2" style="height: 20px; padding-bottom: 0;">
-                    <div class="justify-content-center d-flex w-100">analyzed files / total files (elapsed time)</div>
-                </div>
-                <div class="progress mt-2" style="height: 20px; padding-bottom: 0;">
-                    <div class="progress-bar progress-bar-striped progress-bar-animated text-center" role="progressbar" style="width: 40%">
-                        Analysis Progress
-                    </div>
-                    <div class="progress-bar progress-bar-striped progress-bar-animated bg-warning text-center" role="progressbar" style="width: 40%">
-                        Unpacking Progress
-                    </div>
-                </div>
-                <div class="progress mt-2" style="height: 20px;">
-                    <div class="progress-bar progress-bar-striped bg-success text-center" role="progressbar" style="width: 100%">
-                        Finished Analysis
-                    </div>
-                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
- made design of "current analyses" on system health page more consistent with the rest of the page
- removed legend of "current analyses" (should be self-explaining now)
- "current analyses" should be correctly rendered as link now (meaning stuff like "open in tab" should now work)
- switched to bootstrap "table-sm" for most tables on the page to save some vertical space