### PR TITLE
wait for single file analysis (update)

### DIFF
--- a/src/intercom/front_end_binding.py
+++ b/src/intercom/front_end_binding.py
@@ -27,7 +27,7 @@ class InterComFrontEndBinding:
             self._add_to_redis_queue('update_task', fw, fw.uid)
 
     def add_single_file_task(self, fw):
-        self._add_to_redis_queue('single_file_task', fw, fw.uid)
+        return self._request_response_listener(fw, 'single_file_task', 'single_file_task_resp')
 
     def add_compare_task(self, compare_id, force=False):
         self._add_to_redis_queue('compare_task', (compare_id, force), compare_id)

--- a/src/objects/file.py
+++ b/src/objects/file.py
@@ -96,6 +96,9 @@ class FileObject:
         #: for debugging purposes and as placeholder in UI.
         self.analysis_exception = None
 
+        #: Optional callback method called after the analysis finished in the analysis scheduler
+        self.callback = None
+
         if binary is not None:
             self.set_binary(binary)
         else:

--- a/src/scheduler/analysis/scheduler.py
+++ b/src/scheduler/analysis/scheduler.py
@@ -554,6 +554,7 @@ class AnalysisScheduler:
         if not fw_object.scheduled_analysis:
             logging.info(f'Analysis Completed: {fw_object.uid}')
             self.status.remove_object(fw_object)
+            self._do_callback(fw_object)
         elif (
             isinstance(fw_object, Firmware)
             or fw_object.root_uid is None  # this should only be true if we are dealing with a "single file analysis"
@@ -565,6 +566,14 @@ class AnalysisScheduler:
                 f'Removing {fw_object.uid} from analysis scheduling because analysis of FW {fw_object.root_uid} '
                 f'was cancelled.'
             )
+
+    @staticmethod
+    def _do_callback(fw_object: FileObject):
+        if fw_object.callback is not None:
+            try:
+                fw_object.callback()
+            except Exception as error:
+                logging.exception(f'Callback failed for {fw_object.uid}: {error}')
 
     # ---- miscellaneous functions ----
 

--- a/src/test/unit/web_interface/test_app_show_analysis.py
+++ b/src/test/unit/web_interface/test_app_show_analysis.py
@@ -80,9 +80,11 @@ class TestAppShowAnalysis:
             f'/analysis/{TEST_FW.uid}',
             content_type='multipart/form-data',
             data={'analysis_systems': ['plugin_a', 'plugin_b']},
+            follow_redirects=True,
         )
 
-        assert post_new.status_code == HTTPStatus.FOUND
+        assert post_new.status_code == HTTPStatus.OK
+        assert 'success' in post_new.json
         assert intercom_task_list
         assert intercom_task_list[0].scheduled_analysis == ['plugin_a', 'plugin_b']
 

--- a/src/web_interface/static/js/show_analysis_single_update.js
+++ b/src/web_interface/static/js/show_analysis_single_update.js
@@ -1,0 +1,48 @@
+// single file analysis (update)
+function waitForAnalysis(url, element, formData=null) {
+    // wait until the analysis is finished and then (re)load the page to show it
+    element.innerHTML = `<i class="fas fa-spinner fa-fw margin-right-md fa-spin"></i> analysis in progress ...`;
+    const message = 'Timeout when waiting for analysis. Please manually refresh the page.';
+    fetch(url, {
+        method: 'POST',
+        body: formData,
+        signal: AbortSignal.timeout(60000)
+    })
+    .then(response => response.json())
+    .then(data => {
+        if (data.success) {
+            console.log('Analysis successful');
+            localStorage.setItem('analysisUpdated', `${selected_analysis}-${uid}`);
+            if (formData != null) {
+                const checkedOptions = [];
+                formData.forEach((value, key) => {
+                    if (key === 'analysis_systems') {
+                        checkedOptions.push(value);
+                    }
+                });
+                if (checkedOptions.length > 0 && checkedOptions.indexOf(selected_analysis) === -1) {
+                    let url = window.location.href;
+                    const someSelectedPlugin = checkedOptions[0];
+                    localStorage.setItem('analysisUpdated', `${someSelectedPlugin}-${uid}`);
+                    if (selected_analysis === 'None') {
+                        // no plugin is currently selected
+                        url = `/analysis/${uid}/${someSelectedPlugin}`;
+                    } else {
+                        // another plugin (that was not updated) is selected → replace it in the URL
+                        url = url.replace(selected_analysis, someSelectedPlugin);
+                    }
+                    window.location.href = url;
+                    return;
+                }
+            }
+            window.location.reload();
+        } else {
+            console.log('Analysis failed');
+            element.innerHTML = message;
+        }
+    })
+    .catch(error => {
+        console.error('Error during single file analysis:', error);
+        element.innerHTML = message;
+    });
+}

