### PR TITLE
fix: fix for newest sqlalchemy version 2.0.42 introducing a syntax error

### DIFF
--- a/src/storage/db_interface_frontend.py
+++ b/src/storage/db_interface_frontend.py
@@ -5,8 +5,7 @@ import re
 from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
-from sqlalchemy import Column, func, or_, select
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import Column, Integer, cast, func, or_, select
 
 from helperFunctions.data_conversion import get_value_of_first_key
 from helperFunctions.tag import TagColor
@@ -170,7 +169,7 @@ class FrontEndDbInterface(DbInterfaceCommon):
     def get_latest_comments(self, limit=10):
         with self.get_read_only_session() as session:
             subquery = select(FileObjectEntry.uid, func.jsonb_array_elements(FileObjectEntry.comments)).subquery()
-            query = select(subquery).order_by(subquery.c.jsonb_array_elements.cast(JSONB)['time'].desc())
+            query = select(subquery).order_by(cast(subquery.c.jsonb_array_elements.op('->>')('time'), Integer).desc())
             return [{'uid': uid, **comment_dict} for uid, comment_dict in session.execute(query.limit(limit))]
 
     # --- generic search ---


### PR DESCRIPTION
during sorting of comments