### PR TITLE
hanging CI action fix

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: [ self-hosted, linux, x64, "${{ matrix.os }}" ]
     env:
       DEBIAN_FRONTEND: noninteractive
-    timeout-minutes: 45
+    timeout-minutes: 35
     steps:
       - name: Add Masks
         run: |

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -14,6 +14,8 @@ jobs:
       matrix:
         os: [ focal, jammy, bullseye, bookworm ]
     runs-on: [ self-hosted, linux, x64, "${{ matrix.os }}" ]
+    env:
+      DEBIAN_FRONTEND: noninteractive
     timeout-minutes: 45
     steps:
       - name: Add Masks

--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -14,8 +14,6 @@ jobs:
       matrix:
         os: [ focal, jammy, bullseye, bookworm ]
     runs-on: [ self-hosted, linux, x64, "${{ matrix.os }}" ]
-    env:
-      DEBIAN_FRONTEND: noninteractive
     timeout-minutes: 35
     steps:
       - name: Add Masks

--- a/src/install/pre_install.sh
+++ b/src/install/pre_install.sh
@@ -64,7 +64,12 @@ echo \
 
 # Install Docker Engine
 sudo apt-get update
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo apt-get -o Dpkg::Options::="--force-confnew" install -y \
+  docker-ce \
+  docker-ce-cli \
+  containerd.io \
+  docker-buildx-plugin \
+  docker-compose-plugin
 
 sudo systemctl enable docker
 


### PR DESCRIPTION
* set `Dpkg::Options::="--force-confnew"` apt-get option to automatically accept a new configuration during the docker installation
  * the installation (and the CI) will hang otherwise, waiting for manual input
* reduce timeout from 45 to 35 min (the CI should not run much more than 25 min even if all workers are busy)