### PR TITLE
sped up analysis update by using a more efficient DB method

### DIFF
--- a/src/scheduler/analysis.py
+++ b/src/scheduler/analysis.py
@@ -152,8 +152,7 @@ class AnalysisScheduler:  # pylint: disable=too-many-instance-attributes
         self.pre_analysis(fo)
         self.unpacking_locks.release_unpacking_lock(fo.uid)
         self.status.add_update_to_current_analyses(fo, included_files)
-        for child_uid in included_files:
-            child_fo = self.db_backend_service.get_object(child_uid)
+        for child_fo in self.db_backend_service.get_objects_by_uid_list(included_files):
             child_fo.root_uid = fo.uid  # set correct root_uid so that "current analysis stats" work correctly
             child_fo.force_update = getattr(fo, 'force_update', False)  # propagate forced update to children
             self.task_scheduler.schedule_analysis_tasks(child_fo, fo.scheduled_analysis)

--- a/src/storage/db_interface_common.py
+++ b/src/storage/db_interface_common.py
@@ -72,7 +72,7 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             return file_object_from_entry(fo_entry, analysis_filter=analysis_filter)
 
     def get_objects_by_uid_list(
-        self, uid_list: list[str], analysis_filter: list[str] | None = None
+        self, uid_list: list[str] | set[str], analysis_filter: list[str] | None = None
     ) -> list[FileObject]:
         with self.get_read_only_session() as session:
             parents_table = aliased(included_files_table, name='parents')


### PR DESCRIPTION
The method `update_analysis_of_object_and_children()` used to fetch every object during an update individually from the database. Switching to `get_objects_by_uid_list()` improves the performance significantly. During a test with a firmware with ~1.7k files, this reduced the time to schedule the objects from ~58 seconds to ~2.2.