### PR TITLE
Clickable analysis tags

### DIFF
--- a/src/test/integration/web_interface/test_filter.py
+++ b/src/test/integration/web_interface/test_filter.py
@@ -25,11 +25,11 @@ def test_list_group_collapse(frontend):
 @pytest.mark.parametrize(
     ('tag_dict', 'output'),
     [
-        ({'a': 'danger'}, '<span class="badge badge-danger mr-2" style="font-size: 14px;" > a</span>'),
+        ({'a': 'danger'}, '<span class="badge badge-danger mr-2" style="font-size: 14px;"  > a</span>'),
         (
             {'a': 'danger', 'b': 'primary'},
-            '<span class="badge badge-danger mr-2" style="font-size: 14px;" > a</span>'
-            '<span class="badge badge-primary mr-2" style="font-size: 14px;" > b</span>',
+            '<span class="badge badge-danger mr-2" style="font-size: 14px;"  > a</span>'
+            '<span class="badge badge-primary mr-2" style="font-size: 14px;"  > b</span>',
         ),
         (None, ''),
     ],
@@ -49,6 +49,16 @@ def test_render_analysis_tags_success(frontend):
         output = render_analysis_tags(tags).replace('\n', '').replace('    ', ' ')
     assert 'badge-success' in output
     assert '> wow<' in output
+
+
+def test_render_analysis_tags_link(frontend):
+    plugin, uid, root_uid = 'plugin1', 'foo', 'bar'
+    tags = {plugin: {'tag': {'color': 'success', 'value': 'some_value'}}}
+    with frontend.app.app_context():
+        output = render_analysis_tags(tags, uid=uid, root_uid=root_uid)
+    assert 'onclick' in output
+    link = f'/analysis/{uid}/{plugin}/ro/{root_uid}?load_summary=true'
+    assert link in output
 
 
 def test_render_analysis_tags_fix(frontend):

--- a/src/web_interface/components/ajax_routes.py
+++ b/src/web_interface/components/ajax_routes.py
@@ -6,6 +6,7 @@ from flask import jsonify, render_template
 
 from helperFunctions.data_conversion import none_to_none
 from helperFunctions.database import get_shared_session
+from objects.firmware import Firmware
 from web_interface.components.component_base import AppRoute, ComponentBase, GET
 from web_interface.components.hex_highlighting import preview_data_as_hex
 from web_interface.file_tree.file_tree import remove_virtual_path_from_root
@@ -114,10 +115,11 @@ class AjaxRoutes(ComponentBase):
         with get_shared_session(self.db.frontend) as frontend_db:
             firmware = frontend_db.get_object(uid, analysis_filter=selected_analysis)
             summary_of_included_files = frontend_db.get_summary(firmware, selected_analysis)
+            root_uid = uid if isinstance(firmware, Firmware) else frontend_db.get_root_uid(uid)
         return render_template(
             'summary.html',
             summary_of_included_files=summary_of_included_files,
-            root_uid=uid,
+            root_uid=root_uid,
             selected_analysis=selected_analysis,
         )
 

--- a/src/web_interface/filter.py
+++ b/src/web_interface/filter.py
@@ -281,7 +281,7 @@ def render_fw_tags(tag_dict, size=14):
     return output
 
 
-def render_analysis_tags(tags, size=14):
+def render_analysis_tags(tags, uid=None, root_uid=None, size=14):
     output = ''
     if tags:
         for plugin_name in tags:
@@ -295,6 +295,9 @@ def render_analysis_tags(tags, size=14):
                     value=tag['value'],
                     tooltip=f'{plugin_name}: {key}',
                     size=size,
+                    plugin=plugin_name,
+                    root_uid=root_uid,
+                    uid=uid,
                 )
     return output
 

--- a/src/web_interface/static/js/show_analysis_summary.js
+++ b/src/web_interface/static/js/show_analysis_summary.js
@@ -1,9 +1,14 @@
-function load_summary(uid, selected_analysis){
+function load_summary(uid, selected_analysis, focus=false){
     $("#summary-button").css("display", "none");
     let summary_gif = $("#loading-summary-gif");
     summary_gif.css("display", "block");
     $("#summary-div").load(
         `/ajax_get_summary/${uid}/${selected_analysis}`,
-        () => {summary_gif.css("display", "none");}
+        () => {
+            summary_gif.css("display", "none");
+            if (focus === true) {
+                location.href = "#summary-heading";
+            }
+        }
     );
 }

--- a/src/web_interface/templates/generic_view/tags.html
+++ b/src/web_interface/templates/generic_view/tags.html
@@ -5,6 +5,9 @@
         data-toggle="tooltip"
         title="{{ tooltip | replace_underscore }}"
     {%- endif %}
+    {% if uid -%}
+        onclick="location.href='http://localhost:5000/analysis/{{ uid }}/{{ plugin }}/ro/{{ root_uid }}?load_summary=true'"
+    {%- endif %}
 >
     {{ value }}
 </span>

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -114,7 +114,7 @@
             <h3>
                 {{ firmware.uid | replace_uid_with_hid(root_uid=root_uid) | safe }}<br />
                 {% if firmware.analysis_tags or firmware.tags %}
-                    {{ firmware.analysis_tags | render_analysis_tags | safe }}{{ firmware.tags | render_fw_tags | safe }}<br />
+                    {{ firmware.analysis_tags | render_analysis_tags(uid, root_uid) | safe }}{{ firmware.tags | render_fw_tags | safe }}<br />
                 {% endif %}
                 <span style="font-size: 15px"><strong>UID:</strong> {{ uid | safe }}</span>
             </h3>
@@ -316,7 +316,7 @@
                         </div>
                     </div>
                     <script type="text/javascript" src="{{ url_for('static', filename='js/show_analysis_summary.js') }}"></script>
-                    
+
                 {%- endif -%}
             </div>
 
@@ -358,7 +358,7 @@
                     </div>
 
                     {%- set is_text_preview = firmware.processed_analysis["file_type"]["result"]['mime'][0:5] == "text/" or firmware.processed_analysis["file_type"]["result"]['mime'][0:6] == "image/" %}
-                    
+
                     <script>
                         const isTextOrImage = {{ 'true' if is_text_preview else 'false' }};
                         let mimeType = '{{ firmware.processed_analysis["file_type"]["result"]["mime"].replace("/", "_") }}';
@@ -446,6 +446,15 @@
             document.body.append(radare_form);
             radare_form.submit();
         }
+        document.addEventListener("DOMContentLoaded", function() {
+            // auto load summary if URL parameter "load_summary=true" is set
+            const urlParams = new URLSearchParams(window.location.search);
+            const summary = urlParams.get('load_summary');
+            const has_children = {{ "true" if firmware.files_included | length > 0  else "false" }};
+            if (summary === "true" && has_children && selected_analysis !== "None") {
+                load_summary(uid, selected_analysis, focus=true);
+            }
+        });
     </script>
 
 {% endblock %}

--- a/src/web_interface/templates/summary.html
+++ b/src/web_interface/templates/summary.html
@@ -5,7 +5,7 @@
     </colgroup>
     <thead class="thead-light">
         <tr>
-            <th colspan=2>Summary for Included Files</th>
+            <th id="summary-heading" colspan=2>Summary for Included Files</th>
         </tr>
     </thead>
     {% if summary_of_included_files %}


### PR DESCRIPTION
- Analysis tags can be clicked and link to the summary of the analysis (which set the tag)
- The summary is loaded automatically (only if a tag was clicked, not always)
- fixed a bug in the summary for file objects