### PR TITLE
updated pyopenssl version to fix dependency version conflict

### DIFF
--- a/src/install/requirements_backend.txt
+++ b/src/install/requirements_backend.txt
@@ -3,7 +3,7 @@ docker==6.0.1
 MarkupSafe==2.1.1
 networkx==2.6.3
 Pillow==9.3.0
-pyopenssl==22.1.0
+pyopenssl==23.2.0
 pyyaml==6.0.1
 
 # FIXME This is only needed by the compare/file_header plugin


### PR DESCRIPTION
fixes dependency version conflict caused by `cryptography==41.0.3` being installed in `requirements_backend.txt` and `pyopenssl==22.1.0` from the same file depending on 38.0.0<=cryptography<39