### PR TITLE
Plugin base v1 fixes

### DIFF
--- a/src/analysis/plugin/__init__.py
+++ b/src/analysis/plugin/__init__.py
@@ -1,1 +1,1 @@
-from .plugin import AnalysisPluginV0, Tag  # noqa: F401
+from .plugin import AnalysisFailedError, AnalysisPluginV0, Tag  # noqa: F401

--- a/src/analysis/plugin/plugin.py
+++ b/src/analysis/plugin/plugin.py
@@ -118,7 +118,7 @@ class AnalysisPluginV0(compat.AnalysisBasePluginAdapterMixin, metaclass=abc.ABCM
         file_handle: io.FileIO,
         virtual_file_path: dict,
         analyses: dict[str, pydantic.BaseModel],
-    ) -> typing.Optional[Schema]:
+    ) -> Schema:
         """Analyze a file.
         May return None if nothing was found.
 

--- a/src/analysis/plugin/plugin.py
+++ b/src/analysis/plugin/plugin.py
@@ -15,7 +15,11 @@ if typing.TYPE_CHECKING:
 
 
 class AnalysisFailedError(Exception):
-    ...
+    """
+    This exception is used to cancel an analysis in a controlled way while still providing context information and
+    will not log an error with traceback to the terminal. It is an "expected exception" during analysis: Some
+    requirement is missing or the analysis input is incompatible and the analysis cannot be performend.
+    """
 
 
 class Tag(BaseModel):

--- a/src/plugins/analysis/binwalk/code/binwalk.py
+++ b/src/plugins/analysis/binwalk/code/binwalk.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, List
 
 import binwalk
 from pydantic import BaseModel, Field
+from semver import Version
 
 import config
 from analysis.plugin import AnalysisPluginV0
@@ -37,10 +38,10 @@ class AnalysisPlugin(AnalysisPluginV0):
 
     def __init__(self):
         super().__init__(
-            metadata=AnalysisPluginV0.MetaData(
+            metadata=self.MetaData(
                 name='binwalk',
                 description='binwalk signature and entropy analysis',
-                version='1.0.0',
+                version=Version(1, 0, 0),
                 Schema=self.Schema,
                 mime_blacklist=['audio/', 'image/', 'video/', 'text/', *MIME_BLACKLIST_COMPRESSED],
             ),

--- a/src/plugins/analysis/cpu_architecture/test/test_plugin_cpu_architecture.py
+++ b/src/plugins/analysis/cpu_architecture/test/test_plugin_cpu_architecture.py
@@ -212,7 +212,7 @@ def test_metadatadetector_get_device_architecture(architecture, bitness, endiann
 
 
 @pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
-class TestAnalysisPluginsSoftwareComponents:
+class TestAnalysisPluginCpuArchitecture:
     def test_analyze(self, analysis_plugin):
         dependencies = {
             'kernel_config': _mock_kernel_config_analysis_arm,

--- a/src/plugins/analysis/crypto_hints/code/crypto_hints.py
+++ b/src/plugins/analysis/crypto_hints/code/crypto_hints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, List
 
 import pydantic
+from semver import Version
 
 from analysis.plugin import AnalysisPluginV0, addons, compat
 
@@ -15,10 +16,10 @@ class AnalysisPlugin(AnalysisPluginV0):
         matches: List[dict]
 
     def __init__(self):
-        metadata = AnalysisPluginV0.MetaData(
+        metadata = self.MetaData(
             name='crypto_hints',
             description='find indicators of specific crypto algorithms',
-            version='0.2.1',
+            version=Version(0, 2, 1),
             Schema=AnalysisPlugin.Schema,
         )
         super().__init__(metadata=metadata)

--- a/src/plugins/analysis/crypto_material/code/crypto_material.py
+++ b/src/plugins/analysis/crypto_material/code/crypto_material.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING, List, NamedTuple
 
 from pydantic import BaseModel, Field
+from semver import Version
 
 from analysis.plugin import AnalysisPluginV0, Tag, addons, compat
 from helperFunctions.hash import get_md5
@@ -61,7 +62,7 @@ class AnalysisPlugin(AnalysisPluginV0):
         metadata = self.MetaData(
             name='crypto_material',
             description='detects crypto material like SSH keys and SSL certificates',
-            version='1.0.0',
+            version=Version(1, 0, 0),
             mime_blacklist=['filesystem', *MIME_BLACKLIST_COMPRESSED],
             Schema=self.Schema,
         )

--- a/src/plugins/analysis/device_tree/code/device_tree.py
+++ b/src/plugins/analysis/device_tree/code/device_tree.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Dict
 
 from semver import Version
 
@@ -40,7 +40,7 @@ class AnalysisPlugin(AnalysisPluginV0):
         file_handle: io.FileIO,
         virtual_file_path: dict,
         analyses: Dict[str, dict],
-    ) -> Optional[Schema]:
+    ) -> Schema:
         del virtual_file_path, analyses
 
         binary = file_handle.readall()

--- a/src/plugins/analysis/device_tree/code/device_tree.py
+++ b/src/plugins/analysis/device_tree/code/device_tree.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 class AnalysisPlugin(AnalysisPluginV0):
     def __init__(self):
-        metadata = AnalysisPluginV0.MetaData(
+        metadata = self.MetaData(
             name='device_tree',
             description='get the device tree in text from the device tree blob',
             version=Version(2, 0, 1),

--- a/src/plugins/analysis/example_plugin/code/example_plugin.py
+++ b/src/plugins/analysis/example_plugin/code/example_plugin.py
@@ -2,6 +2,7 @@ import io
 
 import pydantic
 from pydantic import Field
+from semver import Version
 
 from analysis.plugin import AnalysisPluginV0
 
@@ -24,10 +25,10 @@ class AnalysisPlugin(AnalysisPluginV0):
         dependant_analysis: dict
 
     def __init__(self):
-        metadata = AnalysisPluginV0.MetaData(
+        metadata = self.MetaData(
             name='ExamplePlugin',
             description='An example description',
-            version='0.0.0',
+            version=Version(0, 0, 0),
             Schema=AnalysisPlugin.Schema,
             # Note that you don't have to set these fields,
             # they are just here to show that you can.

--- a/src/plugins/analysis/example_plugin/code/example_plugin.py
+++ b/src/plugins/analysis/example_plugin/code/example_plugin.py
@@ -1,10 +1,11 @@
 import io
+from pathlib import Path
 
 import pydantic
 from pydantic import Field
 from semver import Version
 
-from analysis.plugin import AnalysisPluginV0
+from analysis.plugin import AnalysisFailedError, AnalysisPluginV0
 
 
 class AnalysisPlugin(AnalysisPluginV0):
@@ -44,14 +45,16 @@ class AnalysisPlugin(AnalysisPluginV0):
         del result
         return ['big-file', 'binary']
 
-    def analyze(self, file_handle: io.FileIO, virtual_file_path: str, analyses: dict) -> Schema:
-        file_type_analysis = analyses['file_type']
-
+    def analyze(self, file_handle: io.FileIO, virtual_file_path: dict, analyses: dict) -> Schema:
         first_byte = file_handle.read(1)
+        if first_byte == b'\xff':
+            raise AnalysisFailedError('reason for fail')
+        if first_byte == b'\xee':
+            raise Exception('Unexpected exception occurred.')
         return AnalysisPlugin.Schema(
             number=42,
-            name=file_handle.name,
+            name=Path(file_handle.name).name,
             first_byte=first_byte.hex(),
             virtual_file_path=virtual_file_path,
-            dependant_analysis=file_type_analysis,
+            dependant_analysis=analyses['file_type'].model_dump(),
         )

--- a/src/plugins/analysis/file_system_metadata/code/file_system_metadata.py
+++ b/src/plugins/analysis/file_system_metadata/code/file_system_metadata.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, List, NamedTuple, Optional
 
 from docker.types import Mount
 from pydantic import BaseModel, Field
+from semver import Version
 
 import config
 from analysis.plugin import AnalysisPluginV0, Tag
@@ -130,7 +131,7 @@ class AnalysisPlugin(AnalysisPluginV0):
             description=(
                 'extract file system metadata (e.g. owner, group, etc.) from file system images contained in firmware'
             ),
-            version='1.2.0',
+            version=Version(1, 2, 0),
             Schema=self.Schema,
             timeout=30,
         )

--- a/src/plugins/analysis/file_type/code/file_type.py
+++ b/src/plugins/analysis/file_type/code/file_type.py
@@ -5,6 +5,7 @@ from typing import List
 
 import pydantic
 from pydantic import Field
+from semver import Version
 
 from analysis.plugin import AnalysisPluginV0
 from helperFunctions import magic
@@ -24,10 +25,10 @@ class AnalysisPlugin(AnalysisPluginV0):
 
     def __init__(self):
         super().__init__(
-            metadata=AnalysisPluginV0.MetaData(
+            metadata=self.MetaData(
                 name='file_type',
                 description='identify the file type',
-                version='1.0.0',
+                version=Version(1, 0, 0),
                 Schema=AnalysisPlugin.Schema,
             ),
         )

--- a/src/plugins/analysis/kernel_config/code/kernel_config.py
+++ b/src/plugins/analysis/kernel_config/code/kernel_config.py
@@ -8,7 +8,6 @@ from pydantic import BaseModel
 from semver import Version
 
 from analysis.plugin import AnalysisPluginV0, Tag
-from analysis.plugin.compat import AnalysisBasePluginAdapterMixin
 from helperFunctions.tag import TagColor
 from plugins.analysis.kernel_config.internal.checksec_check_kernel import CHECKSEC_PATH, check_kernel_config
 from plugins.analysis.kernel_config.internal.decomp import GZDecompressor
@@ -34,7 +33,7 @@ class CheckSec(BaseModel):
     selinux: dict
 
 
-class AnalysisPlugin(AnalysisPluginV0, AnalysisBasePluginAdapterMixin):
+class AnalysisPlugin(AnalysisPluginV0):
     class Schema(BaseModel):
         is_kernel_config: bool
         kernel_config: Optional[str] = None

--- a/src/plugins/analysis/known_vulnerabilities/code/known_vulnerabilities.py
+++ b/src/plugins/analysis/known_vulnerabilities/code/known_vulnerabilities.py
@@ -38,7 +38,7 @@ class AnalysisPlugin(AnalysisPluginV0):
         vulnerabilities: List[Vulnerability]
 
     def __init__(self):
-        metadata = AnalysisPluginV0.MetaData(
+        metadata = self.MetaData(
             name='known_vulnerabilities',
             description='Rule based detection of known vulnerabilities like Heartbleed',
             dependencies=['file_hashes', 'software_components'],

--- a/src/plugins/analysis/linter/code/source_code_analysis.py
+++ b/src/plugins/analysis/linter/code/source_code_analysis.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, List, Optional
 import pydantic
 from docker.types import Mount
 from pydantic import Field
+from semver import Version
 
 from analysis.plugin import AnalysisPluginV0
 from helperFunctions.docker import run_docker_container
@@ -62,10 +63,10 @@ class AnalysisPlugin(AnalysisPluginV0):
 
     def __init__(self):
         super().__init__(
-            metadata=AnalysisPluginV0.MetaData(
+            metadata=self.MetaData(
                 name='source_code_analysis',
                 description='This plugin implements static code analysis for multiple scripting languages',
-                version='0.7.1',
+                version=Version(0, 7, 1),
                 Schema=AnalysisPlugin.Schema,
                 mime_whitelist=['text/'],
             ),

--- a/src/plugins/analysis/software_components/code/software_components.py
+++ b/src/plugins/analysis/software_components/code/software_components.py
@@ -9,7 +9,6 @@ from semver import Version
 
 import config
 from analysis.plugin import AnalysisPluginV0, Tag, addons
-from analysis.plugin.compat import AnalysisBasePluginAdapterMixin
 from helperFunctions.tag import TagColor
 from plugins.analysis.software_components.bin import OS_LIST
 from plugins.mime_blacklists import MIME_BLACKLIST_NON_EXECUTABLE
@@ -38,7 +37,7 @@ class MatchingString(BaseModel):
     identifier: str = Field(description='Identifier of the rule that this string matched (e.g. "$a")')
 
 
-class AnalysisPlugin(AnalysisPluginV0, AnalysisBasePluginAdapterMixin):
+class AnalysisPlugin(AnalysisPluginV0):
     class Schema(BaseModel):
         software_components: List[SoftwareMatch]
 

--- a/src/plugins/analysis/software_components/test/test_plugin_software_components.py
+++ b/src/plugins/analysis/software_components/test/test_plugin_software_components.py
@@ -8,7 +8,7 @@ YARA_TEST_FILE = Path(__file__).parent / 'data' / 'yara_test_file'
 
 
 @pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
-class TestAnalysisPluginsSoftwareComponents:
+class TestAnalysisPluginSoftwareComponents:
     def test_process_object(self, analysis_plugin):
         with YARA_TEST_FILE.open('rb') as fp:
             results = analysis_plugin.analyze(fp, {}, {})

--- a/src/plugins/analysis/strings/code/strings.py
+++ b/src/plugins/analysis/strings/code/strings.py
@@ -55,7 +55,7 @@ class AnalysisPlugin(AnalysisPluginV0):
             for regex, encoding in STRING_REGEXES
         ]
 
-    def analyze(self, file_handle: FileIO, virtual_file_path: dict, analyses: dict[str, BaseModel]):
+    def analyze(self, file_handle: FileIO, virtual_file_path: dict, analyses: dict[str, BaseModel]) -> Schema:
         del virtual_file_path, analyses
         return self.Schema(
             strings=[

--- a/src/plugins/analysis/users_and_passwords/code/password_file_analyzer.py
+++ b/src/plugins/analysis/users_and_passwords/code/password_file_analyzer.py
@@ -30,7 +30,7 @@ class AnalysisPlugin(AnalysisPluginV0):
 
     def __init__(self):
         super().__init__(
-            metadata=AnalysisPluginV0.MetaData(
+            metadata=self.MetaData(
                 name='users_and_passwords',
                 description=(
                     'search for UNIX, httpd, and mosquitto password files, parse them and try to crack the passwords'

--- a/src/plugins/analysis/users_and_passwords/test/test_plugin_password_file_analyzer.py
+++ b/src/plugins/analysis/users_and_passwords/test/test_plugin_password_file_analyzer.py
@@ -10,7 +10,7 @@ PW_TYPES = ['unix', 'mosquitto', 'http']
 
 
 @pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
-class TestAnalysisPluginPasswordFileAnalyzer:
+class TestAnalysisPluginUsersAndPasswords:
     def test_process_object_shadow_file(self, analysis_plugin):
         test_file = TEST_DATA_DIR / 'passwd_test'
         with test_file.open() as fp:

--- a/src/scheduler/analysis/plugin.py
+++ b/src/scheduler/analysis/plugin.py
@@ -188,7 +188,7 @@ class Worker(mp.Process):
 
         def _handle_sigterm(signum, frame):
             del signum, frame
-            logging.info(f'{self} received SIGTERM. Shutting down.')
+            logging.debug(f'{self} received SIGTERM. Shutting down.')
             nonlocal run
             nonlocal result
             run = False

--- a/src/scheduler/analysis/plugin.py
+++ b/src/scheduler/analysis/plugin.py
@@ -16,7 +16,8 @@ import pydantic
 from pydantic import BaseModel, ConfigDict
 
 import config
-from objects.file import FileObject  # noqa: TCH001  # needed by pydantic
+from analysis.plugin import AnalysisFailedError
+from objects.file import FileObject  # noqa: TCH001 # needed by pydantic
 from statistic.analysis_stats import ANALYSIS_STATS_LIMIT
 from storage.fsorganizer import FSOrganizer
 
@@ -232,6 +233,8 @@ class Worker(mp.Process):
                 result = recv_conn.recv()
 
                 if isinstance(result, str):
+                    if result.startswith('Analysis failed'):
+                        raise AnalysisFailedError(result)
                     raise AnalysisExceptionError(result)
 
                 duration = time.time() - start_time
@@ -247,6 +250,8 @@ class Worker(mp.Process):
             except Worker.CrashedError:
                 logging.warning(f'{analysis_description} crashed.')
                 entry['exception'] = (self._plugin.metadata.name, 'Analysis crashed')
+            except AnalysisFailedError as exc:
+                entry['exception'] = (self._plugin.metadata.name, str(exc))
             except AnalysisExceptionError as exc:
                 logging.error(f'{self} got an exception during {analysis_description}: {exc}')
                 entry['exception'] = (self._plugin.metadata.name, 'Exception occurred during analysis')
@@ -268,7 +273,7 @@ class Worker(mp.Process):
 
     def _write_result_in_file_object(self, entry: dict, file_object: FileObject):
         """Takes a file_object and an entry as it is returned by :py:func:`Worker.run`
