### PR TITLE
User and pw fail fix

### DIFF
--- a/src/plugins/analysis/users_and_passwords/code/password_file_analyzer.py
+++ b/src/plugins/analysis/users_and_passwords/code/password_file_analyzer.py
@@ -43,7 +43,7 @@ class AnalysisPlugin(AnalysisBasePlugin):
     DEPENDENCIES = []
     MIME_BLACKLIST = MIME_BLACKLIST_NON_EXECUTABLE
     DESCRIPTION = 'search for UNIX, httpd, and mosquitto password files, parse them and try to crack the passwords'
-    VERSION = '0.5.3'
+    VERSION = '0.5.4'
     FILE = __file__
 
     def process_object(self, file_object: FileObject) -> FileObject:
@@ -122,12 +122,15 @@ def crack_hash(passwd_entry: bytes, result_entry: dict, format_term: str = '') -
             logging_label='users_and_passwords',
         )
         result_entry['log'] = john_process.stdout
+        if 'No password hashes loaded' in john_process.stdout:
+            result_entry['ERROR'] = 'hash type is not supported'
+            return False
         output = parse_john_output(john_process.stdout)
     if output:
         if any('0 password hashes cracked' in line for line in output):
-            result_entry['ERROR'] = 'hash type is not supported'
+            result_entry['ERROR'] = 'password cracking not successful'
             return False
-        with suppress(KeyError):
+        with suppress(IndexError):
             result_entry['password'] = output[0].split(':')[1]
             return True
     return False

--- a/src/plugins/analysis/users_and_passwords/code/password_file_analyzer.py
+++ b/src/plugins/analysis/users_and_passwords/code/password_file_analyzer.py
@@ -113,7 +113,7 @@ def crack_hash(passwd_entry: bytes, result_entry: dict, format_term: str = '') -
         fp.write(passwd_entry)
         fp.seek(0)
         john_process = run_docker_container(
-            'fact/john:alpine-3.14',
+            'fact/john:alpine-3.18',
             command=f'/work/input_file {format_term}',
             mounts=[
                 Mount('/work/input_file', fp.name, type='bind'),

--- a/src/plugins/analysis/users_and_passwords/install.py
+++ b/src/plugins/analysis/users_and_passwords/install.py
@@ -21,7 +21,7 @@ class UsersAndPasswordsInstaller(AbstractPluginInstaller):
     base_path = Path(__file__).resolve().parent
 
     def install_docker_images(self):
-        self._build_docker_image('fact/john:alpine-3.14')
+        self._build_docker_image('fact/john:alpine-3.18')
 
     def install_files(self):
         if not JOHN_POT.is_file():

--- a/src/plugins/analysis/users_and_passwords/test/test_plugin_password_file_analyzer.py
+++ b/src/plugins/analysis/users_and_passwords/test/test_plugin_password_file_analyzer.py
@@ -73,13 +73,19 @@ class TestAnalysisPluginPasswordFileAnalyzer:
 
 
 def test_crack_hash_failure():
-    passwd_entry = [
-        b'user',
-        b'$6$Ph+uRn1vmQ+pA7Ka$fcn9/Ln3W6c6oT3o8bWoLPrmTUs+NowcKYa52WFVP5qU5jzadqwSq8F+Q4AAr2qOC+Sk5LlHmisri4Eqx7/uDg==',
-    ]
+    passwd_entry = [b'user', b'BfKEUi/mdF1D2']
     result_entry = {}
     assert crack_hash(b':'.join(passwd_entry[:2]), result_entry) is False
     assert 'ERROR' in result_entry
+    assert result_entry['ERROR'] == 'password cracking not successful'
+
+
+def test_hash_unsupported():
+    passwd_entry = [b'user', b'foobar']
+    result_entry = {}
+    assert crack_hash(b':'.join(passwd_entry[:2]), result_entry) is False
+    assert 'ERROR' in result_entry
+    assert result_entry['ERROR'] == 'hash type is not supported'
 
 
 def test_crack_hash_success():


### PR DESCRIPTION
There was a problem in the `users_and_passwords` analysis plugin: If the password hash could not be cracked, it was displayed as "hash type is not supported" in the result. This PR adds differentiation between the cases where the hash is not supported and the cases where it couldn't be cracked.

- fixed docker image label
- added test cases to test differentiation 