### PR TITLE
chore: Update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -36,6 +36,13 @@ body:
     validations:
       required: true
   - type: textarea
+    id: observed-behavior
+    attributes:
+      label: Observed Behavior
+      description: What did happen?
+    validations:
+      required: true
+  - type: textarea
     id: expected-behavior
     attributes:
       label: Expeced Behavior


### PR DESCRIPTION
Bug reports without the option to give information about the ovserved behavior are pretty useless.