-        and returns a FileObject with the corresponding fileds set.
+        and returns a FileObject with the corresponding fields set.
         """
         if 'analysis' in entry:
             file_object.processed_analysis[self._plugin.metadata.name] = entry['analysis']
@@ -285,6 +290,8 @@ class Worker(mp.Process):
         """
         try:
             result = plugin.get_analysis(io.FileIO(task.path), task.virtual_file_path, task.dependencies)
+        except AnalysisFailedError as exc:
+            result = f'Analysis failed: {exc}'
         except Exception as exc:
             result = f'{exc}: {traceback.format_exc()}'
 

--- a/src/scheduler/analysis/scheduler.py
+++ b/src/scheduler/analysis/scheduler.py
@@ -552,9 +552,9 @@ class AnalysisScheduler:
         logging.debug(f'Stopped analysis result collector worker {index}')
 
     def _handle_collected_result(self, fo: FileObject, plugin_name: str):
+        if fo.analysis_exception:
+            self.task_scheduler.reschedule_failed_analysis_task(fo)
         if plugin_name in fo.processed_analysis:
-            if fo.analysis_exception:
-                self.task_scheduler.reschedule_failed_analysis_task(fo)
             self.status.add_analysis(fo, plugin_name)
             self.post_analysis(fo.uid, plugin_name, fo.processed_analysis[plugin_name])
         self._check_further_process_or_complete(fo)

