### PR TITLE
set default installation log level to INFO

### DIFF
--- a/src/install.py
+++ b/src/install.py
@@ -87,7 +87,7 @@ def _setup_argparser():
         '--log_level',
         help='define the log level',
         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR'],
-        default='WARNING',
+        default='INFO',
     )
     return parser.parse_args()
 


### PR DESCRIPTION
the log level of `install.py` was erroneously set to "WARNING" which results in the installation appearing to hang (while it actually runs in the background)