### PR TITLE
helperFunctions/plugin: Update `sys.modules`

### DIFF
--- a/src/helperFunctions/plugin.py
+++ b/src/helperFunctions/plugin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+import sys
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -35,10 +36,12 @@ def _import_plugins(plugin_type):
         spec = importlib.util.spec_from_loader(loader.name, loader)
         plugin_module = importlib.util.module_from_spec(spec)
 
+        sys.modules[spec.name] = plugin_module
         try:
             loader.exec_module(plugin_module)
             plugins.append(plugin_module)
         except Exception:  # pylint: disable=broad-except
+            sys.modules.pop(spec.name)
             # This exception could be caused by upgrading dependencies to incompatible versions. Another cause could
             # be missing dependencies. So if anything goes wrong we want to inform the user about it
             logging.error(f'Could not import plugin {module_name} due to exception', exc_info=True)


### PR DESCRIPTION
The deprecated
[load_module](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module) did this.
Since we are using `exec_module` which apparently does not update `sys.modules` we have to do it ourselves.

The documentation is not that clear imo. This fix might not be the correct way to do this, but it works fine. 