### PR TITLE
Software components bugfixes

### DIFF
--- a/src/plugins/analysis/software_components/code/software_components.py
+++ b/src/plugins/analysis/software_components/code/software_components.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import os
 import re
 import string
 
-from common_helper_files import get_dir_of_file
 
 import config
 from analysis.YaraPluginBase import YaraBasePlugin
@@ -18,8 +16,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from objects.file import FileObject
-
-SIGNATURE_DIR = os.path.join(get_dir_of_file(__file__), '../signatures')  # noqa: PTH118
 
 
 class AnalysisPlugin(YaraBasePlugin):

--- a/src/plugins/analysis/software_components/code/software_components.py
+++ b/src/plugins/analysis/software_components/code/software_components.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import string
 
 from common_helper_files import get_dir_of_file
 
@@ -54,7 +55,7 @@ class AnalysisPlugin(YaraBasePlugin):
         pattern = re.compile(regex)
         version = pattern.search(input_string)
         if version is not None:
-            return self._strip_zeroes(version.group(0))
+            return self._strip_leading_zeroes(version.group(0))
         return ''
 
     @staticmethod
@@ -105,5 +106,18 @@ class AnalysisPlugin(YaraBasePlugin):
         return os_string.strip() == entry.strip()
 
     @staticmethod
-    def _strip_zeroes(version_string: str) -> str:
-        return '.'.join(element.lstrip('0') or '0' for element in version_string.split('.'))
+    def _strip_leading_zeroes(version_string: str) -> str:
+        prefix, suffix = '', ''
+        while version_string and version_string[0] not in string.digits:
+            prefix += version_string[0]
+            version_string = version_string[1:]
+        while version_string and version_string[-1] not in string.digits:
+            suffix = version_string[-1] + suffix
+            version_string = version_string[:-1]
+        elements = []
+        for element in version_string.split('.'):
+            try:
+                elements.append(str(int(element)))
+            except ValueError:
+                elements.append(element)
+        return prefix + '.'.join(elements) + suffix

--- a/src/plugins/analysis/software_components/signatures/00_meta_filter.yara
+++ b/src/plugins/analysis/software_components/signatures/00_meta_filter.yara
@@ -6,7 +6,7 @@ private rule no_text_file
 		software_name = "magic"
 		open_source = true
 		website = "https://www.fkie.fraunhofer.de/"
-		description = "no text_file_rule"	
+		description = "no text_file_rule"
 	condition:
-		magic.mime_type() != "text/plain" or test_flag
+		(magic.mime_type() != "text/plain" and magic.mime_type() != "text/html") or test_flag
 }

--- a/src/plugins/analysis/software_components/signatures/crypto.yara
+++ b/src/plugins/analysis/software_components/signatures/crypto.yara
@@ -5,6 +5,7 @@ rule OpenSSL
 		open_source = true
 		website = "https://www.openssl.org"
 		description ="SSL library"
+		version_regex = "\\d\\.\\d\\.\\d[a-z]{0,2}"
     strings:
         $a = /OpenSSL( \d+\.\d+\.\d+[a-z]?)?/ nocase ascii wide
     condition:

--- a/src/plugins/analysis/software_components/test/test_plugin_software_components.py
+++ b/src/plugins/analysis/software_components/test/test_plugin_software_components.py
@@ -1,19 +1,17 @@
-import os
+from pathlib import Path
 
 import pytest
-from common_helper_files import get_dir_of_file
 
 from objects.file import FileObject
-
 from ..code.software_components import AnalysisPlugin
 
-TEST_DATA_DIR = os.path.join(get_dir_of_file(__file__), 'data')  # noqa: PTH118
+YARA_TEST_FILE = str(Path(__file__).parent / 'data' / 'yara_test_file')
 
 
 @pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
 class TestAnalysisPluginsSoftwareComponents:
     def test_process_object(self, analysis_plugin):
-        test_file = FileObject(file_path=os.path.join(TEST_DATA_DIR, 'yara_test_file'))  # noqa: PTH118
+        test_file = FileObject(file_path=YARA_TEST_FILE)
 
         processed_file = analysis_plugin.process_object(test_file)
         results = processed_file.processed_analysis[analysis_plugin.NAME]
@@ -68,7 +66,7 @@ class TestAnalysisPluginsSoftwareComponents:
         assert analysis_plugin._entry_has_no_trailing_version(' Linux', 'Linux ')
 
     def test_add_os_key_fail(self, analysis_plugin):
