### PR TITLE
Update yara and yara-python to 4.5.0

### DIFF
--- a/src/install/backend.py
+++ b/src/install/backend.py
@@ -127,7 +127,7 @@ def _install_plugins(distribution, skip_docker, only_docker=False):
 
 
 def _install_yara():
-    yara_version = 'v4.4.0'  # must be the same version as `yara-python` in `install/requirements_common.txt`
+    yara_version = 'v4.5.0'  # must be the same version as `yara-python` in `install/requirements_common.txt`
 
     yara_process = subprocess.run('yara --version', shell=True, stdout=PIPE, stderr=STDOUT, text=True, check=False)
     if yara_process.returncode == 0 and yara_process.stdout.strip() == yara_version.strip('v'):

--- a/src/install/requirements_common.txt
+++ b/src/install/requirements_common.txt
@@ -19,7 +19,7 @@ rich==12.6.0
 sqlalchemy==2.0.15
 ssdeep==3.4
 xmltodict==0.13.0
-yara-python==4.4.0
+yara-python==4.5.0
 
 # Config validation
 pydantic==2.4.0

--- a/src/install/requirements_common.txt
+++ b/src/install/requirements_common.txt
@@ -19,8 +19,7 @@ rich==12.6.0
 sqlalchemy==2.0.15
 ssdeep==3.4
 xmltodict==0.13.0
-# FixMe: pin to 4.4.x as soon as it releases
-git+https://github.com/VirusTotal/yara-python@d0921c0
+yara-python==4.4.0
 
 # Config validation
 pydantic==2.4.0


### PR DESCRIPTION
Addressing an old `FIXME` in `requirements_common.txt`

That said, 4.5.0 was released [two days after 4.4.0](https://pypi.org/project/yara-python/#history) and has [a bunch of bug fixes](https://github.com/VirusTotal/yara/releases/tag/v4.5.0); should the version be updated to that instead?