### PR TITLE
feat: show pointer cursor for clickable tags

### DIFF
--- a/src/test/integration/web_interface/test_filter.py
+++ b/src/test/integration/web_interface/test_filter.py
@@ -25,11 +25,14 @@ def test_list_group_collapse(frontend):
 @pytest.mark.parametrize(
     ('tag_dict', 'output'),
     [
-        ({'a': 'danger'}, '<span class="badge badge-danger mr-2" style="font-size: 14px;"  > a</span>'),
+        (
+            {'a': 'danger'},
+            '<span class="badge badge-danger mr-2" style="font-size: 14px; cursor: pointer;"  > a</span>',
+        ),
         (
             {'a': 'danger', 'b': 'primary'},
-            '<span class="badge badge-danger mr-2" style="font-size: 14px;"  > a</span>'
-            '<span class="badge badge-primary mr-2" style="font-size: 14px;"  > b</span>',
+            '<span class="badge badge-danger mr-2" style="font-size: 14px; cursor: pointer;"  > a</span>'
+            '<span class="badge badge-primary mr-2" style="font-size: 14px; cursor: pointer;"  > b</span>',
         ),
         (None, ''),
     ],

--- a/src/web_interface/templates/generic_view/tags.html
+++ b/src/web_interface/templates/generic_view/tags.html
@@ -1,6 +1,6 @@
 <span
     class="badge badge-{{ color }} mr-2"
-    style="font-size: {{ size }}px;"
+    style="font-size: {{ size }}px; cursor: pointer;"
     {% if tooltip -%}
         data-toggle="tooltip"
         title="{{ tooltip | replace_underscore }}"


### PR DESCRIPTION
- show pointer cursor for clickable tags for analysis tags on the analysis page

Thanks to @stauchert for the suggestion!