### PR TITLE
More vfp fixes

### DIFF
--- a/src/storage/entry_conversion.py
+++ b/src/storage/entry_conversion.py
@@ -12,7 +12,7 @@ from storage.schema import AnalysisEntry, FileObjectEntry, FirmwareEntry, Virtua
 
 def firmware_from_entry(fw_entry: FirmwareEntry, analysis_filter: list[str] | None = None) -> Firmware:
     firmware = Firmware()
-    _populate_fo_data(fw_entry.root_object, firmware, analysis_filter)
+    _populate_fo_data(fw_entry.root_object, firmware, analysis_filter, parent_fw=set())
     firmware.device_name = fw_entry.device_name
     firmware.device_class = fw_entry.device_class
     firmware.release_date = convert_time_to_str(fw_entry.release_date)
@@ -23,15 +23,16 @@ def firmware_from_entry(fw_entry: FirmwareEntry, analysis_filter: list[str] | No
     return firmware
 
 
-def file_object_from_entry(
+def file_object_from_entry(  # noqa: PLR0913
     fo_entry: FileObjectEntry,
     analysis_filter: list[str] | None = None,
     included_files: set[str] | None = None,
     parents: set[str] | None = None,
     virtual_file_paths: dict[str, list[str]] | None = None,
+    parent_fw: set[str] | None = None,
 ) -> FileObject:
     file_object = FileObject()
-    _populate_fo_data(fo_entry, file_object, analysis_filter, included_files, parents, virtual_file_paths)
+    _populate_fo_data(fo_entry, file_object, analysis_filter, included_files, parents, virtual_file_paths, parent_fw)
     return file_object
 
 
@@ -49,6 +50,7 @@ def _populate_fo_data(  # noqa: PLR0913
     included_files: set[str] | None = None,
     parents: set[str] | None = None,
     virtual_file_paths: dict[str, list[str]] | None = None,
+    parent_fw: set[str] | None = None,
 ):
     file_object.uid = fo_entry.uid
     file_object.size = fo_entry.size
@@ -63,7 +65,7 @@ def _populate_fo_data(  # noqa: PLR0913
     file_object.comments = fo_entry.comments
     file_object.parents = fo_entry.get_parent_uids() if parents is None else parents
     file_object.files_included = fo_entry.get_included_uids() if included_files is None else included_files
-    file_object.parent_firmware_uids = set(file_object.virtual_file_path)
+    file_object.parent_firmware_uids = fo_entry.get_parent_fw_uids() if parent_fw is None else parent_fw
 
 
 def _collect_analysis_tags(analysis_dict: dict) -> dict:

--- a/src/storage/schema.py
+++ b/src/storage/schema.py
@@ -123,6 +123,9 @@ class FileObjectEntry(Base):
     def get_parent_uids(self) -> set[str]:
         return {parent.uid for parent in self.parent_files}
 
+    def get_parent_fw_uids(self) -> set[str]:
+        return {fw.uid for fw in self.root_firmware}
+
     def __repr__(self) -> str:
         return f'FileObject({self.uid}, {self.file_name}, {self.is_firmware})'
 

--- a/src/test/integration/storage/test_db_interface_backend.py
+++ b/src/test/integration/storage/test_db_interface_backend.py
@@ -4,7 +4,7 @@ import pytest
 
 from test.common_helper import create_test_file_object, create_test_firmware
 
-from .helper import TEST_FO, TEST_FW, create_fw_with_child_fo, create_fw_with_parent_and_child
+from .helper import TEST_FO, TEST_FW, create_fw_with_child_fo, create_fw_with_parent_and_child, add_included_file
 
 
 def test_insert_objects(backend_db):
@@ -114,11 +114,8 @@ def test_update_duplicate_other_fw(backend_db, frontend_db):
 
     fw2 = create_test_firmware()
     fw2.uid = 'test_fw2'
-    fw2.files_included = [fo.uid]
-    fo2 = create_test_file_object()
-    fo2.uid = fo.uid
-    fo2.virtual_file_path = {fw2.uid: [f'{fw2.uid}|/some/path']}
-    fo2.parents = {fw2.uid}
+    fo2 = create_test_file_object(uid=fo.uid)
+    add_included_file(fo2, fw2, fw2, ['/some/path'])
 
     backend_db.add_object(fw2)
     backend_db.add_object(fo2)
@@ -137,7 +134,7 @@ def test_update_duplicate_same_fw(backend_db, frontend_db):
     fo, fw = create_fw_with_child_fo()
     backend_db.insert_multiple_objects(fw, fo)
 
-    fo.virtual_file_path[fw.uid].append(f'{fw.uid}|/some/other/path')
+    fo.virtual_file_path[fw.uid].append('/some/other/path')
     backend_db.add_object(fo)
 
     db_fo = frontend_db.get_object(fo.uid)

--- a/src/test/integration/storage/test_db_interface_backend.py
+++ b/src/test/integration/storage/test_db_interface_backend.py
@@ -219,3 +219,20 @@ def test_update_analysis(backend_db, common_db):
     assert analysis['result']['content'] == 'file efgh'
     assert analysis['summary'] == updated_analysis_data['summary']
     assert analysis['plugin_version'] == updated_analysis_data['plugin_version']
+
+
+def test_get_parent_fw(backend_db, common_db):
+    fw, parent_fo, child_fo = create_fw_with_parent_and_child()
+    fw2 = create_test_firmware()
+    fw2.uid = 'test_fw2'
+    add_included_file(child_fo, fw2, fw2, ['/some/path'])
+    backend_db.insert_multiple_objects(fw, fw2, parent_fo, child_fo)
+
+    root_fw = common_db.get_parent_fw(child_fo.uid)
+    assert root_fw == {fw.uid, fw2.uid}
+
+    root_fw_dict = common_db.get_parent_fw_for_uid_list([fw.uid, parent_fo.uid, child_fo.uid])
+    assert root_fw_dict == {
+        parent_fo.uid: {fw.uid},
+        child_fo.uid: {fw.uid, fw2.uid},
+    }

--- a/src/test/unit/web_interface/test_app_jinja_filter_static.py
+++ b/src/test/unit/web_interface/test_app_jinja_filter_static.py
@@ -13,19 +13,20 @@ def test_split_user_and_password_type_entry():
 
 
 @pytest.mark.parametrize(
-    ('hid', 'uid', 'expected_output'),
+    ('hid', 'uid', 'current_uid', 'expected_output'),
     [
-        ('foo', 'bar', 'badge-secondary">foo'),
-        ('foo', 'a152ccc610b53d572682583e778e43dc1f24ddb6577255bff61406bc4fb322c3_21078024', 'badge-primary">    <a'),
+        ('hid', 'uid', 'uid', 'badge-secondary">hid'),
+        ('hid', 'uid', 'different_uid', 'badge-primary">    <a'),
         (
             'suuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuper/long/human_readable_id',
-            'bar',
+            'uid',
+            'uid',
             '~uuuuuuuuuuuuuuuuuuuuuuuuuuuuper/long/human_readable_id',
         ),
     ],
 )
-def test_virtual_path_element_to_span(hid, uid, expected_output):
-    assert expected_output in FilterClass._virtual_path_element_to_span(hid, uid, 'root_uid')
+def test_virtual_path_element_to_span(hid, uid, current_uid, expected_output):
+    assert expected_output in FilterClass._virtual_path_element_to_span(hid, uid, 'root_uid', current_uid)
 
 
 class FilterClassMock:

--- a/src/web_interface/components/ajax_routes.py
+++ b/src/web_interface/components/ajax_routes.py
@@ -34,7 +34,8 @@ class AjaxRoutes(ComponentBase):
 
     def _generate_file_tree(self, root_uid: str | None, uid: str, whitelist: list[str]) -> FileTreeNode:
         if root_uid is None:
-            root_uid = self.db.frontend.get_parent_fw(uid)
+            # parent FW set should never be empty (if it were empty, the file would not belong to any FW)
+            root_uid = list(self.db.frontend.get_parent_fw(uid)).pop()
         root = FileTreeNode(None)
         with get_shared_session(self.db.frontend) as frontend_db:
             child_uids = [

--- a/src/web_interface/components/ajax_routes.py
+++ b/src/web_interface/components/ajax_routes.py
@@ -32,7 +32,9 @@ class AjaxRoutes(ComponentBase):
             return self.db.comparison.get_exclusive_files(compare_id, root_uid)
         return None
 
-    def _generate_file_tree(self, root_uid: str, uid: str, whitelist: list[str]) -> FileTreeNode:
+    def _generate_file_tree(self, root_uid: str | None, uid: str, whitelist: list[str]) -> FileTreeNode:
+        if root_uid is None:
+            root_uid = self.db.frontend.get_parent_fw(uid)
         root = FileTreeNode(None)
         with get_shared_session(self.db.frontend) as frontend_db:
             child_uids = [

--- a/src/web_interface/components/jinja_filter.py
+++ b/src/web_interface/components/jinja_filter.py
@@ -95,7 +95,7 @@ class FilterClass:
         all_uids = {uid for uid_list in virtual_path_list for uid in uid_list}
         hid_dict = self.db.frontend.get_hid_dict(all_uids, root_uid=root_uid)
         for uid_list in virtual_path_list:
-            components = [self._virtual_path_element_to_span(hid_dict[uid], uid, root_uid=root_uid) for uid in uid_list]
+            components = [self._virtual_path_element_to_span(hid_dict.get(uid, uid), uid, root_uid) for uid in uid_list]
             path_list.append(' '.join(components))
         return path_list
 

--- a/src/web_interface/components/jinja_filter.py
+++ b/src/web_interface/components/jinja_filter.py
@@ -11,7 +11,7 @@ import web_interface.filter as flt
 from helperFunctions.data_conversion import none_to_none
 from helperFunctions.database import get_shared_session
 from helperFunctions.hash import get_md5
-from helperFunctions.uid import is_list_of_uids, is_uid
+from helperFunctions.uid import is_list_of_uids
 from helperFunctions.web_interface import cap_length_of_element, get_color_list
 from web_interface.filter import elapsed_time, random_collapse_id
 from typing import TYPE_CHECKING
@@ -95,22 +95,26 @@ class FilterClass:
         all_uids = {uid for uid_list in virtual_path_list for uid in uid_list}
         hid_dict = self.db.frontend.get_hid_dict(all_uids, root_uid=root_uid)
         for uid_list in virtual_path_list:
-            components = [self._virtual_path_element_to_span(hid_dict.get(uid, uid), uid, root_uid) for uid in uid_list]
+            components = [
+                self._virtual_path_element_to_span(hid_dict.get(uid, uid), uid, root_uid, uid_list[-1])
+                for uid in uid_list
+            ]
             path_list.append(' '.join(components))
         return path_list
 
     @staticmethod
-    def _virtual_path_element_to_span(hid_element: str, uid_element, root_uid) -> str:
+    def _virtual_path_element_to_span(hid_element: str, uid: str, root_uid: str, current_file_uid: str) -> str:
         hid = cap_length_of_element(hid_element)
-        if is_uid(uid_element):
-            return (
-                '<span class="badge badge-primary">'
-                f'    <a style="color: #fff" href="/analysis/{uid_element}/ro/{root_uid}">'
-                f'        {hid}'
-                '    </a>'
-                '</span>'
-            )
-        return f'<span class="badge badge-secondary">{hid}</span>'
+        if uid == current_file_uid:
+            # if we are on the analysis page of this file, the element should not contain a link and use another color
+            return f'<span class="badge badge-secondary">{hid}</span>'
+        return (
+            '<span class="badge badge-primary">'
+            f'    <a style="color: #fff" href="/analysis/{uid}/ro/{root_uid}">'
+            f'        {hid}'
+            '    </a>'
+            '</span>'
+        )
 
     @staticmethod
     def _render_firmware_detail_tabular_field(firmware_meta_data):

--- a/src/web_interface/file_tree/file_tree.py
+++ b/src/web_interface/file_tree/file_tree.py
@@ -180,24 +180,13 @@ class VirtualPathFileTree:
 
     def __init__(self, root_uid: str, parent_uid: str, fo_data: FileTreeData, whitelist: list[str] | None = None):
         self.uid = fo_data.uid
-        self.root_uid = root_uid if root_uid else self._find_root_uid(parent_uid, fo_data)
+        self.root_uid = root_uid
         self.parent_uid = parent_uid
         self.fo_data: FileTreeData = fo_data
         self.whitelist = whitelist
         self.virtual_file_paths: Optional[list[str]] = (
             fo_data.virtual_file_path.get(parent_uid) if fo_data.virtual_file_path else None
         )
-
-    @staticmethod
-    def _find_root_uid(parent_uid: str, fo_data: FileTreeData) -> str:
-        """
-        If we don't have a rood_uid, we must find a root_uid that contains the parent_uid (we can't just take a
-        random one because then the files could be missing from the file tree).
-        """
-        for root_uid, vfp_list in fo_data.virtual_file_path.items():
-            if any(parent_uid in vfp for vfp in vfp_list):
-                return root_uid
-        return list(fo_data.virtual_file_path)[0]  # safety fallback: this should not occur under normal circumstances
 
     def get_file_tree_nodes(self) -> Iterable[FileTreeNode]:
         """


### PR DESCRIPTION
`FileObject.parent_firmware_uids` is set based on `virtual_file_path` which worked in the past, because the keys were the root FW UIDs. Now however, the keys are the parent container UIDs and the contents of `FileObject.parent_firmware_uids` are therefore wrong. This causes some VFP-related bugs in the frontend.