--- a/src/web_interface/templates/analysis_plugins/general_information.html
+++ b/src/web_interface/templates/analysis_plugins/general_information.html
@@ -2,7 +2,7 @@
 
 {% block analysis_result %}
 
-    <table class="table table-bordered" style="table-layout: fixed">
+    <table id="show-analysis-table" class="table table-bordered"  style="table-layout: fixed">
         <colgroup>
             <col style="width: 12.5%">
             <col style="width: 87.5%">
@@ -72,12 +72,21 @@
         {% else %}
             <tr>
                 <td class="table-warning">Analysis outdated</td>
-                <td>
+                <td id="analysis-outdated-td">
                     The backend plugin version ({{ version_backend | string }}) is incompatible with
                     the version ({{ version_database | string }}) of the analysis result.
 
-                    Please update the analysis.
+                    <button class="btn btn-primary btn-sm" onclick="startSingleAnalysis()">
+                        Update Analysis
+                    </button>
                 </td>
+                <script>
+                    function startSingleAnalysis() {
+                        const url = `/analysis/single-update/${uid}/${selected_analysis}`;
+                        let element = document.getElementById("analysis-outdated-td");
+                        waitForAnalysis(url, element);
+                    }
+                </script>
             </tr>
         {% endif %}
         </tbody>

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -35,6 +35,16 @@
         const selected_analysis = "{{ selected_analysis }}";
     </script>
     <script src="{{ url_for('static', filename='js/file_tree.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='js/show_analysis_single_update.js') }}"></script>
+    <script>
+        window.addEventListener('load', function() {
+            // add highlighting animation if analysis was updated
+            if (localStorage.getItem('analysisUpdated') === `${selected_analysis}-${uid}`) {
+                document.getElementById('show-analysis-table').classList.add('updated-analysis');
+                localStorage.setItem('analysisUpdated', 'false');
+            }
+        });
+    </script>
 
     <style>
         {# styling for file preview line lumbers #}
@@ -48,6 +58,13 @@
         }
         .hljs-ln-code {
             padding-left: 10px !important;
+        }
+        @keyframes updated-analysis {
+            from { box-shadow: 0 0 10px 5px rgba(0, 105, 217, 0.5); }
+            to { box-shadow: none; }
+        }
+        .updated-analysis {
+            animation: updated-analysis 2s ease-in-out;
         }
     </style>
 {% endblock %}
@@ -280,8 +297,8 @@
                         <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span></button>
                     </div>
 
-                    <div class="modal-body">
-                        <form class="form-horizontal" action="" method=post enctype=multipart/form-data>
+                    <div class="modal-body" id="modal-body">
+                        <form class="form-horizontal" id="modal-form" action="" method=post enctype=multipart/form-data>
                             <p>Add new analysis</p>
                             {% for system in available_plugins.unused | sort %}
                                 <label class="checkbox-inline" data-toggle="tooltip" title="{{ analysis_plugin_dict[system][0] | safe }}" style="display: block">
@@ -307,6 +324,19 @@
                 </div>
             </div>
         </div>
+        <script>
+            document.addEventListener('DOMContentLoaded', () => {
+                // overwrites the submit action of the "Run additional analysis" modal button
+                // and waits for the result before refreshing the page
+                const form = document.getElementById('modal-form');
+                const modalBody = document.getElementById('modal-body');
+                form.addEventListener('submit', (event) => {
+                    event.preventDefault();
+                    const formData = new FormData(form);
+                    waitForAnalysis(form.action, modalBody, formData);
+                });
+            });
+        </script>
 
         {# Showing analysis section #}
 
@@ -326,7 +356,7 @@
                     <div id="summary-div">
                         <div class="mb-3 border" id="loading-summary-gif" style="display: none; padding: 5px; text-align: center">
                             <img src="{{ url_for("static", filename = "Pacman.gif") }}" alt="loading gif">
-                            <p>Loading summary for included files ..</p>
+                            <p>Loading summary for included files...</p>
                         </div>
                     </div>
                     <script type="text/javascript" src="{{ url_for('static', filename='js/show_analysis_summary.js') }}"></script>


### PR DESCRIPTION
- makes intercom backend listener "responder" asynchronous (so it does not block when waiting for the result)
- converts the "single file analysis task" listener into a responder
- changes the show analysis page so that single file analyses are awaited and the page is automatically reloaded
- adds a button to the "analysis is outdated" message to quickly update it

- [x] based on #1251 so that one should be merged first