### PR TITLE
print out fact version + git hash on start

### DIFF
--- a/src/fact_base.py
+++ b/src/fact_base.py
@@ -3,12 +3,13 @@ import os
 import signal
 import sys
 from pathlib import Path
+from shlex import split
+from subprocess import CalledProcessError, PIPE, run, STDOUT
 from time import sleep
 
 import config
 
 try:
-    import git
     import psutil
     import psycopg2  # noqa: F401
 
@@ -53,9 +54,9 @@ class FactBase:
     @staticmethod
     def _get_git_revision() -> str:
         try:
-            repo = git.Repo(Path(__file__), search_parent_directories=True)
-            return f'commit {repo.head.object.hexsha}'
-        except git.exc.InvalidGitRepositoryError:
+            proc = run(split('git rev-parse --short HEAD'), stdout=PIPE, stderr=STDOUT, cwd=Path(__file__).parent)
+            return proc.stdout.decode().strip()
+        except CalledProcessError:
             return 'unknown revision'
 
     def _register_signal_handlers(self):

--- a/src/install/requirements_common.txt
+++ b/src/install/requirements_common.txt
@@ -7,6 +7,7 @@ setuptools<66
 # General python dependencies
 appdirs==1.4.4
 flaky==3.7.0
+gitpython~=3.1.40
 lief==0.12.3
 psutil==5.9.4
 psycopg2-binary==2.9.5

--- a/src/install/requirements_common.txt
+++ b/src/install/requirements_common.txt
@@ -7,7 +7,6 @@ setuptools<66
 # General python dependencies
 appdirs==1.4.4
 flaky==3.7.0
-gitpython~=3.1.40
 lief==0.12.3
 psutil==5.9.4
 psycopg2-binary==2.9.5


### PR DESCRIPTION
- log fact version, git commit hash and python version on startup of each component
  - should help debugging some of the bare logs we get in GitHub issues