### PR TITLE
fixed a yara meta parsing bug

### DIFF
--- a/src/analysis/YaraPluginBase.py
+++ b/src/analysis/YaraPluginBase.py
@@ -106,9 +106,11 @@ def _append_match_to_result(match, resulting_matches: dict[str, dict], rule):
 
 def _parse_meta_data(meta_data_string: str) -> dict[str, str | bool | int]:
     '''
-    Will be of form 'item0=lowercaseboolean0,item1="value1",item2=value2,..'
+    Will be of form 'item0=lowercaseboolean0,item1="str1",item2=int2,...'
     '''
     try:
+        # YARA insert backslashes before single quotes in the meta output and the YAML parser doesn't like that
+        meta_data_string = meta_data_string.replace(r"\'", "'")
         meta_data = yaml.safe_load(f'{{{meta_data_string.replace("=", ": ")}}}')
         assert isinstance(meta_data, dict)
         return meta_data

--- a/src/test/unit/analysis/test_yara_plugin_base.py
+++ b/src/test/unit/analysis/test_yara_plugin_base.py
@@ -87,7 +87,7 @@ def test_rule_metadata_can_be_parsed(caplog, signature_file):
         if rule_name == 'SHORT_NAME_OF_SOFTWARE':  # ignore demo rule
             continue
         yara_output_form = ','.join(
-            meta_data.replace('    ', '').replace('\t', '').replace(' = ', '=').splitlines()
+            meta_data.replace('    ', '').replace('\t', '').replace(' = ', '=').replace("'", "\\'").splitlines()
         ).strip(',')
         with caplog.at_level(logging.WARNING):
             output = _parse_meta_data(yara_output_form)


### PR DESCRIPTION
- fixed a YARA meta parsing bug caused by single quotes in metadata strings
  - YARA apparently inserts backslashes before single quotes in metadata strings (even though the strings themselves use double quotes)
  - the YAML parser does not like that ("unknown escape")
- changed the parsing test so that it replicates the problem