--- a/src/test/integration/scheduler/test_analysis_fail.py
+++ b/src/test/integration/scheduler/test_analysis_fail.py
@@ -1,0 +1,45 @@
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from objects.firmware import Firmware
+
+REGULAR_RESULT = {
+    'dependant_analysis': {'full': 'ASCII text, with no line terminators', 'mime': 'text/plain'},
+    'first_byte': '6e',
+    'name': 'b55f174c36fd4f56ecc04931099300014d4014377c73af1fa433e258a9b38604_14',
+    'number': 42,
+    'virtual_file_path': {},
+}
+
+
+@pytest.mark.parametrize(
+    ('content', 'expected_result'),
+    [
+        (b'normal content', REGULAR_RESULT),
+        (b'\xeeException', {'failed': 'Exception occurred during analysis'}),
+        (b'\xffFailed', {'failed': 'Analysis failed: reason for fail'}),
+    ],
+)
+def test_analysis_fail(content, expected_result, analysis_scheduler, post_analysis_queue):
+    with NamedTemporaryFile() as tmp_file:
+        tmp_file.write(content)
+        tmp_file.flush()
+        test_fw = Firmware(file_path=tmp_file.name)
+        test_fw.release_date = '1970-01-01'
+        test_fw.scheduled_analysis = ['ExamplePlugin']
+
+        analysis_scheduler.start_analysis_of_object(test_fw)
+
+        processed_container = {}
+        for _ in range(3):  # container with 3 included files times 2 mandatory plugins run
+            uid, plugin, analysis_result = post_analysis_queue.get(timeout=3)
+            processed_container.setdefault(uid, {}).setdefault(plugin, {})
+            processed_container[uid][plugin] = analysis_result
+
+        assert len(processed_container) == 1, '1 files should have been analyzed'
+        assert all(
+            set(processed_analysis) == {'ExamplePlugin', 'file_hashes', 'file_type'}
+            for processed_analysis in processed_container.values()
+        ), 'at least one analysis not done'
+        assert processed_container[test_fw.uid]['ExamplePlugin']['result'] == expected_result


### PR DESCRIPTION
- fixes:
  - removed mixin (which is now part of the base class) from individual plugin class definition
  - fixed test class names
  - added missing `__init__.py`
  - `init()` fixes (version should be semver, missing self when referencing metadata class)
  - plugins should not return `None` as result
  - removed plugin shutdown log spam
- feat: better handling of failed analyses