### PR TITLE
Remove unnecessary saving of uploaded file to tmp dir

### DIFF
--- a/src/test/unit/helperFunctions/test_task_conversion.py
+++ b/src/test/unit/helperFunctions/test_task_conversion.py
@@ -6,7 +6,6 @@ from helperFunctions import tag
 from helperFunctions.task_conversion import (
     _get_tag_list,
     _get_uid_of_analysis_task,
-    _get_uploaded_file_binary,
     check_for_errors,
     convert_analysis_task_to_fw_obj,
 )
@@ -40,9 +39,6 @@ class TestTaskConversion(unittest.TestCase):
         result = check_for_errors(invalid_request)
         assert len(result) == 1, 'number of invalid fields not correct'
         assert result['b'] == 'Please specify the b'
-
-    def test_get_uploaded_file_binary_error(self):
-        assert _get_uploaded_file_binary(None) is None, 'missing upload file should lead to None'
 
     def test_get_uid_of_analysis_task(self):
         analysis_task = {'binary': b'this is a test'}


### PR DESCRIPTION
The [werkzeug `FileStorage` object](https://werkzeug.palletsprojects.com/en/2.3.x/datastructures/#werkzeug.datastructures.FileStorage) provides a `stream` to the underlying bytes, so there's no need to save it to disk to read out the bytes.