### PR TITLE
cpu arch plugin: device tree result changes bug fix

### DIFF
--- a/src/plugins/analysis/architecture_detection/internal/dt.py
+++ b/src/plugins/analysis/architecture_detection/internal/dt.py
@@ -43,7 +43,7 @@ def _get_compatible_entry(dts: str) -> str | None:
 
     compatible = None
 
-    # The yaml output is a bit wired, we have to 'unpack' one level to get to the actual nodes
+    # The yaml output is a bit weird, we have to 'unpack' one level to get to the actual nodes
     for item in dt_yaml:
         if 'cpus' not in item:
             continue
@@ -78,7 +78,7 @@ def construct_result(file_object):
 
     result = {}
     for dt_dict in device_tree_result.get('device_trees', []):
-        dt = dt_dict['device_tree']
+        dt = dt_dict['string']
 
         compatible_entry = _get_compatible_entry(dt)
         if compatible_entry is None:

--- a/src/plugins/analysis/architecture_detection/test/test_plugin_architecture_detection.py
+++ b/src/plugins/analysis/architecture_detection/test/test_plugin_architecture_detection.py
@@ -14,7 +14,7 @@ _mock_device_tree_analysis = {
         'result': {
             'device_trees': [
                 {
-                    'device_tree': dts,
+                    'string': dts,
                 },
             ]
         }


### PR DESCRIPTION
- fixes a bug in the `dt` module of the `cpu_architecture` plugin introduced by changing the result structure of the `device_tree` plugin in #1028 

the bug:
```python
  File "src/plugins/analysis/architecture_detection/internal/dt.py", line 81, in construct_result
    dt = dt_dict['device_tree']
         ~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'device_tree'
```
