### PR TITLE
added config option to allow CVE matches without version constraints

### DIFF
--- a/src/config/fact-core-config.toml
+++ b/src/config/fact-core-config.toml
@@ -112,6 +112,8 @@ name = "cve_lookup"
 processes = 4
 # CVE scores greater or equal to this value are shown as "critical"
 min-critical-score = 9.0
+# match CVE entries without versions constraints (`false` by default due to the high risk of false positives)
+match-any = false
 
 [[backend.plugin]]
 name = "cwe_checker"

--- a/src/plugins/analysis/cve_lookup/code/cve_lookup.py
+++ b/src/plugins/analysis/cve_lookup/code/cve_lookup.py
@@ -37,6 +37,7 @@ class AnalysisPlugin(AnalysisBasePlugin):
 
     def additional_setup(self):
         self.min_crit_score = getattr(config.backend.plugin.get(self.NAME, {}), 'min-critical-score', 9.0)
+        self.match_any = getattr(config.backend.plugin.get(self.NAME, {}), 'match-any', False)
 
     def process_object(self, file_object: FileObject) -> FileObject:
         """
@@ -44,7 +45,7 @@ class AnalysisPlugin(AnalysisBasePlugin):
         """
         cves = {'cve_results': {}}
         connection = DbConnection(f'sqlite:///{DB_PATH}')
-        lookup = Lookup(file_object, connection)
+        lookup = Lookup(file_object, connection, match_any=self.match_any)
         for value in file_object.processed_analysis['software_components']['result'].values():
             product = value['meta']['software_name']
             version = value['meta']['version'][0]


### PR DESCRIPTION
CPEs without version constraints (and therefore also related CVEs) were previously ignored due to the high risk of false positives. This PR adds a config option to enable matching those entries (disabled by default)

resolves #1290