### PR TITLE
feat: start progress tracking before FW unpacking

### DIFF
--- a/src/scheduler/analysis/scheduler.py
+++ b/src/scheduler/analysis/scheduler.py
@@ -106,6 +106,7 @@ class AnalysisScheduler:
         post_analysis: Callable[[str, str, dict], None] | None = None,
         db_interface: BackendDbInterface | None = None,
         unpacking_locks: UnpackingLockManager | None = None,
+        status: AnalysisStatus | None = None,
     ):
         self.analysis_plugins: dict[str, AnalysisPluginV0] = {}
         self._plugin_runners: dict[str, PluginRunner] = {}
@@ -116,7 +117,7 @@ class AnalysisScheduler:
         self.unpacking_locks = unpacking_locks
         self.scheduling_lock = Lock()
 
-        self.status = AnalysisStatus()
+        self.status = status or AnalysisStatus()
         self.task_scheduler = AnalysisTaskScheduler(self.analysis_plugins)
         self.schedule_processes = []
         self.result_collector_processes = []

--- a/src/scheduler/analysis_status.py
+++ b/src/scheduler/analysis_status.py
@@ -37,20 +37,20 @@ class AnalysisStatus:
         self._currently_analyzed = self._manager.dict()
         self._worker = AnalysisStatusWorker(currently_analyzed_fw=self._currently_analyzed)
 
-    def start(self):
+    def start(self) -> None:
         self._worker.start()
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         self._worker.shutdown()
         self._manager.shutdown()
 
-    def add_update(self, fw_object: FileObject, included_files: list[str] | set[str]):
+    def add_update(self, fw_object: FileObject, included_files: list[str] | set[str]) -> None:
         # normally, status is initialized during unpacking, but since unpacking is skipped for updates, we need to
         # init it here first before adding the object
         self.init_firmware(fw_object)
         self._worker.queue.put((_UpdateType.add_update, fw_object.uid, included_files))
 
-    def init_firmware(self, fw_object: FileObject):
+    def init_firmware(self, fw_object: FileObject) -> None:
         self._worker.queue.put(
             (
                 _UpdateType.add_firmware,
@@ -60,7 +60,7 @@ class AnalysisStatus:
             )
         )
 
-    def add_object(self, fw_object: FileObject):
+    def add_object(self, fw_object: FileObject) -> None:
         self._worker.queue.put(
             (
                 _UpdateType.add_file,
@@ -70,16 +70,16 @@ class AnalysisStatus:
             )
         )
 
-    def add_analysis(self, fw_object: FileObject, plugin: str):
+    def add_analysis(self, fw_object: FileObject, plugin: str) -> None:
         self._worker.queue.put((_UpdateType.add_analysis, fw_object.root_uid, plugin))
 
-    def remove_object(self, fw_object: FileObject):
+    def remove_object(self, fw_object: FileObject) -> None:
         self._worker.queue.put((_UpdateType.remove_file, fw_object.uid, fw_object.root_uid))
 
     def fw_analysis_is_in_progress(self, fw_object: FileObject) -> bool:
         return fw_object.root_uid in self._currently_analyzed or fw_object.uid in self._currently_analyzed
 
-    def cancel_analysis(self, root_uid: str):
+    def cancel_analysis(self, root_uid: str) -> None:
         self._worker.queue.put((_UpdateType.cancel, root_uid))
 
 
@@ -108,19 +108,19 @@ class AnalysisStatusWorker:
         self._running = Value('i', 0)
         self.redis = RedisStatusInterface()
 
-    def start(self):
+    def start(self) -> None:
         if self._running.value == 0:
             self._running.value = 1
             self._worker_process = Process(target=self._worker_loop)
             self._worker_process.start()
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         if self._running.value == 1:
             self._running.value = 0
             if self._worker_process is not None:
                 stop_process(self._worker_process, timeout=10)
 
-    def _worker_loop(self):
+    def _worker_loop(self) -> None:
         logging.debug(f'starting analysis status worker (pid: {os.getpid()})')
         next_update_time = 0
         while self._running.value:
@@ -135,7 +135,7 @@ class AnalysisStatusWorker:
                 next_update_time = current_time + config.backend.analysis_status_update_interval
         logging.debug('stopped analysis status worker')
 
