### PR TITLE
Replace deprecated nodejs repo setup with updated method

### DIFF
--- a/src/install/pre_install.sh
+++ b/src/install/pre_install.sh
@@ -80,8 +80,9 @@ then
 fi
 sudo usermod -aG docker "$FACTUSER"
 
-# Setup npm repository as described in https://github.com/nodesource/distributions/blob/master/README.md#debinstall
-curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+# Setup npm repository as described in https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions
+curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 
 IS_VENV=$(python3 -c 'import sys; print(sys.exec_prefix!=sys.base_prefix)')
 SUDO=""


### PR DESCRIPTION
The `setup_lts.x` script [has been deprecated](https://github.com/nodesource/distributions). 
> The installation scripts setup_XX.x are no longer supported and are not needed anymore, as the installation process is straightforward for any RPM and DEB distro.

This PR modifies `pre_install.sh` to use the new repo setup method. I used the 18 LTS repo since that's the one the original script set up.