### PR TITLE
added ruff pre-commit hook and removed flake8 and pylint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,17 +51,13 @@ repos:
     hooks:
     -   id: jshint
 
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.9.3
-    hooks:
-    -   id: isort
-
 -   repo: https://github.com/ambv/black
     rev: 23.3.0
     hooks:
     -   id: black
 
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.0.265'
+  rev: 'v0.0.267'
   hooks:
     - id: ruff
+      args: [ --fix, --exit-non-zero-on-fix ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,8 @@ repos:
 
     -   id: check-merge-conflict
 
+    -   id: check-toml
+
     -   id: check-yaml
 
     -   id: double-quote-string-fixer
@@ -34,18 +36,6 @@ repos:
     -   id: trailing-whitespace
         types: [python]
 
--   repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-    -   id: flake8
-
--   repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v3.0.0a4
-    hooks:
-    -   id: pylint
-        language: system
-        args: [--rcfile=pyproject.toml]
-
 -   repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.5
     hooks:
@@ -67,6 +57,11 @@ repos:
     -   id: isort
 
 -   repo: https://github.com/ambv/black
-    rev: stable
+    rev: 23.3.0
     hooks:
     -   id: black
+
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: 'v0.0.265'
+  hooks:
+    - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,9 +17,6 @@ repos:
 
     -   id: double-quote-string-fixer
 
-    -   id: end-of-file-fixer
-        types: [python]
-
     -   id: fix-encoding-pragma
         args: [--remove]
 
@@ -32,9 +29,6 @@ repos:
 
     -   id: pretty-format-json
         args: [--autofix]
-
-    -   id: trailing-whitespace
-        types: [python]
 
 -   repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ markers = [
 
 [tool.ruff]
 select = ["F", "E", "W", "C90", "N", "UP", "B", "A", "PL", "C4", "EXE", "ISC", "PIE", "T20", "PT", "RET", "SIM", "TCH",
-    "PTH", "PLR", "PLW", "ARG", "ERA"]
-ignore = ["A003"]
+    "PTH", "PLR", "PLW", "ARG", "ERA", "RUF"]
+ignore = ["A003", "RUF001", "RUF002", "RUF003"]
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["F", "W", "I", "C4", "PT", "RET"]
 exclude = [
@@ -57,6 +57,7 @@ exclude = [
     ".venv",
     "bin",
     "node_modules",
+    "scripts",  # ingore plugins/*/*/docker/scripts/* jython ghidra scripts
     "venv",
 ]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ markers = [
 select = ["F", "E", "W", "C90", "N", "UP", "B", "A", "PL", "C4", "EXE", "ISC", "PIE", "T20", "PT", "RET", "SIM", "TCH",
     "PTH", "PLR", "PLW", "ARG", "ERA", "RUF"]
 ignore = ["A003", "RUF001", "RUF002", "RUF003"]
-# Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["F", "W", "I", "C4", "PT", "RET"]
 exclude = [
     ".git",
@@ -57,7 +56,7 @@ exclude = [
     ".venv",
     "bin",
     "node_modules",
-    "scripts",  # ingore plugins/*/*/docker/scripts/* jython ghidra scripts
+    "docker",  # ingore plugins/*/*/docker/scripts/* jython ghidra scripts
     "venv",
 ]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,14 +33,6 @@ max-public-methods = 40
 [tool.pylint.imports]
 known-third-party = ["enchant", "docker"]
 
-[tool.isort]
-line_length=120
-default_section = "THIRDPARTY"
-known_first_party = ["analysis", "compare", "helperFunctions", "install", "intercom", "objects", "plugins", "scheduler",
-    "statistic", "storage", "test", "unpacker", "version", "web_interface"]
-known_third_party = "docker"
-profile = "black"
-
 [tool.pytest.ini_options]
 addopts = "-v"
 testpaths = [
@@ -54,10 +46,11 @@ markers = [
 ]
 
 [tool.ruff]
-select = ["F", "E", "W", "C90", "N", "UP", "B", "A", "PL", "C4", "EXE", "ISC", "PIE", "T20", "PT", "RET", "SIM", "TCH", "PTH", "ARG", "ERA"]
+select = ["F", "E", "W", "C90", "N", "UP", "B", "A", "PL", "C4", "EXE", "ISC", "PIE", "T20", "PT", "RET", "SIM", "TCH",
+    "PTH", "PLR", "PLW", "ARG", "ERA"]
 ignore = ["A003"]
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+fixable = ["F", "W", "I", "C4", "PT", "RET"]
 exclude = [
     ".git",
     ".ruff_cache",
@@ -72,6 +65,11 @@ target-version = "py38"
 [tool.ruff.per-file-ignores]
 "test*.py" = ["ARG002"]
 "conftest.py" = ["ARG002"]
+
+[tool.ruff.isort]
+known-first-party = ["analysis", "compare", "helperFunctions", "install", "intercom", "objects", "plugins", "scheduler",
+    "statistic", "storage", "test", "unpacker", "version", "web_interface", "config"]
+known-third-party = ["docker"]
 
 [tool.ruff.mccabe]
 max-complexity = 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 120
 skip-string-normalization = true
-target-version = ['py37']
+target-version = ['py38']
 
 [tool.pylint.main]
 init-hook = 'import sys; sys.path.append("./src")'
@@ -52,3 +52,26 @@ markers = [
     "cfg_defaults: Overwrite defaults for the testing config",
     "WebInterfaceUnitTestConfig: Configure the web_interface fixture",
 ]
+
+[tool.ruff]
+select = ["F", "E", "W", "C90", "N", "UP", "B", "A", "PL", "C4", "EXE", "ISC", "PIE", "T20", "PT", "RET", "SIM", "TCH", "PTH", "ARG", "ERA"]
+ignore = ["A003"]
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+exclude = [
+    ".git",
+    ".ruff_cache",
+    ".venv",
+    "bin",
+    "node_modules",
+    "venv",
+]
+line-length = 120
+target-version = "py38"
+
+[tool.ruff.per-file-ignores]
+"test*.py" = ["ARG002"]
+"conftest.py" = ["ARG002"]
+
+[tool.ruff.mccabe]
+max-complexity = 10


### PR DESCRIPTION
pylint has become so slow on modules like sqlalchemy that it is almost unusable. "ruff" is a linter written in Rust that can replace many checks of popular python linters and is lightning fast. The downside: it does not implement *all* checks that pylint does. On the upside it includes more checks from other linters we did not previously use like bugbear. Other not included  pylint checks 
are covered by included flake8 extensions. On the whole, it extends the linting capabilities and adds some new interesting checks.

- added ruff pre-commit hook (incl. auto-fix)
- removed pylint, isort and flake8 hooks (mostly replaced by ruff)
- updated version of black hook (to address warning)
- added toml check hook
- updated python version (to reflect removal of python 3.7 support #1024 )
- added ruff configuration to pyproject.toml
- the pylint configuration is still present in case someone want to manually run pylint