### PR TITLE
System version fixes

### DIFF
--- a/src/plugins/analysis/ip_and_uri_finder/code/ip_and_uri_finder.py
+++ b/src/plugins/analysis/ip_and_uri_finder/code/ip_and_uri_finder.py
@@ -65,7 +65,7 @@ class AnalysisPlugin(AnalysisPluginV0, AnalysisBasePluginAdapterMixin):
                     'application/x-sharedlib',
                     'application/x-dosexec',
                 ],
-                system_version=self.ip_and_uri_finder.system_version,
+                system_version=self.ip_and_uri_finder.plugin_version,
             ),
         )
 

--- a/src/storage/db_interface_backend.py
+++ b/src/storage/db_interface_backend.py
@@ -197,6 +197,7 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
         with self.get_read_write_session() as session:
             entry = session.get(AnalysisEntry, (uid, plugin))
             entry.plugin_version = analysis_data['plugin_version']
+            entry.system_version = analysis_data.get('system_version')
             entry.analysis_date = analysis_data['analysis_date']
             entry.summary = analysis_data.get('summary')
             entry.tags = analysis_data.get('tags')


### PR DESCRIPTION
- fixed plugin `ip_and_uri_finder` system version (was unintentionally set to  `None`)
- fixed system version not being set when analysis entries are updated