### PR TITLE
bug fix: pin recusive dependency numpy to <2

### DIFF
--- a/src/install/requirements_frontend.txt
+++ b/src/install/requirements_frontend.txt
@@ -16,6 +16,9 @@ quantiphy~=2.20
 uwsgi~=2.0.25.1
 virtualenv~=20.26.1
 
+# FixMe: dependency of matplotlib which does not work with numpy>=2 yet
+numpy<2
+
 # must be below dependent packages (flask, flask-login, flask-restx)
 werkzeug~=3.0.3
 

--- a/src/plugins/analysis/binwalk/requirements.txt
+++ b/src/plugins/analysis/binwalk/requirements.txt
@@ -1,3 +1,5 @@
 capstone==4.0.2
 cstruct==4.0
 matplotlib==3.7.3
+# FixMe: dependency of matplotlib which does not work with numpy>=2 yet
+numpy<2


### PR DESCRIPTION
The recently released version 2 of numpy causes weird import errors because matplotlib is not yet compatible