-    def _update_status(self):
+    def _update_status(self) -> None:
         update_type, *args = self.queue.get(timeout=config.backend.analysis_status_update_interval)
         if update_type == _UpdateType.add_update:
             self._add_update(*args)
@@ -150,7 +150,7 @@ class AnalysisStatusWorker:
         elif update_type == _UpdateType.cancel:
             self._cancel_analysis(*args)
 
-    def _add_update(self, fw_uid: str, included_files: set[str]):
+    def _add_update(self, fw_uid: str, included_files: set[str]) -> None:
         status = self.currently_running[fw_uid]
         status.files_to_unpack = set()
         file_count = len(included_files) + 1
@@ -159,18 +159,18 @@ class AnalysisStatusWorker:
         status.total_files_with_duplicates = file_count
         status.files_to_analyze = {fw_uid, *included_files}
 
-    def _add_firmware(self, uid: str, hid: str, scheduled_analyses: list[str] | None):
+    def _add_firmware(self, uid: str, hid: str, scheduled_analyses: list[str] | None) -> None:
         self.currently_running[uid] = FwAnalysisStatus(
             files_to_unpack={uid},
             files_to_analyze={uid},
             total_files_count=1,
             hid=hid,
-            analysis_plugins={p: 0 for p in scheduled_analyses or []},
+            analysis_plugins=dict.fromkeys(scheduled_analyses or [], 0),
         )
         # This is only for checking if a FW is currently analyzed from *outside* of this class
         self.currently_analyzed[uid] = True
 
