### PR TITLE
enable multiprocessing option for coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,8 @@ omit = [
     # ignore files only run inside docker
     "src/plugins/analysis/*/docker/**",
 ]
+concurrency = ["multiprocessing"]
+parallel = true
 
 [tool.coverage.report]
 exclude_also = [


### PR DESCRIPTION
many lines are missed by the coverage because the multiprocessing support is no longer enabled by default in the newer version