### PR TITLE
refactor: Remove unhelpful calls to sys.exit(1)

### DIFF
--- a/src/start_fact.py
+++ b/src/start_fact.py
@@ -26,16 +26,9 @@ from pathlib import Path
 from shlex import split
 from subprocess import Popen, TimeoutExpired
 from time import sleep
-
-import config
-
-try:
-    import fact_base  # noqa: F401
-except ImportError:
-    sys.exit(1)
-
 from typing import TYPE_CHECKING
 
+import config
 from helperFunctions.fileSystem import get_src_dir
 from helperFunctions.program_setup import setup_argparser, setup_logging
 

--- a/src/start_fact_backend.py
+++ b/src/start_fact_backend.py
@@ -24,10 +24,7 @@ import resource
 import sys
 from pathlib import Path
 
-try:
-    from fact_base import FactBase
-except (ImportError, ModuleNotFoundError):
-    sys.exit(1)
+from fact_base import FactBase
 
 import config
 from analysis.PluginBase import PluginInitException


### PR DESCRIPTION
The ImportError gives way more insight than just exiting.