### PR TITLE
feat: make throttling check interval configurable

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -125,6 +125,7 @@ class Backend(Common):
         max_depth: int
         memory_limit: int = 2048
 
+        throttle_interval: float
         throttle_limit: int
 
         delay: float

--- a/src/config/fact-core-config.toml
+++ b/src/config/fact-core-config.toml
@@ -93,7 +93,10 @@ whitelist = [
 max-depth = 8
 # Memory limit in MiB.
 # memory-limit = 2048
+# halt unpacking temporarily if the cumulated input queue length of all analysis plugins reaches this value
 throttle-limit = 100
+# time interval in seconds to check if throttling should be enabled
+throttle-interval = 2
 # tcp port(s) for task server
 base-port = 9900
 # if you experience FileNotFound errors during unpacking, increasing this value slightly might help

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -114,6 +114,7 @@ def backend_config(request, common_config, firmware_file_storage_directory) -> c
             'whitelist': [],
             'max_depth': 8,
             'memory_limit': 2048,
+            'throttle_interval': 0.5,
             'throttle_limit': 50,
             'delay': 0.0,
             'base_port': 9900,

--- a/src/scheduler/unpacking_scheduler.py
+++ b/src/scheduler/unpacking_scheduler.py
@@ -36,9 +36,6 @@ class NoFreeWorker(RuntimeError):  # noqa: N818
     pass
 
 
-THROTTLE_INTERVAL = 2
-
-
 class UnpackingScheduler:
     """
     This scheduler performs unpacking on firmware objects
@@ -103,7 +100,7 @@ class UnpackingScheduler:
         self.in_queue.close()
         stop_processes(
             [self.work_load_process, self.extraction_process],
-            THROTTLE_INTERVAL,
+            config.backend.unpacking.throttle_interval,
         )
         self.stop_containers()
         self._clean_tmp_dirs()
@@ -318,7 +315,7 @@ class UnpackingScheduler:
                 message += ' (throttled)'
 
             log_function(color_string(message, TerminalColors.WARNING))
-            sleep(THROTTLE_INTERVAL)
+            sleep(config.backend.unpacking.throttle_interval)
         logging.debug('Stopped unpacking work load monitor')
 
     def _get_combined_analysis_workload(self):


### PR DESCRIPTION
- make `THROTTLE_INTERVAL` configurable through the main config 
  - and set it to 0.5 for the tests to reduce unnecessary sleeps and speed them up