### PR TITLE
feat: revised IP&URI template

### DIFF
--- a/src/plugins/analysis/ip_and_uri_finder/view/ip_and_uri_finder.html
+++ b/src/plugins/analysis/ip_and_uri_finder/view/ip_and_uri_finder.html
@@ -1,38 +1,62 @@
 {% extends "analysis_plugins/general_information.html" %}
 
+{% macro result_list(results, location=False) %}
+    <ul class="list-group p-0 mb-0" style="width: 100%;">
+        {% for item in results %}
+            {% if location %}
+                <li class="list-group-item d-flex justify-content-between align-items-center rounded-0">
+                    {{ item.address }}
+                    {% if item.location %}
+                        <a href="https://www.google.de/maps/place/{{ item.location.latitude }},{{ item.location.longitude }}">
+                            <i class="fas fa-map-marker-alt"></i>
+                        </a>
+                    {% endif %}
+                </li>
+            {% else %}
+                <li class="list-group-item rounded-0">
+                    <a href="{{ item }}">{{ item }}</a>
+                </li>
+            {% endif %}
+        {% endfor %}
+    </ul>
+{% endmacro %}
+
 {% block analysis_result_details %}
-
-    {% for key, value in analysis_result.items() %}
+    {% if analysis_result['interesting_uris'] %}
         <tr>
-        {% if value != [] %}
-            <td>
-                {% if key == "ips_v4" %}IPv4
-                {% elif key == "ips_v6" %}IPv6
-                {% elif key == "uris" %}URI
-                {% else %}Interesting URIs{% endif %}
-            </td>
+            <td>Interesting URIs</td>
             <td class="p-0">
-                <ul class="list-group p-0 mb-0" style="width: 100%;">
-                    {% for item in value %}
-                        {% if key == "ips_v6" or  key == "ips_v4" %}
-                            <li class="list-group-item d-flex justify-content-between align-items-center rounded-0">
-                                {{ item.address }}
-                                {% if item.location %}
-                                    <a href="https://www.google.de/maps/place/{{ item.location.latitude }},{{ item.location.longitude }}">
-                                        <i class="fas fa-map-marker-alt"></i>
-                                    </a>
-                                {% endif %}
-                            </li>
-                        {% else %}
-                            <li class="list-group-item rounded-0">
-                                <a href="{{ item }}">{{ item }}</a>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
-                </ul>
+                {{ result_list(analysis_result['interesting_uris'] | sort) }}
             </td>
-        {% endif %}
         </tr>
-    {% endfor %}
+    {% endif %}
 
+    {# deduplicate "interesting" URIs for the analysis page #}
+    {% set results = (analysis_result['uris'] | to_set - analysis_result['interesting_uris'] | to_set) | sort %}
+    {% if results %}
+        <tr>
+            <td>URIs</td>
+            <td class="p-0">
+                {{ result_list(results) }}
+            </td>
+        </tr>
+    {% endif %}
+
+    {% if analysis_result['ips_v4'] %}
+        <tr>
+            <td>IPv4 Addresses</td>
+            <td class="p-0">
+                {{ result_list(analysis_result['ips_v4'] | sort_ip_list, True) }}
+            </td>
+        </tr>
+    {% endif %}
+
+    {% if analysis_result['ips_v6'] %}
+        <tr>
+            <td>IPv6 Addresses</td>
+            <td class="p-0">
+                {{ result_list(analysis_result['ips_v6'] | sort_ip_list, True) }}
+            </td>
+        </tr>
+    {% endif %}
 {% endblock %}

--- a/src/test/unit/web_interface/test_filter.py
+++ b/src/test/unit/web_interface/test_filter.py
@@ -536,3 +536,33 @@ def test_is_text_file_or_image(type_analysis, expected_result):
 )
 def test_sort_dict_list_by_key(input_, expected_result):
     assert flt.sort_dict_list_by_key(input_, 'a') == expected_result
+
+
+@pytest.mark.parametrize(
+    ('input_', 'expected_result'),
+    [
+        ([], []),  # test empty
+        (  # test IPv4
+            [{'address': '4.2.3.1'}, {'address': '1.2.3.4'}, {'address': '3.4.2.1'}, {'address': '2.3.1.4'}],
+            [{'address': '1.2.3.4'}, {'address': '2.3.1.4'}, {'address': '3.4.2.1'}, {'address': '4.2.3.1'}],
+        ),
+        (  # test IPv6
+            [
+                {'address': '2001:0db8:85a3:08d3::0370:7344'},
+                {'address': '2001:0db8::'},
+                {'address': '::1'},
+                {'address': 'fec0::'},
+            ],
+            [
+                {'address': '::1'},
+                {'address': '2001:0db8::'},
+                {'address': '2001:0db8:85a3:08d3::0370:7344'},
+                {'address': 'fec0::'},
+            ],
+        ),
+        # test fallback
+        ([{'address': '4.2.3.1'}, {'address': 'a.b.c'}], [{'address': 'a.b.c'}, {'address': '4.2.3.1'}]),
+    ],
+)
+def test_sort_ip_list(input_, expected_result):
+    assert flt.sort_ip_list(input_) == expected_result

--- a/src/web_interface/components/jinja_filter.py
+++ b/src/web_interface/components/jinja_filter.py
@@ -216,11 +216,13 @@ class FilterClass:
                 'replace_uid_with_hid': self._filter_replace_uid_with_hid,
                 'replace_underscore': flt.replace_underscore_filter,
                 'version_is_compatible': flt.version_is_compatible,
+                'to_set': set,
                 'sort_chart_list_by_name': flt.sort_chart_list_by_name,
                 'sort_chart_list_by_value': flt.sort_chart_list_by_value,
                 'sort_comments': flt.sort_comments,
                 'sort_cve': flt.sort_cve_results,
                 'sort_dict_list': flt.sort_dict_list_by_key,
+                'sort_ip_list': flt.sort_ip_list,
                 'sort_privileges': (
                     lambda privileges: sorted(privileges, key=lambda role: len(privileges[role]), reverse=True)
                 ),

--- a/src/web_interface/filter.py
+++ b/src/web_interface/filter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import binascii
+import ipaddress
 import json
 import logging
 import random
@@ -593,3 +594,20 @@ def is_image(mime: str) -> bool:
 def is_text_file_or_image(fo: FileObject) -> bool:
     mime = fo.processed_analysis.get('file_type', {}).get('result', {}).get('mime', '')
     return is_image(mime) or is_text_file(mime)
+
+
+IPv6 = 6
+
+
+def sort_ip_list(ip_list: list[dict]) -> list[dict]:
+    return sorted(ip_list, key=lambda d: _ip_str_to_tuple(d['address']))
+
+
+def _ip_str_to_tuple(ip_str: str) -> tuple[int, ...]:
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return (0,)
+    if addr.version == IPv6:
+        return tuple(int(i, 16) for i in addr.exploded.split(':'))
+    return tuple(int(i) for i in addr.exploded.split('.'))


### PR DESCRIPTION
* fixed order of keys ('interesting' URIs -> URIs -> IPv4 -> IPv6)
* sorted results
* don't display 'interesting' URIs twice (also in URIs)