### PR TITLE
cwe-checker: add memory limit

### DIFF
--- a/src/config/fact-core-config.toml
+++ b/src/config/fact-core-config.toml
@@ -108,6 +108,14 @@ name = "cve_lookup"
 processes = 4
 
 [[backend.plugin]]
+name = "cwe_checker"
+processes = 2
+memory-limit = "4G"
+# see https://docs.docker.com/config/containers/resource_constraints/#--memory-swap-details
+# unintuitively, if memswap-limit is set to the same value as memory-limit, the swap will *not* be used
+memswap-limit = "4G"
+
+[[backend.plugin]]
 name = "elf_analysis"
 processes = 4
 

--- a/src/plugins/analysis/cwe_checker/code/cwe_checker.py
+++ b/src/plugins/analysis/cwe_checker/code/cwe_checker.py
@@ -17,6 +17,7 @@ from collections import defaultdict
 
 from docker.types import Mount
 
+import config
 from analysis.PluginBase import AnalysisBasePlugin
 from helperFunctions.docker import run_docker_container
 
@@ -36,7 +37,7 @@ class AnalysisPlugin(AnalysisBasePlugin):
         'Due to the nature of static analysis, this plugin may run for a long time.'
     )
     DEPENDENCIES = ['cpu_architecture', 'file_type']  # noqa: RUF012
-    VERSION = '0.5.2'
+    VERSION = '0.5.3'
     TIMEOUT = 600  # 10 minutes
     MIME_WHITELIST = [  # noqa: RUF012
         'application/x-executable',
@@ -50,6 +51,8 @@ class AnalysisPlugin(AnalysisBasePlugin):
 
     def additional_setup(self):
         self._log_version_string()
+        self.memory_limit = getattr(config.backend.plugin.get(self.NAME, None), 'memory_limit', '4G')
+        self.swap_limit = getattr(config.backend.plugin.get(self.NAME, None), 'memswap_limit', '4G')
 
     def _log_version_string(self):
         output = self._run_cwe_checker_to_get_version_string()
@@ -78,6 +81,8 @@ class AnalysisPlugin(AnalysisBasePlugin):
             mounts=[
                 Mount('/input', file_object.file_path, type='bind'),
             ],
+            mem_limit=self.memory_limit,
+            memswap_limit=self.swap_limit,
         )
         return result.stdout
 


### PR DESCRIPTION
- adds an option for configuring a memory limit for the `cwe_checker` plugin
  - sets a default value of 4GB