### PR TITLE
chore: Update fact_extractor module path

### DIFF
--- a/src/unpacker/extraction_container.py
+++ b/src/unpacker/extraction_container.py
@@ -57,7 +57,7 @@ class ExtractionContainer:
             detach=True,
             remove=True,
             environment={'CHMOD_OWNER': f'{getuid()}:{getgid()}'},
-            entrypoint='gunicorn --timeout 600 -w 1 -b 0.0.0.0:5000 server:app',
+            entrypoint='gunicorn --timeout 600 -w 1 -b 0.0.0.0:5000 fact_extractor.server:app',
         )
         self.container_id = container.id
         logging.info(f'Started unpack worker {self.id_}')


### PR DESCRIPTION
This is required as of [#155](https://github.com/fkie-cad/fact_extractor/pull/155).

This technically breaks installations of FACT that have the old image on the system.
This problem is not solvable at the moment as we do not have versioning for the extractor container.
Let's follow what we did, when we introduced the extraction service: Nothing.

Depends on:
- [ ] https://github.com/fkie-cad/fact_extractor/pull/155
- [ ] Image is pushed to [dockerhub](https://hub.docker.com/r/fkiecad/fact_extractor)