### PR TITLE
Improved ipc plugin performance by disabling all possible ghidra analyses

### DIFF
--- a/src/plugins/analysis/ipc/docker/Dockerfile
+++ b/src/plugins/analysis/ipc/docker/Dockerfile
@@ -1,8 +1,9 @@
-FROM fkiecad/ghidra_headless_base:10.1.2 as runtime
+FROM fkiecad/ghidra_headless_base:10.2.2 as runtime
 
 WORKDIR /ipc
 
-RUN apt-get update && apt-get install -y --no-install-recommends python3 \
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends python3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/src/plugins/analysis/ipc/docker/ghidra_headless.py
+++ b/src/plugins/analysis/ipc/docker/ghidra_headless.py
@@ -15,13 +15,6 @@ def parse_arguments() -> argparse.Namespace():
     return args
 
 
-def get_script_path(ghidra_path: Path) -> Path:
-    """
-    Returns script path
-    """
-    return ghidra_path / 'Ghidra/Features/Python/ghidra_scripts/ipc_analyzer.py'
-
-
 def check_ghidra(ghidra_path: Path) -> bool:
     """
     Checks if Ghidra executable exists
@@ -37,10 +30,11 @@ def get_ghidra_command(ghidra_path: Path, project_path: Path, file_path: Path, r
     Builds the Ghidra command
     """
     headless_path = ghidra_path / 'support/analyzeHeadless'
-    script_path = get_script_path(ghidra_path)
+    pre_script = 'headless_prescript.py'
+    post_script = 'ipc_analyzer.py'
     project_name = 'tmp_ghidra_project'
     return f'{headless_path} {project_path} {project_name} -readOnly \
-            -import {file_path} -postscript {script_path} {result_path}'
+            -import {file_path} -preScript {pre_script} -postScript {post_script} {result_path}'
 
 
 def get_binaries(file_path: Path) -> list[Path]:

--- a/src/plugins/analysis/ipc/docker/ipc_analyzer/headless_prescript.py
+++ b/src/plugins/analysis/ipc/docker/ipc_analyzer/headless_prescript.py
@@ -1,0 +1,72 @@
+# @category IPC
+
+# pylint: disable=undefined-variable,consider-using-f-string
+# flake8: noqa
+
+import sys
+
+
+def main():
+    """
+    Disables specific analyzers in Ghidra's headless analyzer
+
+    :return: int
+    """
+
+    turn_off = [
+        'Aggressive Instruction Finder.Create Analysis Bookmarks',
+        'Apply Data Archives.Create Analysis Bookmarks',
+        'Call Convention ID',
+        'Call-Fixup Installer',
+        'Create Address Tables.Create Analysis Bookmarks',
+        'Create Address Tables.Relocation Table Guide',
+        'Data Reference.Relocation Table Guide',
+        'Data Reference.Respect Execute Flag',
+        'Data Reference.Subroutine References',
+        'Data Reference.Unicode String References',
+        'Decompiler Parameter ID.Commit Data Types',
+        'Demangler GNU',
+        'Demangler GNU.Apply Function Calling Conventions',
+        'Demangler GNU.Apply Function Signatures',
+        'Disassemble Entry Points.Respect Execute Flag',
+        'DWARF',
+        'DWARF.Create Function Signatures',
+        'DWARF.Import Data Types',
+        'DWARF.Import Functions',
+        'DWARF.Try To Pack Structs',
+        'ELF Scalar Operand References',
+        'ELF Scalar Operand References.Relocation Table Guide',
+        'Embedded Media',
+        'Embedded Media.Create Analysis Bookmarks',
+        'External Entry References',
+        'Function ID',
+        'Function ID.Create Analysis Bookmarks',
+        'Function Start Pre Search',
+        'Function Start Search After Code',
+        'GCC Exception Handlers',
+        'GCC Exception Handlers.Create Try Catch Comments',
+        'Non-Returning Functions - Discovered',
+        'Non-Returning Functions - Discovered.Create Analysis Bookmarks',
+        'Non-Returning Functions - Discovered.Repair Flow Damage',
+        'Non-Returning Functions - Known.Create Analysis Bookmarks',
+        'Reference.Ascii String References',
+        'Reference.References to Pointers',
+        'Reference.Relocation Table Guide',
+        'Reference.Unicode String References',
+        'Shared Return Calls.Assume Contiguous Functions Only',
+        'Stack',
+        'Stack.useNewFunctionStackAnalysis',
+        'Stack.Create Local Variables',
+        'Stack.Create Param Variables',
+        'Subroutine References.Create Thunks Early',
+    ]
+    options = getCurrentAnalysisOptionsAndValues(currentProgram)
+    for option in turn_off:
+        if options.containsKey(option):
+            print('turning off {}'.format(option))
+            setAnalysisOption(currentProgram, option, 'false')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/plugins/analysis/ipc/docker/ipc_analyzer/ipc_analyzer.py
+++ b/src/plugins/analysis/ipc/docker/ipc_analyzer/ipc_analyzer.py
@@ -79,8 +79,8 @@ class GhidraAnalysis:
         decompiler = DecompInterface()
         options = DecompileOptions()
         decompiler.setOptions(options)
-        decompiler.toggleCCode(True)
         decompiler.toggleSyntaxTree(True)
+        decompiler.toggleCCode(False)
         decompiler.setSimplificationStyle('decompile')
         decompiler.openProgram(current_program)
         return decompiler


### PR DESCRIPTION
Added a preScript that turns off all analyses in Ghidra's headless mode without losing any precision. The performance gain per file is not very large, but when an entire firmware is analyzed, this should make a significant difference.