### PR TITLE
file tree: linux kernel image icon

### DIFF
--- a/src/install/frontend.py
+++ b/src/install/frontend.py
@@ -137,6 +137,7 @@ def _copy_mime_icons():
         ('places/folder-brown.svg', 'folder.svg'),
         ('status/dialog-error.svg', 'not_analyzed.svg'),
         ('emblems/emblem-symbolic-link.svg', 'mimetypes/inode-symlink.svg'),
+        ('apps/tux.svg', 'linux.svg'),
     ]:
         run_cmd_with_logging(f'cp -rL {ICON_THEME_INSTALL_PATH / source} {MIME_ICON_DIR / target}')
 

--- a/src/web_interface/file_tree/file_tree.py
+++ b/src/web_interface/file_tree/file_tree.py
@@ -97,6 +97,7 @@ TYPE_CATEGORY_TO_ICON = {
     'image/': f'/{ICON_URL_BASE}/mimetypes/image-x-generic.svg',
     'text/': f'/{ICON_URL_BASE}/mimetypes/text-x-generic.svg',
     'video/': f'/{ICON_URL_BASE}/mimetypes/video-x-generic.svg',
+    'linux/': f'/{ICON_URL_BASE}/linux.svg',
 }
 
 


### PR DESCRIPTION
- file tree: added dedicated icon for linux kernel image files

![image](https://github.com/user-attachments/assets/dd048030-4ee1-4ffa-8347-2c853cc096ae)
