### PR TITLE
fix(plugins): Don't crash when result is None

### DIFF
--- a/src/analysis/plugin/plugin.py
+++ b/src/analysis/plugin/plugin.py
@@ -125,7 +125,7 @@ class AnalysisPluginV0(metaclass=abc.ABCMeta):
         result = self.analyze(file_handle, virtual_file_path, analyses)
 
         summary = None
-        tags = None
+        tags = []
         if result is not None:
             summary = self.summarize(result)
             tags = self.get_tags(result, summary)


### PR DESCRIPTION
The idea here as to have the symmetry that when result is None the tags would also be None.
While I like this in general this was not thought out. The get_tags signature did not allow this and the rest of the codebase was not build with this in mind.