### PR TITLE
Refactoring and test coverage

### DIFF
--- a/src/helperFunctions/install.py
+++ b/src/helperFunctions/install.py
@@ -273,7 +273,7 @@ def install_pip_packages(package_file: Path):
             # don't fail if a package is already installed using apt and can't be upgraded
             if error.stdout is not None and 'distutils installed' in error.stdout:
                 logging.warning(
-                    f'Pip package {package} is already installed with distutils. This may Cause problems:\n{error.stderr}'
+                    f'Pip package {package} is already installed with distutils. This may Cause problems:\n{error.stdout}'
                 )
                 continue
             logging.error(f'Pip package {package} could not be installed:\n{error.stderr or error.stdout}')

--- a/src/test/integration/storage/test_db_interface_frontend.py
+++ b/src/test/integration/storage/test_db_interface_frontend.py
@@ -227,6 +227,32 @@ def test_generic_search_json_array(db):
     assert db.frontend.generic_search({'processed_analysis.plugin.list': {'$contains': 'd'}}) == []
 
 
+def test_generic_search_dict_in_list(db):
+    fw, parent_fo, child_fo = create_fw_with_parent_and_child()
+    parent_fo.processed_analysis = {
+        'plugin': generate_analysis_entry(analysis_result={'key': [{'name': 'a', 'foo': 'bar'}]})
+    }
+    child_fo.processed_analysis = {
+        'plugin': generate_analysis_entry(
+            analysis_result={'key': [{'name': 'b', 'foo': 'bar'}, {'name': 'c', 'foo': 'test'}]}
+        )
+    }
+    db.backend.insert_object(fw)
+    db.backend.insert_object(parent_fo)
+    db.backend.insert_object(child_fo)
+
+    assert db.frontend.generic_search({'processed_analysis.plugin.key': {'$contains': [{'name': 'a'}]}}) == [
+        parent_fo.uid
+    ]
+    assert db.frontend.generic_search({'processed_analysis.plugin.key': {'$contains': [{'name': 'b'}]}}) == [
+        child_fo.uid
+    ]
+    assert set(db.frontend.generic_search({'processed_analysis.plugin.key': {'$contains': [{'foo': 'bar'}]}})) == {
+        parent_fo.uid,
+        child_fo.uid,
+    }
+
+
 def test_generic_search_json_types(db):
     fo, fw = create_fw_with_child_fo()
     fo.processed_analysis = {


### PR DESCRIPTION
- fixed the logging output of the pip package installation (switched to `stdout` because `stderr` is usually empty)
- added an advanced search test for searching in objects (dicts) inside arrays (lists) in `JSONB` columns
  - the syntax is not very intuitive and therefore the test also demonstrates how such a search works
    - which could be interesting for a structural change of the analysis results of some plugins in the future