### PR TITLE
extractor: added retry to mitigate connection errors

### DIFF
--- a/src/scheduler/unpacking_scheduler.py
+++ b/src/scheduler/unpacking_scheduler.py
@@ -4,7 +4,6 @@ import logging
 import os
 from concurrent.futures import ThreadPoolExecutor
 from multiprocessing import Manager, Queue, Value
-from pathlib import Path
 from queue import Empty
 from tempfile import TemporaryDirectory
 from threading import Thread
@@ -153,11 +152,9 @@ class UnpackingScheduler:  # pylint: disable=too-many-instance-attributes
 
     def work_thread(self, task: FileObject, container: ExtractionContainer):
         with TemporaryDirectory(dir=container.tmp_dir.name) as tmp_dir:
-            container_url = f'http://localhost:{container.port}/start/{Path(tmp_dir).name}'
-
             extracted_objects = None
             try:
-                extracted_objects = self.unpacker.unpack(task, tmp_dir, container_url)
+                extracted_objects = self.unpacker.unpack(task, tmp_dir, container)
             except ExtractionError:
                 docker_logs = self._fetch_logs(container)
                 logging.warning(f'Exception happened during extraction of {task.uid}.{docker_logs}')

--- a/src/unpacker/extraction_container.py
+++ b/src/unpacker/extraction_container.py
@@ -4,17 +4,21 @@ import logging
 import multiprocessing
 from contextlib import suppress
 from os import getgid, getuid
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import docker
+import requests
 from docker.errors import APIError, DockerException
 from docker.models.containers import Container
 from docker.types import Mount
+from requests.adapters import HTTPAdapter, Retry
 
 from config import cfg
 
 DOCKER_CLIENT = docker.from_env()
 EXTRACTOR_DOCKER_IMAGE = 'fkiecad/fact_extractor'
+retries = Retry(total=5, backoff_factor=0.1)
 
 
 class ExtractionContainer:
@@ -24,6 +28,8 @@ class ExtractionContainer:
         self.port = cfg.unpack.base_port + id_
         self.container_id = None
         self.exception = value
+        self.session = requests.Session()
+        self.session.mount('http://', HTTPAdapter(max_retries=retries))
 
     def start(self):
         if self.container_id is not None:
@@ -103,3 +109,7 @@ class ExtractionContainer:
     def get_logs(self) -> str:
         container = self._get_container()
         return container.logs().decode(errors='replace')
+
+    def start_unpacking(self, tmp_dir: str, timeout: int | None = None):
+        url = f'http://localhost:{self.port}/start/{Path(tmp_dir).name}'
+        return self.session.get(url, timeout=timeout)

--- a/src/unpacker/unpack.py
+++ b/src/unpacker/unpack.py
@@ -13,6 +13,7 @@ from helperFunctions.tag import TagColor
 from helperFunctions.virtual_file_path import get_base_of_virtual_path, join_virtual_path
 from objects.file import FileObject
 from storage.fsorganizer import FSOrganizer
+from unpacker.extraction_container import ExtractionContainer
 from unpacker.unpack_base import ExtractionError, UnpackBase
 
 
@@ -21,7 +22,9 @@ class Unpacker(UnpackBase):
         self.file_storage_system = FSOrganizer() if fs_organizer is None else fs_organizer
         self.unpacking_locks = unpacking_locks
 
-    def unpack(self, current_fo: FileObject, tmp_dir: str, container_url: str | None = None) -> list[FileObject]:
+    def unpack(
+        self, current_fo: FileObject, tmp_dir: str, container: ExtractionContainer | None = None
+    ) -> list[FileObject]:
         '''
         Recursively extract all objects included in current_fo and add them to current_fo.files_included
         '''
@@ -32,7 +35,7 @@ class Unpacker(UnpackBase):
 
         file_path = self._generate_local_file_path(current_fo)
         try:
-            extracted_files = self.extract_files_from_file(file_path, tmp_dir, container_url)
+            extracted_files = self.extract_files_from_file(file_path, tmp_dir, container)
         except ExtractionError as error:
             self._store_unpacking_error_skip_info(current_fo, error=error)
             raise


### PR DESCRIPTION
`ConnectionError`s mostly appear in tests because the docker container is not yet ready for accepting extraction requests