### PR TITLE
update preset `KeyError` fix

### DIFF
--- a/src/web_interface/components/analysis_routes.py
+++ b/src/web_interface/components/analysis_routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from contextlib import suppress
 from typing import TYPE_CHECKING
@@ -244,6 +245,9 @@ def _add_preset_from_firmware(plugin_dict, fw: Firmware):
         plugin_dict.pop('unpacker')
         previously_processed_plugins.remove('unpacker')
     for plugin in previously_processed_plugins:
-        plugin_dict[plugin][2][preset_name] = True
+        if plugin in plugin_dict:
+            plugin_dict[plugin][2][preset_name] = True
+        else:
+            logging.warning(f'Previously used analysis plugin {plugin} not found for update preset')
 
     return preset_name


### PR DESCRIPTION
fixed a `KeyError` that occurs during update preset generation when a plugin is removed (but the DB entry of the FW contains an analysis result of that plugin)