### PR TITLE
fix: fix for redirect loop in case of user w/o roles

### DIFF
--- a/src/web_interface/components/miscellaneous_routes.py
+++ b/src/web_interface/components/miscellaneous_routes.py
@@ -25,7 +25,7 @@ class MiscellaneousRoutes(ComponentBase):
         self.stats_updater = StatsUpdater(stats_db=self.db.stats_updater)
 
     @login_required
-    @roles_accepted(*PRIVILEGES['status'])
+    @roles_accepted(no_role_needed=True)
     @AppRoute('/', GET)
     def show_home(self):
         latest_count = config.frontend.number_of_latest_firmwares_to_display

--- a/src/web_interface/security/decorator.py
+++ b/src/web_interface/security/decorator.py
@@ -5,11 +5,11 @@ from flask_security import roles_accepted as original_decorator
 import config
 
 
-def roles_accepted(*roles):
+def roles_accepted(*roles, no_role_needed: bool = False):
     def wrapper(fn):
         @wraps(fn)
         def decorated_view(*args, **kwargs):
-            if not config.frontend.authentication.enabled:
+            if not config.frontend.authentication.enabled or no_role_needed:
                 return fn(*args, **kwargs)
             return original_decorator(*roles)(fn)(*args, **kwargs)
 


### PR DESCRIPTION
removes role requirements from root `/` (home) endpoint to fix redirect loop for users without roles when authentication is enabled. The user still needs to log in to view the page, though.

resolves #1353