-    def _add_included_file(self, uid: str, root_uid: str, included_files: set[str]):
+    def _add_included_file(self, uid: str, root_uid: str, included_files: set[str]) -> None:
         """
         An included file of a FW comes from unpacking. There are two things that need to be updated:
         - move the file from files_to_unpack to files_to_analyze (could be a duplicate, i.e. was already moved)
@@ -189,14 +189,14 @@ class AnalysisStatusWorker:
             status.files_to_analyze.add(uid)
             status.unpacked_files_count += 1
 
-    def _add_analysis(self, root_uid: str, plugin: str):
+    def _add_analysis(self, root_uid: str, plugin: str) -> None:
         if root_uid not in self.currently_running:
             return
         status = self.currently_running[root_uid]
         status.analysis_plugins.setdefault(plugin, 0)
         status.analysis_plugins[plugin] += 1
 
-    def _remove_object(self, uid: str, root_uid: str):
+    def _remove_object(self, uid: str, root_uid: str) -> None:
         if root_uid not in self.currently_running:
             return
         status = self.currently_running[root_uid]
@@ -222,13 +222,13 @@ class AnalysisStatusWorker:
             'hid': analysis_status.hid,
         }
 
-    def _clear_recently_finished(self):
+    def _clear_recently_finished(self) -> None:
         for status_dict in (self.recently_finished, self.recently_canceled):
             for uid, stats in list(status_dict.items()):
                 if time() - stats['time_finished'] > RECENTLY_FINISHED_DISPLAY_TIME_IN_SEC:
                     status_dict.pop(uid)
 
-    def _store_status(self):
+    def _store_status(self) -> None:
         status = {
             'current_analyses': self._get_current_analyses_stats(),
             'recently_finished_analyses': self.recently_finished,
@@ -236,7 +236,7 @@ class AnalysisStatusWorker:
         }
         self.redis.set_analysis_status(status)
 
-    def _get_current_analyses_stats(self):
+    def _get_current_analyses_stats(self) -> dict[str, dict]:
         return {
             uid: {
                 'unpacked_count': status.unpacked_files_count,
@@ -250,7 +250,7 @@ class AnalysisStatusWorker:
             for uid, status in self.currently_running.items()
         }
 
-    def _cancel_analysis(self, root_uid: str):
+    def _cancel_analysis(self, root_uid: str) -> None:
         if root_uid in self.currently_running:
             status = self.currently_running.pop(root_uid)
             self.recently_canceled[root_uid] = {

--- a/src/scheduler/unpacking_scheduler.py
+++ b/src/scheduler/unpacking_scheduler.py
@@ -29,8 +29,12 @@ from unpacker.unpack import Unpacker
 from unpacker.unpack_base import ExtractionError
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
     from objects.file import FileObject
     from scheduler.analysis_status import AnalysisStatus
+    from storage.fsorganizer import FSOrganizer
+    from storage.unpacking_locks import UnpackingLockManager
 
 
 class NoFreeWorker(RuntimeError):  # noqa: N818
@@ -47,11 +51,11 @@ class UnpackingScheduler:
 
     def __init__(
         self,
-        post_unpack=None,
-        analysis_workload=None,
-        fs_organizer=None,
-        unpacking_locks=None,
-        db_interface=BackendDbInterface,
+        post_unpack: Callable,
+        analysis_workload: Callable | None = None,
+        fs_organizer: FSOrganizer | None = None,
+        unpacking_locks: UnpackingLockManager | None = None,
+        db_interface: type[BackendDbInterface] = BackendDbInterface,
         status: AnalysisStatus | None = None,
     ):
         self.stop_condition = Value('i', 0)
@@ -75,14 +79,14 @@ class UnpackingScheduler:
         self.db_interface = db_interface
 
     @contextmanager
-    def _sync(self):
+    def _sync(self) -> Iterator:
         try:
             self.sync_lock.acquire()
             yield
         finally:
             self.sync_lock.release()
 
-    def start(self):
+    def start(self) -> None:
         self.manager = Manager()
         self.workers = self.manager.list()  # type: list[ExtractionContainer]
         self.currently_extracted = self.manager.dict()  # type: dict[str, dict[str, set]]
@@ -92,12 +96,12 @@ class UnpackingScheduler:
         self.extraction_process = self._start_extraction_loop()
         logging.info('Unpacking scheduler online')
 
-    def _start_extraction_loop(self):
+    def _start_extraction_loop(self) -> ExceptionSafeProcess:
         extraction_loop_process = ExceptionSafeProcess(target=self.extraction_loop)
         extraction_loop_process.start()
         return extraction_loop_process
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         """
         shutdown the scheduler
         """
@@ -114,7 +118,7 @@ class UnpackingScheduler:
             self.manager.shutdown()
         logging.info('Unpacking scheduler offline')
 
-    def _clean_tmp_dirs(self):
+    def _clean_tmp_dirs(self) -> None:
         for tmp_dir in self.worker_tmp_dirs:
             try:
                 tmp_dir.cleanup()
@@ -123,7 +127,7 @@ class UnpackingScheduler:
 
     # ---- internal functions ----
 
-    def add_task(self, fw: Firmware):
+    def add_task(self, fw: Firmware) -> None:
         """
         schedule a firmware_object for unpacking
         """
@@ -132,10 +136,10 @@ class UnpackingScheduler:
             self.status.init_firmware(fw)  # initialize unpacking and analysis progress tracking
         self.in_queue.put(fw)
 
-    def get_scheduled_workload(self):
+    def get_scheduled_workload(self) -> dict:
         return {'unpacking_queue': self.in_queue.qsize(), 'is_throttled': self.throttle_condition.value == 1}
 
-    def create_containers(self):
+    def create_containers(self) -> None:
         logging.info(f'Starting unpacking workers... (tag: {config.backend.unpacking.docker_image})')
         self._validate_container_image()
         for id_ in range(config.backend.unpacking.processes):
@@ -145,12 +149,12 @@ class UnpackingScheduler:
             self.workers.append(container)
             self.worker_tmp_dirs.append(tmp_dir)
 
-    def stop_containers(self):
+    def stop_containers(self) -> None:
         if self.workers:
             with ThreadPoolExecutor(max_workers=len(self.workers)) as pool:
                 pool.map(lambda container: container.stop(), self.workers)
 
-    def extraction_loop(self):
+    def extraction_loop(self) -> None:
         logging.debug(f'Starting unpacking scheduler loop (pid={os.getpid()})')
         while self.stop_condition.value == 0:
             self.check_pending()
@@ -171,7 +175,7 @@ class UnpackingScheduler:
                 pass
         logging.debug('Stopped unpacking scheduler loop')
 
-    def check_pending(self):
+    def check_pending(self) -> None:
         for container_id, thread in list(self.pending_tasks.items()):
             if not thread.is_alive():
                 thread.join()
@@ -187,7 +191,7 @@ class UnpackingScheduler:
                 return container
         raise NoFreeWorker()
 
-    def _work_thread_wrapper(self, task: FileObject, container: ExtractionContainer):
+    def _work_thread_wrapper(self, task: FileObject, container: ExtractionContainer) -> None:
         """
         Exceptions in Threads will simply disappear when the thread is joined. We wrap everything in a
         try-except block and log exceptions so that no exception occurs unnoticed.
