### PR TITLE
fix: allow empty plugin blacklist in config

### DIFF
--- a/src/scheduler/analysis/scheduler.py
+++ b/src/scheduler/analysis/scheduler.py
@@ -483,19 +483,19 @@ class AnalysisScheduler:
             self._add_completed_analysis_results_to_file_object('file_type', fw_object)
         return fw_object.processed_analysis['file_type']['result']['mime'].lower()
 
-    def _get_blacklist_and_whitelist(self, next_analysis: str) -> tuple[list, list]:
+    def _get_blacklist_and_whitelist(self, next_analysis: str) -> tuple[list[str], list[str]]:
         blacklist, whitelist = self._get_blacklist_and_whitelist_from_config(next_analysis)
-        if not (blacklist or whitelist):
+        if blacklist is None and whitelist is None:
             blacklist, whitelist = self._get_blacklist_and_whitelist_from_plugin(next_analysis)
-        return blacklist, whitelist
+        return blacklist or [], whitelist or []
 
     @staticmethod
-    def _get_blacklist_and_whitelist_from_config(analysis_plugin: str) -> tuple[list, list]:
-        blacklist = getattr(config.backend.plugin.get(analysis_plugin, None), 'mime_blacklist', [])
-        whitelist = getattr(config.backend.plugin.get(analysis_plugin, None), 'mime_whitelist', [])
+    def _get_blacklist_and_whitelist_from_config(analysis_plugin: str) -> tuple[list[str] | None, list[str] | None]:
+        blacklist = getattr(config.backend.plugin.get(analysis_plugin, None), 'mime_blacklist', None)
+        whitelist = getattr(config.backend.plugin.get(analysis_plugin, None), 'mime_whitelist', None)
         return blacklist, whitelist
 
-    def _get_blacklist_and_whitelist_from_plugin(self, analysis_plugin: str) -> tuple[list, list]:
+    def _get_blacklist_and_whitelist_from_plugin(self, analysis_plugin: str) -> tuple[list[str], list[str]]:
         try:
             blacklist = self.analysis_plugins[analysis_plugin].metadata.mime_blacklist
         except AttributeError:

--- a/src/test/unit/scheduler/test_analysis.py
+++ b/src/test/unit/scheduler/test_analysis.py
@@ -80,9 +80,9 @@ class TestScheduleInitialAnalysis:
 
     def test_get_plugin_dict_description(self, analysis_scheduler):
         result = analysis_scheduler.get_plugin_dict()
-        assert (
-            result['file_type'][0] == analysis_scheduler.analysis_plugins['file_type'].metadata.description
-        ), 'description not correct'
+        assert result['file_type'][0] == analysis_scheduler.analysis_plugins['file_type'].metadata.description, (
+            'description not correct'
+        )
 
     @pytest.mark.backend_config_overwrite(
         {
@@ -105,12 +105,12 @@ class TestScheduleInitialAnalysis:
 
     def test_get_plugin_dict_version(self, analysis_scheduler):
         result = analysis_scheduler.get_plugin_dict()
-        assert (
-            result['file_type'][3] == analysis_scheduler.analysis_plugins['file_type'].metadata.version
-        ), 'version not correct'
-        assert (
-            result['file_hashes'][3] == analysis_scheduler.analysis_plugins['file_hashes'].metadata.version
-        ), 'version not correct'
+        assert result['file_type'][3] == analysis_scheduler.analysis_plugins['file_type'].metadata.version, (
+            'version not correct'
+        )
+        assert result['file_hashes'][3] == analysis_scheduler.analysis_plugins['file_hashes'].metadata.version, (
+            'version not correct'
+        )
 
     def test_process_next_analysis_unknown_plugin(self, analysis_scheduler):
         test_fw = Firmware(file_path=get_test_data_dir() / 'get_files_test/testfile1')
@@ -135,7 +135,7 @@ class TestScheduleInitialAnalysis:
         test_fw.scheduled_analysis = ['file_hashes']
         test_fw.processed_analysis['file_type'] = {'result': {'mime': 'text/plain'}}
         analysis_scheduler._start_or_skip_analysis('ExamplePlugin', test_fw)
-        uid, plugin, analysis_result = post_analysis_queue.get(timeout=10)
+        _, plugin, analysis_result = post_analysis_queue.get(timeout=10)
         assert plugin == 'ExamplePlugin'
         assert 'skipped' in analysis_result['result']
 
@@ -190,7 +190,7 @@ class TestAnalysisSchedulerBlacklist:
     def test_get_blacklist_and_whitelist_from_config(self):
         blacklist, whitelist = self.sched._get_blacklist_and_whitelist_from_config('test_plugin')
         assert blacklist == ['type1', 'type2']
-        assert whitelist == []
+        assert whitelist is None
 
     @pytest.mark.backend_config_overwrite(
         {
@@ -397,7 +397,7 @@ class TestAnalysisShouldReanalyse:
             (20, 10, 'foo', '1.0', '1.0', None, False),  # invalid version => not up to date
         ],
     )
-    def test_analysis_is_up_to_date(  # noqa: PLR0913
+    def test_analysis_is_up_to_date(
         self,
         plugin_date,
         dependency_date,


### PR DESCRIPTION
Currently, if an empty list is set as plugin blacklist in the config, the blacklist/whitelist from the plugin's metadata will be loaded (instead of actually using the empty list as blacklist). This fix changes this to allow disabling blacklists through the config file.