### PR TITLE
cancel analysis

### DIFF
--- a/src/intercom/common_redis_binding.py
+++ b/src/intercom/common_redis_binding.py
@@ -5,16 +5,13 @@ import os
 import pickle
 from multiprocessing import Process, Value
 from time import sleep, time
-from typing import TYPE_CHECKING, Any, Callable
+from typing import Any, Callable
 
 from redis.exceptions import RedisError
 
 import config
 from helperFunctions.hash import get_sha256
 from storage.redis_interface import RedisInterface
-
-if TYPE_CHECKING:
-    from objects.file import FileObject
 
 
 def generate_task_id(input_data: Any) -> str:
@@ -34,7 +31,7 @@ class InterComListener:
 
     CONNECTION_TYPE = 'test'  # unique for each listener
 
-    def __init__(self, processing_function: Callable[[FileObject], None] | None = None):
+    def __init__(self, processing_function: Callable[[Any], None] | None = None):
         super().__init__()
         self.redis = RedisInterface()
         self.process = None

--- a/src/intercom/front_end_binding.py
+++ b/src/intercom/front_end_binding.py
@@ -35,6 +35,9 @@ class InterComFrontEndBinding:
     def delete_file(self, uid_list: set[str]):
         self._add_to_redis_queue('file_delete_task', uid_list)
 
+    def cancel_analysis(self, root_uid: str):
+        self._add_to_redis_queue('cancel_task', root_uid)
+
     def get_available_analysis_plugins(self):
         plugin_dict = self.redis.get('analysis_plugins', delete=False)
         if plugin_dict is None:

--- a/src/test/integration/intercom/test_backend_scheduler.py
+++ b/src/test/integration/intercom/test_backend_scheduler.py
@@ -8,7 +8,7 @@ from intercom.common_redis_binding import InterComListener
 from intercom.front_end_binding import InterComFrontEndBinding
 
 # This number must be changed, whenever a listener is added or removed
-NUMBER_OF_LISTENERS = 12
+NUMBER_OF_LISTENERS = 13
 
 
 class ServiceMock:

--- a/src/test/integration/intercom/test_task_communication.py
+++ b/src/test/integration/intercom/test_task_communication.py
@@ -10,6 +10,7 @@ import pytest
 from intercom.back_end_binding import (
     InterComBackEndAnalysisTask,
     InterComBackEndBinarySearchTask,
+    InterComBackEndCancelTask,
     InterComBackEndCompareTask,
     InterComBackEndFileDiffTask,
     InterComBackEndLogsTask,
@@ -25,7 +26,8 @@ from test.common_helper import create_test_firmware
 
 
 class AnalysisServiceMock:
-    def get_plugin_dict(self):
+    @staticmethod
+    def get_plugin_dict():
         return {'dummy': 'dummy description'}
 
 
@@ -189,3 +191,10 @@ class TestInterComTaskCommunication:
                 result = result_future.result()
             assert task is None, 'task not correct'
             assert result == expected_result.split()
+
+    def test_cancel_task(self, intercom_frontend):
+        task = InterComBackEndCancelTask()
+        root_uid = 'root_uid'
+        intercom_frontend.cancel_analysis(root_uid)
+        result = task.get_next_task()
+        assert result == root_uid

--- a/src/test/unit/conftest.py
+++ b/src/test/unit/conftest.py
@@ -67,6 +67,9 @@ class CommonIntercomMock:
     def add_re_analyze_task(self, task, unpack=True):
         self.task_list.append(task)
 
+    def cancel_analysis(self, root_uid):
+        self.task_list.append(root_uid)
+
 
 class FrontendDatabaseMock:
     """A class mocking :py:class:`~web_interface.frontend_database.FrontendDatabase`."""

--- a/src/test/unit/web_interface/test_app_ajax_routes.py
+++ b/src/test/unit/web_interface/test_app_ajax_routes.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 import pytest
 
 from helperFunctions.data_conversion import normalize_compare_id
@@ -78,3 +80,10 @@ class TestAppAjaxRoutes:
         result = test_client.get('/ajax_get_hex_preview/some_uid/0/10')
         assert result.data.startswith(b'<pre')
         assert b'foobar' in result.data
+
+    def test_ajax_cancel_analysis(self, test_client, intercom_task_list):
+        uid = 'some_uid'
+        result = test_client.get(f'/ajax/cancel_analysis/{uid}')
+        assert intercom_task_list == [uid], 'task not added to intercom'
+        assert result.data == b'{}\n'
+        assert result.status_code == HTTPStatus.OK

--- a/src/web_interface/components/ajax_routes.py
+++ b/src/web_interface/components/ajax_routes.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import html
+import logging
+from http import HTTPStatus
 
 from flask import jsonify, render_template
 
@@ -143,3 +145,10 @@ class AjaxRoutes(ComponentBase):
             'systemHealth': self.db.stats_viewer.get_stats_list('backend', 'frontend', 'database'),
             'analysisStatus': self.status.get_analysis_status(),
         }
+
+    @roles_accepted(*PRIVILEGES['cancel_analysis'])
+    @AppRoute('/ajax/cancel_analysis/<root_uid>', GET)
+    def cancel_analysis(self, root_uid: str):
+        logging.info(f'Received analysis cancel request for {root_uid}')
+        self.intercom.cancel_analysis(root_uid=root_uid)
+        return {}, HTTPStatus.OK

--- a/src/web_interface/security/privileges.py
+++ b/src/web_interface/security/privileges.py
@@ -9,6 +9,7 @@ PRIVILEGES = {
     'advanced_search': ['superuser', 'senior_analyst', 'analyst'],
     'pattern_search': ['superuser', 'senior_analyst', 'analyst'],
     'submit_analysis': ['superuser', 'senior_analyst'],
+    'cancel_analysis': ['superuser', 'senior_analyst'],
     'download': ['superuser', 'senior_analyst'],
     'delete': ['superuser'],
     'manage_users': ['superuser'],


### PR DESCRIPTION
- new feature: cancel analyses that are currently in progress (also works with updates)
  - analyses and extractions that are currently underway will not be canceled
  - instead, following analyses and extractions will not be scheduled
  - can be triggered on the "system health" page in the web interface (REST: TODO)