### PR TITLE
Yara python fix

### DIFF
--- a/src/helperFunctions/install.py
+++ b/src/helperFunctions/install.py
@@ -269,10 +269,7 @@ def install_pip_packages(package_file: Path):
     """
     for package in read_package_list_from_file(package_file):
         try:
-            command = f'pip3 install -U {package} --prefer-binary'  # prefer binary release to compiling latest
-            if not is_virtualenv():
-                command = 'sudo -EH ' + command
-            run_cmd_with_logging(command, silent=True)
+            install_single_pip_package(package)
         except CalledProcessError as error:
             # don't fail if a package is already installed using apt and can't be upgraded
             if error.stdout is not None and 'distutils installed' in error.stdout:
@@ -283,6 +280,13 @@ def install_pip_packages(package_file: Path):
                 continue
             logging.error(f'Pip package {package} could not be installed:\n{error.stderr or error.stdout}')
             raise
+
+
+def install_single_pip_package(package: str):
+    command = f'pip3 install -U {package} --prefer-binary'  # prefer binary release to compiling latest
+    if not is_virtualenv():
+        command = 'sudo -EH ' + command
+    run_cmd_with_logging(command, silent=True)
 
 
 def read_package_list_from_file(path: Path):

--- a/src/helperFunctions/yara_binary_search.py
+++ b/src/helperFunctions/yara_binary_search.py
@@ -130,29 +130,3 @@ class YaraBinarySearchScanner:
         compiled_rules = yara.compile(source=yara_rules.decode())
         compiled_rules.save(file=temp_rule_file)
         temp_rule_file.flush()
-
-
-def is_valid_yara_rule_file(yara_rules: str | bytes) -> bool:
-    """
-    Check if ``yara_rules`` is a valid set of yara rules.
-
-    :param: A string containing yara rules.
-    :return: ``True`` if the rules are valid and ``False`` otherwise.
-    """
-    return get_yara_error(yara_rules) is None
-
-
-def get_yara_error(rules_file: str | bytes) -> Exception | None:
-    """
-    Get the exception that is caused by trying to compile ``rules_file`` with yara or ``None`` if there is none.
-
-    :param rules_file: A string containing yara rules.
-    :result: The exception if compiling the rules causes an exception or ``None`` otherwise.
-    """
-    try:
-        if isinstance(rules_file, bytes):
-            rules_file = rules_file.decode()
-        yara.compile(source=rules_file)
-        return None
-    except (yara.Error, TypeError, UnicodeDecodeError) as error:
-        return error

--- a/src/install/requirements_common.txt
+++ b/src/install/requirements_common.txt
@@ -20,7 +20,6 @@ rich==12.6.0
 sqlalchemy~=2.0.30
 ssdeep==3.4
 xmltodict==0.13.0
-yara-python==4.5.0
 
 # Config validation
 pydantic==2.4.0

--- a/src/intercom/front_end_binding.py
+++ b/src/intercom/front_end_binding.py
@@ -56,6 +56,9 @@ class InterComFrontEndBinding:
     def get_repacked_binary_and_file_name(self, uid: str):
         return self._request_response_listener(uid, 'tar_repack_task', 'tar_repack_task_resp')
 
+    def get_yara_error(self, yara_rule: str | bytes) -> str | None:
+        return self._request_response_listener(yara_rule, 'check_yara_rules_task', 'check_yara_rules_task_resp')
+
     def add_binary_search_request(self, yara_rule_binary: bytes, firmware_uid: str | None = None):
         request_id = generate_task_id(yara_rule_binary)
         self._add_to_redis_queue('binary_search_task', (yara_rule_binary, firmware_uid), request_id)

--- a/src/test/data/yara_magic.yara
+++ b/src/test/data/yara_magic.yara
@@ -1,0 +1,13 @@
+import "magic"
+
+/*
+The sole purpose of this rule file is to test if yara-python is installed correctly.
+To be more specific, it is tested whether yara is installed with the magic module enabled (which is needed for some
+plugins (for more info see https://yara.readthedocs.io/en/stable/modules/magic.html).
+If you get an error like e.g. `invalid field name "mime_type"` when compiling these rules, then the module is missing.
+*/
+
+rule test_magic_module_is_enabled {
+	condition:
+		magic.mime_type() == "text/plain"
+}

--- a/src/test/integration/intercom/test_backend_scheduler.py
+++ b/src/test/integration/intercom/test_backend_scheduler.py
@@ -8,7 +8,7 @@ from intercom.common_redis_binding import InterComListener
 from intercom.front_end_binding import InterComFrontEndBinding
 
 # This number must be changed, whenever a listener is added or removed
-NUMBER_OF_LISTENERS = 13
+NUMBER_OF_LISTENERS = 14
 
 
 class ServiceMock:

--- a/src/test/integration/intercom/test_task_communication.py
+++ b/src/test/integration/intercom/test_task_communication.py
@@ -11,6 +11,7 @@ from intercom.back_end_binding import (
     InterComBackEndAnalysisTask,
     InterComBackEndBinarySearchTask,
     InterComBackEndCancelTask,
+    InterComBackEndCheckYaraRuleTask,
     InterComBackEndCompareTask,
     InterComBackEndFileDiffTask,
     InterComBackEndLogsTask,
@@ -198,3 +199,18 @@ class TestInterComTaskCommunication:
         intercom_frontend.cancel_analysis(root_uid)
         result = task.get_next_task()
         assert result == root_uid
+
+    def test_get_yara_error(self, intercom_frontend):
+        listener = InterComBackEndCheckYaraRuleTask()
+        invalid_rule = 'rule foobar {}'
+        intercom_frontend.get_yara_error(invalid_rule)
+        task = listener.get_next_task()
+        assert task == invalid_rule
+        error = listener.get_response(task)
+        assert 'expecting <condition>' in error
+
+    def test_get_yara_error_valid(self, intercom_frontend):
+        listener = InterComBackEndCheckYaraRuleTask()
+        valid_rule = 'rule valid {condition: true}'
+        error = listener.get_response(valid_rule)
+        assert error is None, 'the rule should be valid and the error should be None'

--- a/src/test/unit/analysis/test_addons_yara.py
+++ b/src/test/unit/analysis/test_addons_yara.py
@@ -50,3 +50,10 @@ def test_output_is_compatible():
     assert converted_match['strings'] == EXPECTED_RESULT['strings']
     for key, value in EXPECTED_RESULT['meta'].items():
         assert converted_match['meta'][key] == value
+
+
+def test_compile():
+    test_file = Path(get_src_dir()) / 'test/data/yara_magic.yara'
+    assert test_file.is_file()
+    rules = yara.compile(str(test_file))
+    assert rules

--- a/src/test/unit/conftest.py
+++ b/src/test/unit/conftest.py
@@ -70,6 +70,13 @@ class CommonIntercomMock:
     def cancel_analysis(self, root_uid):
         self.task_list.append(root_uid)
 
+    def get_yara_error(self, rule):
+        if isinstance(rule, bytes):
+            rule = rule.decode(errors='ignore')
+        if 'invalid' in rule:
+            return 'SyntaxError: line 1: syntax error, unexpected identifier'
+        return None
+
 
 class FrontendDatabaseMock:
     """A class mocking :py:class:`~web_interface.frontend_database.FrontendDatabase`."""

--- a/src/test/unit/web_interface/rest/test_rest_binary_search.py
+++ b/src/test/unit/web_interface/rest/test_rest_binary_search.py
@@ -16,7 +16,7 @@ def test_no_rule_file(test_client):
 
 
 def test_wrong_rule_file_format(test_client):
-    result = test_client.post('/rest/binary_search', json={'rule_file': 'not an actual rule file'}).json
+    result = test_client.post('/rest/binary_search', json={'rule_file': 'invalid rule file'}).json
     assert 'Error in YARA rule file' in result['error_message']
 
 

--- a/src/test/unit/web_interface/test_app_binary_search.py
+++ b/src/test/unit/web_interface/test_app_binary_search.py
@@ -55,7 +55,7 @@ class TestAppBinarySearch:
         response = _post_binary_search(
             test_client, {'file': (BytesIO(b'invalid_rule'), 'test_file.txt'), 'textarea': ''}
         )
-        assert 'Error in YARA rules' in response
+        assert 'syntax error' in response
 
     def test_app_binary_search_post_empty(self, test_client):
         response = _post_binary_search(test_client, {'file': None, 'textarea': ''})


### PR DESCRIPTION
* [install yara-python from source](https://github.com/fkie-cad/FACT_core/commit/ecafc7c6d54d7d6840a9dfefd2f9425d7c96680f)
  * Why ist this necessary? Plugins like software_components need support for YARA modules (especially magic) and the pre-built version of yara-python from PyPI does not include this
* [moved get_yara_error method to backend (intercom)](https://github.com/fkie-cad/FACT_core/commit/700adcad062220f8cb9360dbdde237082e31c6e9)
  * having the method in the frontend does not make a lot of sense, because the yara version of the backend could be different and compiling the rules could still fail