@@ -197,7 +201,7 @@ class UnpackingScheduler:
         except Exception:
             logging.exception(f'Exception occurred during unpacking of {task.uid}')
 
-    def work_thread(self, task: FileObject, container: ExtractionContainer):
+    def work_thread(self, task: FileObject, container: ExtractionContainer) -> None:
         if isinstance(task, Firmware):
             self._init_currently_unpacked(task)
         elif task.root_uid not in self.currently_extracted:
@@ -230,7 +234,7 @@ class UnpackingScheduler:
 
     def _update_currently_unpacked(
         self, task: FileObject, extracted_objects: list[FileObject], db_interface: BackendDbInterface
-    ):
+    ) -> None:
         with self._sync():
             currently_unpacked = self.currently_extracted.get(task.root_uid)
             if currently_unpacked is None:
@@ -260,7 +264,7 @@ class UnpackingScheduler:
         db_interface: BackendDbInterface,
         extracted_objects: list[FileObject],
         current_fo: FileObject,
-    ):
+    ) -> None:
         for fo in extracted_objects[:]:
             path_list = fo.virtual_file_path[current_fo.uid]
             # 3 cases: unpacking not yet started, unpacking currently in progress, unpacking already done
@@ -284,11 +288,11 @@ class UnpackingScheduler:
             logging.error('Could not fetch unpacking container logs')
             return ''
 
-    def _schedule_extracted_files(self, object_list: list[FileObject]):
+    def _schedule_extracted_files(self, object_list: list[FileObject]) -> None:
         for item in object_list:
             self._add_object_to_unpack_queue(item)
 
-    def _add_object_to_unpack_queue(self, item):
+    def _add_object_to_unpack_queue(self, item: FileObject) -> None:
         while self.stop_condition.value == 0:
             if self.throttle_condition.value == 0:
                 self.in_queue.put(item)
@@ -296,12 +300,12 @@ class UnpackingScheduler:
             logging.debug('Throttling down unpacking to reduce memory consumption...')
             sleep(5)
 
-    def start_work_load_monitor(self):
+    def start_work_load_monitor(self):  # noqa: ANN201
         work_load_process = ExceptionSafeProcess(target=self._work_load_monitor)
         work_load_process.start()
         return work_load_process
 
-    def _work_load_monitor(self):
+    def _work_load_monitor(self) -> None:
         logging.debug(f'Started unpacking work load monitor (pid={os.getpid()})')
         while self.stop_condition.value == 0:
             workload = self._get_combined_analysis_workload()
@@ -326,31 +330,31 @@ class UnpackingScheduler:
             sleep(THROTTLE_INTERVAL)
         logging.debug('Stopped unpacking work load monitor')
 
-    def _get_combined_analysis_workload(self):
+    def _get_combined_analysis_workload(self) -> int:
         if self.get_analysis_workload is not None:
             return self.get_analysis_workload()
         return 0
 
-    def check_exceptions(self):
+    def check_exceptions(self) -> bool:
         list_with_load_process = [self.work_load_process]
         shutdown = check_worker_exceptions(list_with_load_process, 'unpack-load', self._work_load_monitor)
         if new_worker_was_started(new_process=list_with_load_process[0], old_process=self.work_load_process):
             self.work_load_process = list_with_load_process.pop()
         return shutdown
 
-    def _init_currently_unpacked(self, fo: Firmware):
+    def _init_currently_unpacked(self, fo: Firmware) -> None:
         with self._sync():
             if fo.uid in self.currently_extracted:
                 logging.warning(f'Starting unpacking of {fo.uid} but it is currently also still being unpacked')
             else:
                 self.currently_extracted[fo.uid] = {'remaining': {fo.uid}, 'done': set(), 'delayed_vfp_update': {}}
 
