### PR TITLE
forward to analysis page (missing analysis)

### DIFF
--- a/src/test/unit/web_interface/test_app_show_analysis.py
+++ b/src/test/unit/web_interface/test_app_show_analysis.py
@@ -67,7 +67,7 @@ class TestAppShowAnalysis:
 
     def test_app_show_analysis_invalid_analysis(self, test_client):
         result = test_client.get(f'/analysis/{TEST_FW.uid}/this_analysis_does_not_exist/ro/{TEST_FW.uid}').data
-        assert b'Error!' in result
+        assert b'The requested analysis (this_analysis_does_not_exist) has not run (yet)' in result
 
     def test_app_single_file_analysis(self, test_client, intercom_task_list):
         result = test_client.get(f'/analysis/{TEST_FW.uid}')

--- a/src/web_interface/components/analysis_routes.py
+++ b/src/web_interface/components/analysis_routes.py
@@ -58,9 +58,8 @@ class AnalysisRoutes(ComponentBase):
             if not file_obj:
                 return render_template('uid_not_found.html', uid=uid)
             if selected_analysis is not None and selected_analysis not in file_obj.processed_analysis:
-                return render_template(
-                    'error.html', message=f'The requested analysis ({selected_analysis}) has not run (yet)'
-                )
+                flash(f'The requested analysis ({selected_analysis}) has not run (yet)', 'warning')
+                selected_analysis = None
             if isinstance(file_obj, Firmware):
                 root_uid = file_obj.uid
                 other_versions = frontend_db.get_other_versions_of_firmware(file_obj)


### PR DESCRIPTION
- if an analysis did not run for a file, the user is directed to an error page (a page empty except for an error message)
- this is not helpful, so this PR changes this behavior as follows: Instead of showing the error page the user is forwarded back to the analysis page (without selected plugin) and the error is displayed as flash message
- steps to (re)produce the error: Go to some file in a FW, run a "single file analysis" and go back to the root object through the link in the "general information" section