### PR TITLE
unpacking: retry bugfix

### DIFF
--- a/src/unpacker/extraction_container.py
+++ b/src/unpacker/extraction_container.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from http import HTTPStatus
 import logging
 from contextlib import suppress
 from os import getgid, getuid
@@ -16,6 +17,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from docker.models.containers import Container
+    from requests.adapters import Response
     from tempfile import TemporaryDirectory
     import multiprocessing
 
@@ -30,7 +32,7 @@ class ExtractionContainer:
         self.port = config.backend.unpacking.base_port + id_
         self.container_id = None
         self.exception = value
-        self._adapter = HTTPAdapter(max_retries=Retry(total=5, backoff_factor=0.1))
+        self._adapter = HTTPAdapter(max_retries=Retry(total=3, backoff_factor=0.1))
 
     def start(self):
         if self.container_id is not None:
@@ -111,8 +113,20 @@ class ExtractionContainer:
         container = self._get_container()
         return container.logs().decode(errors='replace')
 
-    def start_unpacking(self, tmp_dir: str, timeout: int | None = None):
+    def start_unpacking(self, tmp_dir: str, timeout: int | None = None) -> Response:
+        response = self._check_connection()
+        if response.status_code != HTTPStatus.OK:
+            return response
         url = f'http://localhost:{self.port}/start/{Path(tmp_dir).name}'
+        return requests.get(url, timeout=timeout)
+
+    def _check_connection(self) -> Response:
+        """
+        Try to access the /status endpoint of the container to make sure the container is ready.
+        The `self._adapter` includes a retry in order to wait if the connection cannot be established directly.
+        We can't retry on the actual /start endpoint (or else we would start unpacking multiple times).
+        """
+        url = f'http://localhost:{self.port}/status'
         with requests.Session() as session:
             session.mount('http://', self._adapter)
-            return session.get(url, timeout=timeout)
+            return session.get(url, timeout=5)


### PR DESCRIPTION
fixed bug where an unpacking container timeout during get leads to multiple extractions because of a retry