### PR TITLE
fix: Cpu arch missing section fix

### DIFF
--- a/src/plugins/analysis/cpu_architecture/internal/elf.py
+++ b/src/plugins/analysis/cpu_architecture/internal/elf.py
@@ -20,22 +20,23 @@ FLAGS_TO_STR = {
 }
 
 
-def _mips_flags_to_str(flags):
+def _mips_flags_to_str(flags: int) -> str:
     return ', '.join(
         (arch_str for arch_flags, arch_str in FLAGS_TO_STR.items() if (flags & E_FLAGS.EF_MIPS_ARCH) == arch_flags)
     )
 
 
-def _get_mips_isa(elffile):
-    assert elffile['e_machine'] == 'EM_MIPS'
-    # TODO implement parsing abiflags section
+def _get_mips_isa(elffile: ELFFile) -> str:
+    if elffile['e_machine'] != 'EM_MIPS':
+        raise ValueError(f'Unsupported ISA {elffile["e_machine"]}, should be EM_MIPS')
+    # FixMe: implement parsing abiflags section
     header = elffile.header
     flags = header['e_flags']
 
     return _mips_flags_to_str(flags)
 
 
-def _get_arm_isa(elffile):
+def _get_arm_isa(elffile: ELFFile) -> str | None:
     result = ''
 
     # Somehow the section does not appear in arm64 binaries
@@ -55,7 +56,7 @@ def _get_arm_isa(elffile):
         return None
 
 
-def construct_result(file_path: str | Path):
+def construct_result(file_path: str | Path) -> dict[str, str]:
     result = {}
     with Path(file_path).open('rb') as fp:
         try:

--- a/src/plugins/analysis/cpu_architecture/internal/elf.py
+++ b/src/plugins/analysis/cpu_architecture/internal/elf.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from elftools.common.exceptions import ELFError
+from elftools.common.exceptions import ELFError, ELFParseError
 from elftools.elf.constants import E_FLAGS
 from elftools.elf.descriptions import describe_attr_tag_arm
 from elftools.elf.elffile import ELFFile
@@ -39,19 +39,20 @@ def _get_arm_isa(elffile):
     result = ''
 
     # Somehow the section does not appear in arm64 binaries
-    sec = elffile.get_section_by_name('.ARM.attributes')
-    if sec is None:
+    try:
+        sec = elffile.get_section_by_name('.ARM.attributes')
+        if sec is None:
+            return None
+        for sub_sec in sec.iter_subsections():
+            for sub_sub_sec in sub_sec.iter_subsubsections():
+                for attribute in sub_sub_sec.iter_attributes():
+                    if attribute.tag not in ['TAG_CPU_ARCH', 'TAG_CPU_NAME', 'TAG_CPU_ARCH_PROFILE']:
+                        continue
+                    descr = describe_attr_tag_arm(attribute.tag, attribute.value, attribute.extra)
+                    result += f'{descr}\n'
+        return result
+    except (ELFParseError, ELFError):  # file is probably missing section information
         return None
-    for sub_sec in sec.iter_subsections():
-        for sub_sub_sec in sub_sec.iter_subsubsections():
-            for attribute in sub_sub_sec.iter_attributes():
-                if attribute.tag not in ['TAG_CPU_ARCH', 'TAG_CPU_NAME', 'TAG_CPU_ARCH_PROFILE']:
-                    continue
-
-                descr = describe_attr_tag_arm(attribute.tag, attribute.value, attribute.extra)
-                result += f'{descr}\n'
-
-    return result
 
 
 def construct_result(file_path: str | Path):


### PR DESCRIPTION
Adds error handling for exceptions occurring in the `cpu_architecture` plugin when analyzing ELF files without section information