### PR TITLE
scheduler/unpacking: Don't call post_unpack when extraction failed

### DIFF
--- a/src/scheduler/unpacking_scheduler.py
+++ b/src/scheduler/unpacking_scheduler.py
@@ -160,6 +160,7 @@ class UnpackingScheduler:  # pylint: disable=too-many-instance-attributes
                 docker_logs = self._fetch_logs(container)
                 logging.warning(f'Exception happened during extraction of {task.uid}.{docker_logs}')
                 container.set_exception()
+                return
 
             sleep(cfg.expert_settings.unpacking_delay)  # unpacking may be too fast for the FS to keep up
 


### PR DESCRIPTION
This lead to confusion when unpacking failed but seemingly succeeded because post_unpack was called.