-    def cancel_unpacking(self, root_uid: str):
+    def cancel_unpacking(self, root_uid: str) -> None:
         if self.currently_extracted is not None and root_uid in self.currently_extracted:
             self.currently_extracted.pop(root_uid)
 
     @staticmethod
-    def _validate_container_image():
+    def _validate_container_image() -> None:
         try:
             DOCKER_CLIENT.images.get(config.backend.unpacking.docker_image)
         except NotFound:

--- a/src/start_fact_backend.py
+++ b/src/start_fact_backend.py
@@ -53,6 +53,7 @@ class FactBackend(FactBase):
             post_unpack=self.analysis_service.start_analysis_of_object,
             analysis_workload=self.analysis_service.get_combined_analysis_workload,
             unpacking_locks=self.unpacking_lock_manager,
+            status=self.analysis_service.status,
         )
         self.compare_service = ComparisonScheduler()
         self.intercom = InterComBackEndBinding(

--- a/src/start_fact_backend.py
+++ b/src/start_fact_backend.py
@@ -1,20 +1,20 @@
 #! /usr/bin/env python3
 """
-    Firmware Analysis and Comparison Tool (FACT)
-    Copyright (C) 2015-2026  Fraunhofer FKIE
+Firmware Analysis and Comparison Tool (FACT)
+Copyright (C) 2015-2026  Fraunhofer FKIE
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import grp
@@ -24,9 +24,8 @@ import resource
 import sys
 from pathlib import Path
 
-from fact_base import FactBase
-
 import config
+from fact_base import FactBase
 from helperFunctions.process import complete_shutdown
 from intercom.back_end_binding import InterComBackEndBinding
 from scheduler.analysis import AnalysisScheduler
@@ -63,13 +62,13 @@ class FactBackend(FactBase):
             unpacking_locks=self.unpacking_lock_manager,
         )
 
-    def start(self):
+    def start(self) -> None:
         self.analysis_service.start()
         self.unpacking_service.start()
         self.compare_service.start()
         self.intercom.start()
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         super().shutdown()
         self.intercom.shutdown()
         self.compare_service.shutdown()
@@ -79,14 +78,14 @@ class FactBackend(FactBase):
         if not self.args.testing:
             complete_shutdown()
 
-    def _update_component_workload(self):
+    def _update_component_workload(self) -> None:
         self.work_load_stat.update(
             unpacking_workload=self.unpacking_service.get_scheduled_workload(),
             analysis_workload=self.analysis_service.get_scheduled_workload(),
         )
 
     @staticmethod
-    def _create_docker_base_dir():
+    def _create_docker_base_dir() -> None:
         docker_mount_base_dir = Path(config.backend.docker_mount_base_dir)
         docker_mount_base_dir.mkdir(0o770, exist_ok=True)
         docker_gid = grp.getgrnam('docker').gr_gid
@@ -97,7 +96,7 @@ class FactBackend(FactBase):
             # E.g. in FACT_docker the correct group is not the group named 'docker'
             logging.warning('Could not change permissions of docker-mount-base-dir. Ignoring.')
 
-    def _exception_occurred(self):
+    def _exception_occurred(self) -> bool:
         return any(
             (
                 self.unpacking_service.check_exceptions(),
@@ -107,7 +106,7 @@ class FactBackend(FactBase):
         )
 
 
-def _check_ulimit():
+def _check_ulimit() -> None:
     """
     2024-07-16 - the numbers are prone to change over time
 

--- a/src/test/conftest.py
+++ b/src/test/conftest.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from multiprocessing import Event, Queue, Value
 from pathlib import Path
-from typing import List, NamedTuple, Type, TypeVar
+from typing import NamedTuple, TypeVar
 
 import pytest
 from pydantic import BaseModel, ConfigDict
@@ -37,7 +37,7 @@ def _assert_fixture_is_requested(request: pytest.FixtureRequest, fixture: str):
     assert fixture in request.fixturenames, f'{request.fixturename} cannot be used without requiring {fixture}'
 
 
-def merge_markers(request, name: str, dtype: Type[T]) -> T:
+def merge_markers(request, name: str, dtype: type[T]) -> T:
     """Merge all markers from closest to farthest. Closer markers overwrite markers that are farther away.
 
     The marker must either get an instance of ``dtype`` as an argument or have one or more keyword arguments.
@@ -124,12 +124,12 @@ class MockIntercom:
     def __init__(self):
         self.deleted_files = []
 
-    def delete_file(self, uid_list: List[str]):
+    def delete_file(self, uid_list: list[str]):
         self.deleted_files.extend(uid_list)
 
 
 @pytest.fixture(scope='session')
-def _database_interfaces():  # noqa: PT005
+def _database_interfaces():
     """Creates the tables that backend needs.
     This is equivalent to executing ``init_postgres.py``.
     """
@@ -504,20 +504,20 @@ class SchedulerTestConfig(BaseModel):
     #: Set the class that is used as :py:class:`~storage.db_interface_backend.BackendDbInterface`.
     #: This can be either a mocked class or the actual :py:class:`~storage.db_interface_backend.BackendDbInterface`.
     #: This is used by the :py:func:`analysis_scheduler`
-    backend_db_class: Type
+    backend_db_class: type
     #: Set the class that is used as :py:class:`~storage.db_interface_comparison.ComparisonDbInterface`.
     #: This can be either a mocked class or the actual :py:class:`~storage.db_interface_comparison.ComparisonDbInterface`.  # noqa: E501
     #: This is used by the :py:func:`comparison_scheduler`
-    comparison_db_class: Type
+    comparison_db_class: type
     #: Set the class that is used as :py:class:`~storage.fsorganizer.FSOrganizer`.
     #: This can be either a mocked class or the actual :py:class:`~storage.fsorganizer.FSOrganizer`.
     #: This is used by the :py:func:`unpacking_scheduler` and the :py:func:`analysis_scheduler`.
-    fs_organizer_class: Type
+    fs_organizer_class: type
     #: Set the class that is used as :py:class:`~storage.db_interface_view_sync.ViewUpdater`.
     #: If you set this to the actual :py:class:`~storage.db_interface_view_sync.ViewUpdater` note that the fixture
     #: :py:func:`~test.conftest.database_interfaces` has to be executed before (e.g. by
     #: ``pytest.fixture(autouse=True)``) any of the scheduler fixtures.
-    view_updater_class: Type
+    view_updater_class: type
     #: If set to ``True`` the :py:func:`unpacking_scheduler` and :py:func:`analysis_scheduler` are connected via their
     #: hooks.
     #: To be precise the analysis is started after unpacking.

--- a/src/test/unit/scheduler/test_analysis_status.py
+++ b/src/test/unit/scheduler/test_analysis_status.py
@@ -23,9 +23,22 @@ class TestAnalysisStatus:
         self.status = AnalysisStatus()
         self.status._worker.redis = MockRedis()
 
-    def test_add_firmware_to_current_analyses(self):
+    def test_init_firmware(self):
         fw = Firmware(binary=b'foo')
         fw.files_included = ['foo', 'bar']
+        self.status.init_firmware(fw)
+        self.status._worker._update_status()
+
+        assert fw.uid in self.status._worker.currently_running
+        result = self.status._worker.currently_running[fw.uid]
+        assert result.files_to_unpack == {fw.uid}
+        assert result.files_to_analyze == {fw.uid}
+        assert result.completed_files == set()
+        assert result.unpacked_files_count == 0
+        assert result.analyzed_files_count == 0
+        assert result.total_files_count == 1
+
+        # after unpacking, the file is added again with add_object to add the included files
         self.status.add_object(fw)
         self.status._worker._update_status()
 
@@ -47,6 +60,7 @@ class TestAnalysisStatus:
                 hid='',
                 total_files_count=2,
                 total_files_with_duplicates=2,
+                unpacked_files_count=1,
             )
         }
         fo = FileObject(binary=b'foo')


### PR DESCRIPTION
- start tracking the progress of the (root) firmware file object before unpacking (so that it can be seen earlier in the status page of the webinterface)
  - this fixes the "bug" that the progress seemingly hangs after upload if unpacking takes long