### PR TITLE
fix: strings plugin hex offset fix

### DIFF
--- a/src/plugins/analysis/strings/view/printable_strings.html
+++ b/src/plugins/analysis/strings/view/printable_strings.html
@@ -60,7 +60,7 @@
 
     <script>
         function formatHex(value) {
-            return `0x${value.toString(16)}`;
+            return `0x${Number(value).toString(16)}`;
         }
 
         function formatFloat(value) {


### PR DESCRIPTION
fixes a bug where the hex offsets in the strings plugin view are displayed as decimals