### PR TITLE
feat: speedup cve_lookup installation on CI

### DIFF
--- a/src/plugins/analysis/cve_lookup/internal/data_parsing.py
+++ b/src/plugins/analysis/cve_lookup/internal/data_parsing.py
@@ -9,9 +9,10 @@ import ijson
 import requests
 from requests.adapters import HTTPAdapter, Retry
 
-from ..internal.helper_functions import CveEntry
+from ..internal.helper_functions import CveEntry, is_ci
 
-FILE_NAME = 'CVE-all.json.xz'
+# Hack: if this is running on the CI, only load recent CVE entries instead of all
+FILE_NAME = 'CVE-all.json.xz' if not is_ci() else 'CVE-recent.json.xz'
 CVE_URL = f'https://github.com/fkie-cad/nvd-json-data-feeds/releases/latest/download/{FILE_NAME}'
 DB_DIR = Path(__file__).parent / 'database'
 OUTPUT_FILE = DB_DIR / FILE_NAME

--- a/src/plugins/analysis/cve_lookup/internal/helper_functions.py
+++ b/src/plugins/analysis/cve_lookup/internal/helper_functions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import getpass
+import os
 from typing import NamedTuple
 
 
@@ -24,3 +26,7 @@ def replace_wildcards(attributes: list[str]) -> list[str]:
         elif attribute == '-':
             attributes[index] = 'N/A'
     return attributes
+
+
+def is_ci():
+    return getpass.getuser() == 'vagrant' and os.environ.get('GITHUB_RUNNER_ACTION_TOKEN') is not None


### PR DESCRIPTION
- if a CI worker is detected, don't load the whole CVE database