### PR TITLE
github: Add ruff action

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,11 @@
+name: Ruff
+on: [push, pull_request]
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: chartboost/ruff-action@v1
+        with:
+          version: 0.0.275


### PR DESCRIPTION
While it is not that popular according to github stars it is the one mentioned in the official docs.

https://beta.ruff.rs/docs/usage/#github-action