### PR TITLE
chore: added summary job to build-ci action

### DIFF
--- a/.github/workflows/build_ci.yml
+++ b/.github/workflows/build_ci.yml
@@ -85,6 +85,19 @@ jobs:
           verbose: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  build-ci-complete:
+    name: Build CI Complete
+    needs: build-ci
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check build-ci matrix result
+        run: |
+          if [ "${{ needs.build-ci.result }}" != "success" ]; then
+            echo "Some build-ci matrix jobs failed!"
+            exit 1
+          fi
+          echo "All build-ci matrix jobs passed!"
       - name: Teams webhook
         if: failure() && github.event_name == 'schedule'
         run: |
@@ -114,8 +127,7 @@ jobs:
                       {
                         "type": "FactSet",
                         "facts": [
-                          { "title": "Branch", "value": "${{ matrix.target }}" },
-                          { "title": "OS", "value": "${{ matrix.os }}" },
+                          { "title": "Result", "value": "${{ needs.build-ci.result }}" },
                           { "title": "Commit", "value": "${{ github.sha }}" }
                         ]
                       }


### PR DESCRIPTION
* added summary job to build-ci action
  * so that we have a job that can be referenced e.g. for required actions (matrix jobs can't be referenced by name, because the name is dynamically generated)