### PR TITLE
Bump werkzeug to 2.3.8 to fix slow uploads of large files via the UI

### DIFF
--- a/src/install/requirements_frontend.txt
+++ b/src/install/requirements_frontend.txt
@@ -17,7 +17,7 @@ uwsgi==2.0.22
 virtualenv
 
 # must be below dependent packages (flask, flask-login, flask-restx)
-werkzeug==2.3.7
+werkzeug==2.3.8
 
 # Used for username validation by flask-security
 bleach==5.0.1

--- a/src/install/requirements_pre_install.txt
+++ b/src/install/requirements_pre_install.txt
@@ -6,7 +6,7 @@ python-magic==0.4.27
 requests==2.31.0
 # Needed by config.py
 pydantic==2.1.1
-werkzeug==2.3.4
+werkzeug==2.3.8
 toml==0.10.2
 
 git+https://github.com/fkie-cad/common_helper_files.git


### PR DESCRIPTION
I'm pretty confident that this fixes #1144. I experienced the same behavior described there (i.e. slow uploads of large files, but only when performed via the web UI). Updating to werkzeug 2.3.8 fixed the issue.

#1153 will also address this problem, but since there's no ETA on when a compatible flask-restx will be released, I think it makes sense to bump to 2.3.8 in the meantime. The slow multipart parsing is [the only change 2.3.8 contains](https://github.com/pallets/werkzeug/pull/2804), so there should be no compatibility problems.