### PR TITLE
fix: fixed multiple crossdependencies between frontend and backend

### DIFF
--- a/src/install/requirements_common.txt
+++ b/src/install/requirements_common.txt
@@ -2,6 +2,7 @@
 testresources==2.0.1
 
 # General python dependencies
+aiohttp==3.14.1
 docker~=7.1.0
 pytest-rerunfailures~=14.0
 lief~=0.17.0

--- a/src/plugins/analysis/file_system_metadata/routes/routes.py
+++ b/src/plugins/analysis/file_system_metadata/routes/routes.py
@@ -14,13 +14,12 @@ from web_interface.rest.rest_resource_base import RestResourceBase
 from web_interface.security.decorator import roles_accepted
 from web_interface.security.privileges import PRIVILEGES
 
-from ..code.file_system_metadata import AnalysisPlugin
-
 if TYPE_CHECKING:
     from web_interface.frontend_database import FrontendDatabase
 
 
 VIEW_PATH = Path(__file__).absolute().parent / 'ajax_view.html'
+PLUGIN_NAME = 'file_system_metadata'
 
 
 class ParentAnalysisLookupMixin:
@@ -31,7 +30,7 @@ class ParentAnalysisLookupMixin:
         with get_shared_session(self.db.frontend) as db:
             vfp = db.get_vfps(uid)
             for parent_uid in vfp:
-                parent_analysis = db.get_analysis(parent_uid, AnalysisPlugin.NAME) or {}
+                parent_analysis = db.get_analysis(parent_uid, PLUGIN_NAME) or {}
                 results.append(_get_results_from_parent_fo(parent_analysis.get('result', {}), parent_uid, vfp))
         return results
 
@@ -83,4 +82,4 @@ class PluginRestRoutes(RestResourceBase, ParentAnalysisLookupMixin):
         endpoint = self.ENDPOINTS[0][0]
         if not results:
             error_message(f'no results found for uid {uid}', endpoint, request_data={'uid': uid})
-        return success_message({AnalysisPlugin.NAME: results}, endpoint, request_data={'uid': uid})
+        return success_message({PLUGIN_NAME: results}, endpoint, request_data={'uid': uid})

--- a/src/plugins/analysis/file_system_metadata/routes/routes.py
+++ b/src/plugins/analysis/file_system_metadata/routes/routes.py
@@ -55,16 +55,16 @@ def _result_list_to_dict(results: list[dict]) -> dict[str, dict]:
 
 
 class PluginRoutes(ComponentBase, ParentAnalysisLookupMixin):
-    def _init_component(self):
+    def _init_component(self) -> None:
         self._app.add_url_rule(
             '/plugins/file_system_metadata/ajax/<uid>',
             'plugins/file_system_metadata/ajax/<uid>',
             self._get_analysis_results_of_parent_fo,
         )
-        assert VIEW_PATH.is_file()
+        assert VIEW_PATH.is_file(), f'View of {PLUGIN_NAME} not found'  # noqa: S101
 
     @roles_accepted(*PRIVILEGES['view_analysis'])
-    def _get_analysis_results_of_parent_fo(self, uid):
+    def _get_analysis_results_of_parent_fo(self, uid: str) -> str:
         results = self.get_analysis_results_for_included_uid(uid)
         return render_template_string(VIEW_PATH.read_text(), results=results)
 
@@ -77,7 +77,7 @@ class PluginRestRoutes(RestResourceBase, ParentAnalysisLookupMixin):
     ENDPOINTS = (('/plugins/file_system_metadata/rest/<uid>', ['GET']),)
 
     @roles_accepted(*PRIVILEGES['view_analysis'])
-    def get(self, uid: str):
+    def get(self, uid: str) -> tuple[dict, int]:
         results = self.get_analysis_results_for_included_uid(uid)
         endpoint = self.ENDPOINTS[0][0]
         if not results:

--- a/src/plugins/analysis/ip_and_uri_finder/requirements.txt
+++ b/src/plugins/analysis/ip_and_uri_finder/requirements.txt
@@ -1,4 +1,3 @@
 git+https://github.com/fkie-cad/common_analysis_ip_and_uri.git
 geoip2==4.7.0
-# dependency of geoip2 for python >= 3.12
-aiohttp==3.14.1
+

--- a/src/plugins/analysis/qemu_exec/routes/routes.py
+++ b/src/plugins/analysis/qemu_exec/routes/routes.py
@@ -11,8 +11,7 @@ from web_interface.rest.rest_resource_base import RestResourceBase
 from web_interface.security.decorator import roles_accepted
 from web_interface.security.privileges import PRIVILEGES
 
-from ..code.qemu_exec import PLUGIN_NAME
-
+PLUGIN_NAME = 'qemu_exec'
 VIEW_PATH = Path(__file__).absolute().parent / 'ajax_view.html'
 
 

--- a/src/plugins/analysis/qemu_exec/routes/routes.py
+++ b/src/plugins/analysis/qemu_exec/routes/routes.py
@@ -15,7 +15,7 @@ PLUGIN_NAME = 'qemu_exec'
 VIEW_PATH = Path(__file__).absolute().parent / 'ajax_view.html'
 
 
-def get_analysis_results_for_included_uid(uid: str, db_interface: FrontEndDbInterface):
+def get_analysis_results_for_included_uid(uid: str, db_interface: FrontEndDbInterface) -> dict[str, dict]:
     results = {}
     with get_shared_session(db_interface) as db:
         this_fo = db.get_object(uid)
@@ -27,7 +27,7 @@ def get_analysis_results_for_included_uid(uid: str, db_interface: FrontEndDbInte
     return results
 
 
-def _get_results_from_parent_fo(analysis_entry: dict, uid: str):
+def _get_results_from_parent_fo(analysis_entry: dict, uid: str) -> dict | None:
     if (
         analysis_entry is not None
         and analysis_entry['result'] is not None
@@ -40,13 +40,13 @@ def _get_results_from_parent_fo(analysis_entry: dict, uid: str):
 
 
 class PluginRoutes(ComponentBase):
-    def _init_component(self):
+    def _init_component(self) -> None:
         self._app.add_url_rule(
             '/plugins/qemu_exec/ajax/<uid>', 'plugins/qemu_exec/ajax/<uid>', self._get_analysis_results_of_parent_fo
         )
 
     @roles_accepted(*PRIVILEGES['view_analysis'])
-    def _get_analysis_results_of_parent_fo(self, uid):
+    def _get_analysis_results_of_parent_fo(self, uid: str) -> str:
         results = get_analysis_results_for_included_uid(uid, self.db.frontend)
         return render_template_string(VIEW_PATH.read_text(), results=results)
 
@@ -59,7 +59,7 @@ class PluginRestRoutes(RestResourceBase):
     ENDPOINTS = (('/plugins/qemu_exec/rest/<uid>', ['GET']),)
 
     @roles_accepted(*PRIVILEGES['view_analysis'])
-    def get(self, uid):
+    def get(self, uid: str) -> tuple[dict, int]:
         results = get_analysis_results_for_included_uid(uid, self.db.frontend)
         endpoint = self.ENDPOINTS[0][0]
         if not results:


### PR DESCRIPTION
* fixes import of analysis plugin module from the frontend (causes dependency problems) in FS metadata and QEMU exec plugins
* makes `aoihttp` a common dependency (was only installed in the backend but is also used in the frontend in the GraphQL module)