### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/analysis/plugin/plugin.py
+++ b/src/analysis/plugin/plugin.py
@@ -134,7 +134,7 @@ class AnalysisPluginV0(metaclass=abc.ABCMeta):
         # Misses the root uid, which must be added by the scheduler
         tags_dict = {}
         for tag in tags:
-            tag_dict = tag.dict()
+            tag_dict = tag.model_dump()
             name = tag_dict.pop('name')
             tags_dict.update({name: tag_dict})
 
@@ -145,7 +145,7 @@ class AnalysisPluginV0(metaclass=abc.ABCMeta):
             'system_version': self.metadata.system_version,
             'summary': summary,
             'tags': tags_dict,
-            'result': result.dict() if result else None,
+            'result': result.model_dump() if result else None,
         }
 
     def get_tags(self, result: Schema, summary: list[str]) -> list[Tag]:

--- a/src/config.py
+++ b/src/config.py
@@ -171,9 +171,9 @@ def load(path: str | None = None):
         When you only import the ``config`` module the ``load`` function will be looked up at runtime.
         See `this blog entry <https://alexmarandon.com/articles/python_mock_gotchas/>`_ for some more information.
     """
-    Common.update_forward_refs()
-    Backend.update_forward_refs()
-    Frontend.update_forward_refs()
+    Common.model_rebuild()
+    Backend.model_rebuild()
+    Frontend.model_rebuild()
     if path is None:
         path = Path(__file__).parent / 'config/fact-core-config.toml'
 
@@ -190,7 +190,7 @@ def load(path: str | None = None):
     preset_dict = {}
     for preset in preset_list:
         p = Common.AnalysisPreset(**preset)
-        preset_dict[p.name] = p.dict()
+        preset_dict[p.name] = p.model_dump()
 
     common_dict['analysis_preset'] = preset_dict
 
@@ -198,7 +198,7 @@ def load(path: str | None = None):
     plugin_dict = {}
     for plugin in plugin_list:
         p = Backend.Plugin(**plugin)
-        plugin_dict[p.name] = p.dict()
+        plugin_dict[p.name] = p.model_dump()
 
     backend_dict['plugin'] = plugin_dict
 

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -8,8 +8,7 @@ from tempfile import TemporaryDirectory
 from typing import Type, Union
 
 import pytest
-from pydantic import BaseModel, Field
-from pydantic.v1 import ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from pydantic.v1.utils import deep_update
 
 import config

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -9,7 +9,8 @@ from typing import Type, Union
 
 import pytest
 from pydantic import BaseModel, Field
-from pydantic.utils import deep_update
+from pydantic.v1 import ConfigDict
+from pydantic.v1.utils import deep_update
 
 import config
 from analysis.PluginBase import AnalysisBasePlugin
@@ -123,7 +124,7 @@ def backend_config(request, common_config, _firmware_file_storage_directory) -> 
         },
     }
 
-    test_config.update(common_config.dict())
+    test_config.update(common_config.model_dump())
     test_config = deep_update(test_config, overwrite_config)
 
     return config.Backend(**test_config)
@@ -146,7 +147,7 @@ def frontend_config(request, common_config) -> config.Frontend:
         },
     }
 
-    test_config.update(common_config.dict())
+    test_config.update(common_config.model_dump())
     test_config = deep_update(test_config, overwrite_config)
 
     return config.Frontend(**test_config)
@@ -178,6 +179,8 @@ def patch_config(monkeypatch, common_config, backend_config, frontend_config):  
 class AnalysisPluginTestConfig(BaseModel):
     """A class configuring the :py:func:`analysis_plugin` fixture."""
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     #: The class of the plugin to be tested. It will most probably be called ``AnalysisPlugin``.
     plugin_class: Union[Type[AnalysisBasePlugin], Type[AnalysisPluginV0]] = AnalysisBasePlugin
     #: Whether or not to start the workers (see ``AnalysisPlugin.start``).
@@ -186,9 +189,6 @@ class AnalysisPluginTestConfig(BaseModel):
     #: Keyword arguments to be given to the ``plugin_class`` constructor.
     #: Not supported for AnalysisPluginV0
     init_kwargs: dict = Field(default_factory=dict)
-
-    class Config:
-        arbitrary_types_allowed = True
 
 
 @pytest.fixture

--- a/src/install/requirements_backend.txt
+++ b/src/install/requirements_backend.txt
@@ -8,7 +8,7 @@ pyyaml==6.0.1
 
 # FIXME This is only needed by the compare/file_header plugin
 #       See Issue #832
-flask==2.3.2
+flask==2.3.3
 
 git+https://github.com/fkie-cad/common_helper_yara.git
 

--- a/src/install/requirements_frontend.txt
+++ b/src/install/requirements_frontend.txt
@@ -1,12 +1,12 @@
 bcrypt==4.0.1
-email-validator==1.3.0
+email-validator==1.3.1
 flask-login==0.6.2
 flask-paginate==2022.1.8
-flask-security-too==5.2.0
+flask-security-too==5.3.0
 flask-wtf==1.1.1
-flask==2.3.2
+flask==2.3.3
 flask_restx==1.1.0
-flask_sqlalchemy==3.0.2
+flask_sqlalchemy==3.0.5
 itsdangerous==2.1.2
 matplotlib==3.5.3
 more_itertools==9.0.0
@@ -17,7 +17,7 @@ uwsgi==2.0.22
 virtualenv
 
 # must be below dependent packages (flask, flask-login, flask-restx)
-werkzeug==2.3.4
+werkzeug==2.3.7
 
 # Used for username validation by flask-security
 bleach==5.0.1

--- a/src/plugins/analysis/file_system_metadata/test/test_file_system_metadata_routes.py
+++ b/src/plugins/analysis/file_system_metadata/test/test_file_system_metadata_routes.py
@@ -1,5 +1,4 @@
 from base64 import b64encode
-from unittest import TestCase
 
 from decorator import contextmanager
 from flask import Flask
@@ -107,7 +106,7 @@ class DbMock:
 
 
 class TestFileSystemMetadataRoutes:
-    def setup(self):
+    def setup_method(self):
         app = Flask(__name__)
         app.config.from_object(__name__)
         app.config['TESTING'] = True
@@ -121,8 +120,8 @@ class TestFileSystemMetadataRoutes:
         assert 'test_value' in rv.data.decode()
 
 
-class TestFileSystemMetadataRoutesRest(TestCase):
-    def setUp(self):
+class TestFileSystemMetadataRoutesRest:
+    def setup_method(self):
         app = Flask(__name__)
         app.config.from_object(__name__)
         app.config['TESTING'] = True

--- a/src/plugins/analysis/qemu_exec/test/test_routes.py
+++ b/src/plugins/analysis/qemu_exec/test/test_routes.py
@@ -86,8 +86,8 @@ class DbMock:
     frontend = DbInterfaceMock()
 
 
-class TestFileSystemMetadataRoutes:
-    def setup(self):
+class TestQemuExecRoutes:
+    def setup_method(self):
         app = Flask(__name__)
         app.config.from_object(__name__)
         app.config['TESTING'] = True
@@ -119,8 +119,8 @@ class TestFileSystemMetadataRoutes:
         assert 'some error' in response
 
 
-class TestFileSystemMetadataRoutesRest:
-    def setup(self):
+class TestQemuExecRoutesRest:
+    def setup_method(self):
         app = Flask(__name__)
         app.config.from_object(__name__)
         app.config['TESTING'] = True

--- a/src/plugins/compare/file_header/code/file_header.py
+++ b/src/plugins/compare/file_header/code/file_header.py
@@ -1,6 +1,6 @@
 import binascii
 
-from flask import Markup
+from markupsafe import Markup
 
 from compare.PluginBase import CompareBasePlugin
 

--- a/src/plugins/compare/file_header/test/test_file_header.py
+++ b/src/plugins/compare/file_header/test/test_file_header.py
@@ -1,4 +1,4 @@
-from flask import Markup
+from markupsafe import Markup
 
 from test.unit.compare.compare_plugin_test_class import ComparePluginTest
 

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -2,8 +2,10 @@ from multiprocessing import Event, Queue, Value
 from typing import List, NamedTuple, Type, TypeVar
 
 import pytest
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel
 from pathlib import Path
+
+from pydantic.v1 import ConfigDict
 
 import config
 from scheduler.analysis import AnalysisScheduler
@@ -64,7 +66,7 @@ def merge_markers(request, name: str, dtype: Type[T]) -> T:
             if isinstance(argument, dict):
                 marker_dict.update(argument)
             elif isinstance(argument, BaseModel):
-                marker_dict.update(argument.dict())
+                marker_dict.update(argument.model_dump())
         else:
             raise _err
     return dtype(**marker_dict)
@@ -81,6 +83,8 @@ class DatabaseInterfaces(NamedTuple):
 
 
 class MockDataStorage(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
     postgres_server: str
     postgres_port: int
     postgres_database: str
@@ -103,20 +107,16 @@ class MockDataStorage(BaseModel):
     redis_host: str
     redis_port: int
 
-    class Config:
-        extra = Extra.forbid
-
 
 class ConfigCommonMock(BaseModel):
     """This class is a mock of :py:class:`config.Common` which only contains
     postgres and redis configuration.
     """
 
+    model_config = ConfigDict(extra='forbid')
+
     postgres: config.Common.Postgres
     redis: config.Common.Redis
-
-    class Config:
-        extra = Extra.forbid
 
 
 class MockIntercom:

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -2,10 +2,8 @@ from multiprocessing import Event, Queue, Value
 from typing import List, NamedTuple, Type, TypeVar
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from pathlib import Path
-
-from pydantic.v1 import ConfigDict
 
 import config
 from scheduler.analysis import AnalysisScheduler

--- a/src/test/integration/web_interface/rest/base.py
+++ b/src/test/integration/web_interface/rest/base.py
@@ -2,7 +2,7 @@ from web_interface.frontend_main import WebFrontEnd
 
 
 class RestTestBase:
-    def setup(self):
+    def setup_method(self):
         self.frontend = WebFrontEnd()
         self.frontend.app.config['TESTING'] = True
         self.test_client = self.frontend.app.test_client()

--- a/src/test/integration/web_interface/rest/test_rest_binary.py
+++ b/src/test/integration/web_interface/rest/test_rest_binary.py
@@ -12,12 +12,12 @@ from test.integration.web_interface.rest.base import RestTestBase
 
 @pytest.mark.usefixtures('database_interfaces')
 class TestRestDownload(RestTestBase):
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         self.db_interface = BackendDbInterface()
         self.test_queue = Queue()
 
-    def teardown(self):
+    def teardown_method(self):
         self.test_queue.close()
 
     def test_rest_download_valid(self, backend_config):

--- a/src/test/integration/web_interface/rest/test_rest_statistics.py
+++ b/src/test/integration/web_interface/rest/test_rest_statistics.py
@@ -8,8 +8,8 @@ from test.integration.web_interface.rest.base import RestTestBase
 
 @pytest.mark.usefixtures('database_interfaces')
 class TestRestStatistics(RestTestBase):
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         self.stats_updater = StatsUpdateDbInterface()
         self.stats_updater.update_statistic(
             'file_type',

--- a/src/test/unit/compare/compare_plugin_test_class.py
+++ b/src/test/unit/compare/compare_plugin_test_class.py
@@ -9,7 +9,7 @@ class ComparePluginTest:
     PLUGIN_NAME = 'base'
     PLUGIN_CLASS = None
 
-    def setup(self):
+    def setup_method(self):
         self.config = self.generate_config()
         self.config.add_section('expert-settings')
         self.config.set('expert-settings', 'ssdeep-ignore', '80')
@@ -17,7 +17,7 @@ class ComparePluginTest:
         self.c_plugin = self.setup_plugin()
         self.setup_test_fw()
 
-    def teardown(self):
+    def teardown_method(self):
         gc.collect()
 
     def setup_plugin(self):

--- a/src/test/unit/compare/test_plugin_base.py
+++ b/src/test/unit/compare/test_plugin_base.py
@@ -14,7 +14,7 @@ def compare_plugin():
     return ComparePlugin(view_updater=CommonDatabaseMock())
 
 
-@pytest.mark.backend_config(
+@pytest.mark.backend_config_overwrite(
     {
         'ssdeep_ignore': 80,
     }

--- a/src/test/unit/web_interface/test_plugin_routes.py
+++ b/src/test/unit/web_interface/test_plugin_routes.py
@@ -24,7 +24,7 @@ class PluginRoutesMock(PluginRoutes):
 
 
 class TestPluginRoutes:
-    def setup(self):
+    def setup_method(self):
         self.app = Flask(__name__)
         self.app.config.from_object(__name__)
         self.api = Api(self.app)


### PR DESCRIPTION
[The last scheduled master CI build](https://github.com/fkie-cad/FACT_core/actions/runs/5995159722/job/16257774384) had 43624 warnings when running the tests. This PR should reduce this number to less than 30. There are some warnings that can't be fixed because they are caused by dependencies or where it is too complicated (the crypto_hints plugin should be fixed in its own PR).