-        test_file = FileObject(file_path=os.path.join(TEST_DATA_DIR, 'yara_test_file'))  # noqa: PTH118
+        test_file = FileObject(file_path=YARA_TEST_FILE)
         with pytest.raises(KeyError):
             analysis_plugin.add_os_key(test_file)
 
@@ -77,14 +75,14 @@ class TestAnalysisPluginsSoftwareComponents:
         assert 'tags' not in test_file.processed_analysis[analysis_plugin.NAME]
 
     def test_add_os_key_success(self, analysis_plugin):
-        test_file = FileObject(file_path=os.path.join(TEST_DATA_DIR, 'yara_test_file'))  # noqa: PTH118
+        test_file = FileObject(file_path=YARA_TEST_FILE)
         test_file.processed_analysis[analysis_plugin.NAME] = {'summary': ['Linux Kernel']}
         analysis_plugin.add_os_key(test_file)
         assert 'tags' in test_file.processed_analysis[analysis_plugin.NAME]
         assert test_file.processed_analysis[analysis_plugin.NAME]['tags']['OS']['value'] == 'Linux Kernel'
 
     def test_update_os_key(self, analysis_plugin):
-        test_file = FileObject(file_path=os.path.join(TEST_DATA_DIR, 'yara_test_file'))  # noqa: PTH118
+        test_file = FileObject(file_path=YARA_TEST_FILE)
 
         test_file.processed_analysis[analysis_plugin.NAME] = {
             'summary': ['Linux Kernel'],

--- a/src/plugins/analysis/software_components/test/test_plugin_software_components.py
+++ b/src/plugins/analysis/software_components/test/test_plugin_software_components.py
@@ -35,17 +35,26 @@ class TestAnalysisPluginsSoftwareComponents:
         assert len(results['summary']) == 1, 'Number of summary results not correct'
         assert 'Test Software 0.1.3' in results['summary']
 
-    def check_version(self, analysis_plugin, input_string, version):
-        assert analysis_plugin.get_version(input_string, {}) == version, f'{version} not found correctly'
-
-    def test_get_version(self, analysis_plugin):
-        self.check_version(analysis_plugin, 'Foo 15.14.13', '15.14.13')
-        self.check_version(analysis_plugin, 'Foo 1.0', '1.0')
-        self.check_version(analysis_plugin, 'Foo 1.1.1b', '1.1.1b')
-        self.check_version(analysis_plugin, 'Foo', '')
-        self.check_version(analysis_plugin, 'Foo 01.02.03', '1.2.3')
-        self.check_version(analysis_plugin, 'Foo 00.1.', '0.1')
-        self.check_version(analysis_plugin, '\x001.22.333\x00', '1.22.333')
+    @pytest.mark.parametrize(
+        ('version', 'expected_output', 'meta_dict'),
+        [
+            ('', '', {}),
+            ('Foo 15.14.13', '15.14.13', {}),
+            ('Foo 1.0', '1.0', {}),
+            ('Foo 1.1.1b', '1.1.1b', {}),
+            ('Foo', '', {}),
+            ('Foo 01.02.03', '1.2.3', {}),
+            ('Foo 00.1.', '0.1', {}),
+            ('\x001.22.333\x00', '1.22.333', {}),
+            ('Foo 03.02.01abc', '3.2.1a', {}),
+            ('OpenSSL 1.1.0i', '1.1.0i', {}),
+            ('OpenSSL 0.9.8zh', '0.9.8zh', {'version_regex': '\\d\\.\\d\\.\\d[a-z]{0,2}'}),
+            ('Foo v1.2.3', 'v1.2.3', {'version_regex': 'v?\\d\\.\\d\\.\\d'}),
+            ('Bar a.b', 'a.b', {'version_regex': '[a-z]\\.[a-z]'}),
+        ],
+    )
+    def test_get_version(self, analysis_plugin, version, expected_output, meta_dict):
+        assert analysis_plugin.get_version(version, meta_dict) == expected_output, f'{version} not found correctly'
 
     def test_get_version_from_meta(self, analysis_plugin):
         version = 'v15.14.1a'


### PR DESCRIPTION
- fixed a bug where OpenSSL versions like OpenSSL 0.9.8zh were detected as 0.9.8z
- fixed a bug where software versions like 1.1.0i (e.g. OpenSSL) were detected as 1.1.i
- fixed a bug where text files were matched with "no_text_file" signatures because of their MIME type (text/html instead of text/plain)
- refactoring and ruff fixes