### PR TITLE
Bugfix: file_system_meta_data did not show all results for a file object across firmwares

### DIFF
--- a/src/plugins/analysis/file_system_metadata/routes/ajax_view.html
+++ b/src/plugins/analysis/file_system_metadata/routes/ajax_view.html
@@ -5,47 +5,49 @@
             Results for this File
         </th>
     </tr>
-    {% for file, metadata in results.items() %}
-        <tr>
-            <td onclick="location.href='/analysis/{{ results[file]['parent_uid'] }}'">
-                {{ results[file]["parent_uid"] | replace_uid_with_hid | safe }} | {{ file }}
-            </td>
-            <td class="p-0">
-                {# this should be the same as in ../view/file_system_metadata.html #}
-                <table class="table table-bordered table-sm mb-0">
-                    {% set tr_class = "" if key not in ('suid_bit', 'sgid_bit') or not value else "table-danger"%}
-                    <tr class={{ tr_class }}>
-                    <tr>
-                        <td class="text-right" style="width: 25%">user / group ID</td>
-                        <td class="text-left" style="width: 25%">
-                            {{ metadata.uid | safe }} {{ "(" + metadata.user + ")" if metadata.user else "" }} /
-                            {{ metadata.gid | safe }} {{ "(" + metadata.group + ")" if metadata.group else "" }}
-                        </td>
-                        <td class="text-right" style="width: 25%">creation time</td>
-                        <td class="text-left" style="width: 25%">{{ metadata.creation_time | nice_unix_time | safe }}</td>
-                    </tr>
-                    <tr>
-                        <td class="text-right">permissions</td>
-                        <td class="text-left">
-                            {{ metadata.mode | safe }} ({{ metadata.mode | octal_to_readable }})
-                        </td>
-                        <td class="text-right">modification time</td>
-                        <td class="text-left">{{ metadata.modification_time | nice_unix_time | safe }}</td>
-                    </tr>
-                    <tr>
-                        <td class="text-right">SUID / SGID / sticky bit</td>
-                        {% set td_class = "table-danger" if metadata.suid_bit or metadata.sgid_bit else "" %}
-                        <td class="text-left {{ td_class }}">
-                            {{ metadata.suid_bit | safe }} /
-                            {{ metadata.sgid_bit | safe }} /
-                            {{ metadata.sticky_bit | safe }}
-                        </td>
-                        <td class="text-right">last access time</td>
-                        <td class="text-left">{{ metadata.access_time | nice_unix_time | safe }}</td>
-                    </tr>
-                </table>
-            </td>
-        </tr>
+    {% for fw_results in results %}
+        {% for file, metadata in fw_results.items() %}
+            <tr>
+                <td onclick="location.href='/analysis/{{ metadata['parent_uid'] }}'">
+                    {{ metadata["parent_uid"] | replace_uid_with_hid | safe }} | {{ file }}
+                </td>
+                <td class="p-0">
+                    {# this should be the same as in ../view/file_system_metadata.html #}
+                    <table class="table table-bordered table-sm mb-0">
+                        {% set tr_class = "" if key not in ('suid_bit', 'sgid_bit') or not value else "table-danger"%}
+                        <tr class={{ tr_class }}>
+                        <tr>
+                            <td class="text-right" style="width: 25%">user / group ID</td>
+                            <td class="text-left" style="width: 25%">
+                                {{ metadata.uid | safe }} {{ "(" + metadata.user + ")" if metadata.user else "" }} /
+                                {{ metadata.gid | safe }} {{ "(" + metadata.group + ")" if metadata.group else "" }}
+                            </td>
+                            <td class="text-right" style="width: 25%">creation time</td>
+                            <td class="text-left" style="width: 25%">{{ metadata.creation_time | nice_unix_time | safe }}</td>
+                        </tr>
+                        <tr>
+                            <td class="text-right">permissions</td>
+                            <td class="text-left">
+                                {{ metadata.mode | safe }} ({{ metadata.mode | octal_to_readable }})
+                            </td>
+                            <td class="text-right">modification time</td>
+                            <td class="text-left">{{ metadata.modification_time | nice_unix_time | safe }}</td>
+                        </tr>
+                        <tr>
+                            <td class="text-right">SUID / SGID / sticky bit</td>
+                            {% set td_class = "table-danger" if metadata.suid_bit or metadata.sgid_bit else "" %}
+                            <td class="text-left {{ td_class }}">
+                                {{ metadata.suid_bit | safe }} /
+                                {{ metadata.sgid_bit | safe }} /
+                                {{ metadata.sticky_bit | safe }}
+                            </td>
+                            <td class="text-right">last access time</td>
+                            <td class="text-left">{{ metadata.access_time | nice_unix_time | safe }}</td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        {% endfor %}
     {% endfor %}
 </table>
 {% endif %}

--- a/src/plugins/analysis/file_system_metadata/routes/routes.py
+++ b/src/plugins/analysis/file_system_metadata/routes/routes.py
@@ -26,13 +26,13 @@ VIEW_PATH = Path(__file__).absolute().parent / 'ajax_view.html'
 class ParentAnalysisLookupMixin:
     db: FrontendDatabase
 
-    def get_analysis_results_for_included_uid(self, uid: str) -> dict:
-        results = {}
+    def get_analysis_results_for_included_uid(self, uid: str) -> list:
+        results = []
         with get_shared_session(self.db.frontend) as db:
             vfp = db.get_vfps(uid)
             for parent_uid in vfp:
                 parent_analysis = db.get_analysis(parent_uid, AnalysisPlugin.NAME) or {}
-                results.update(_get_results_from_parent_fo(parent_analysis.get('result', {}), parent_uid, vfp))
+                results.append(_get_results_from_parent_fo(parent_analysis.get('result', {}), parent_uid, vfp))
         return results
 
 

--- a/src/plugins/analysis/file_system_metadata/test/test_file_system_metadata_routes.py
+++ b/src/plugins/analysis/file_system_metadata/test/test_file_system_metadata_routes.py
@@ -97,21 +97,21 @@ class TestFileSystemMetadataRoutesStatic:
         result = mock_plugin.get_analysis_results_for_included_uid('foo')
 
         assert result is not None
-        assert result != {}, 'result should not be empty'
+        assert result != [], 'result should not be empty'
         assert len(result) == 1, 'wrong number of results'
-        assert 'some_file' in result, 'files missing from result'
+        assert 'some_file' in result[0], 'files missing from result'
 
     def test_get_analysis_results_for_included_uid__uid_not_found(self, mock_plugin):
         result = mock_plugin.get_analysis_results_for_included_uid('not_found')
 
         assert result is not None
-        assert result == {}, 'result should be empty'
+        assert result == [], 'result should be empty'
 
     def test_get_analysis_results_for_included_uid__parent_not_found(self, mock_plugin):
         result = mock_plugin.get_analysis_results_for_included_uid('bar')
 
         assert result is not None
-        assert result == {}, 'result should be empty'
+        assert result == [], 'result should be empty'
 
 
 class DbMock:
@@ -151,11 +151,12 @@ class TestFileSystemMetadataRoutesRest:
     def test_get_rest(self):
         result = self.test_client.get('/plugins/file_system_metadata/rest/foo').json
         assert AnalysisPlugin.NAME in result
-        assert 'some_file' in result[AnalysisPlugin.NAME]
-        assert 'mode' in result[AnalysisPlugin.NAME]['some_file']
-        assert result[AnalysisPlugin.NAME]['some_file']['mode'] == '1337'
+        assert 'some_file' in result[AnalysisPlugin.NAME][0]
+        assert 'mode' in result[AnalysisPlugin.NAME][0]['some_file']
+        assert result[AnalysisPlugin.NAME][0]['some_file']['mode'] == '1337'
 
     def test_get_rest__no_result(self):
         result = self.test_client.get('/plugins/file_system_metadata/rest/not_found').json
+        assert result, 'result should not be empty'
         assert AnalysisPlugin.NAME in result
-        assert result[AnalysisPlugin.NAME] == {}
+        assert result[AnalysisPlugin.NAME] == []


### PR DESCRIPTION
When an unpacked and analyzed file has the same name across firmware images, the `file_system_meta_data` plugin did not show the results for all firmware images in the file object view.