### PR TITLE
feat: add PUT endpoint to /rest/analysis

### DIFF
--- a/src/test/integration/web_interface/rest/test_rest_analysis.py
+++ b/src/test/integration/web_interface/rest/test_rest_analysis.py
@@ -38,3 +38,58 @@ class TestRestAnalysis(RestTestBase):
         assert 'analysis' not in response.json
         assert 'error_message' in response.json
         assert 'not found' in response.json['error_message']
+
+    def test_rest_put_analysis(self, backend_db, monkeypatch):
+        insert_test_fo(backend_db, 'uid')
+
+        monkeypatch.setattr(
+            'intercom.front_end_binding.InterComFrontEndBinding.get_available_analysis_plugins',
+            lambda _: ['file_type', 'some_other_plugin'],
+        )
+        monkeypatch.setattr(
+            'intercom.front_end_binding.InterComFrontEndBinding.add_single_file_task',
+            lambda _, __: True,
+        )
+
+        response = self.test_client.put('/rest/analysis/uid/file_type')
+        assert response.status_code == HTTPStatus.OK
+        assert response.json['success'] is True
+
+    def test_rest_put_analysis_no_file(self, monkeypatch):
+        monkeypatch.setattr(
+            'intercom.front_end_binding.InterComFrontEndBinding.get_available_analysis_plugins',
+            lambda _: ['file_type'],
+        )
+
+        response = self.test_client.put('/rest/analysis/unknown_uid/file_type')
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert 'error_message' in response.json
+        assert 'No file object with UID' in response.json['error_message']
+
+    def test_rest_put_analysis_invalid_plugin(self, backend_db, monkeypatch):
+        insert_test_fo(backend_db, 'uid')
+        monkeypatch.setattr(
+            'intercom.front_end_binding.InterComFrontEndBinding.get_available_analysis_plugins',
+            lambda _: ['file_type'],
+        )
+
+        unknown_plugin = 'unknown_plugin'
+        response = self.test_client.put(f'/rest/analysis/uid/{unknown_plugin}')
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+        assert 'error_message' in response.json
+        assert f'Analysis plugin "{unknown_plugin}" not found' in response.json['error_message']
+
+    def test_rest_put_analysis_force(self, backend_db, monkeypatch):
+        insert_test_fo(backend_db, 'uid')
+        monkeypatch.setattr(
+            'intercom.front_end_binding.InterComFrontEndBinding.get_available_analysis_plugins',
+            lambda _: ['file_type'],
+        )
+        monkeypatch.setattr(
+            'intercom.front_end_binding.InterComFrontEndBinding.add_single_file_task',
+            lambda _, fo: fo.force_update is True,
+        )
+
+        response = self.test_client.put('/rest/analysis/uid/file_type?force=true')
+        assert response.status_code == HTTPStatus.OK
+        assert response.json['success'] is True

--- a/src/test/unit/web_interface/rest/test_rest_analysis.py
+++ b/src/test/unit/web_interface/rest/test_rest_analysis.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import pytest
 
 from test.common_helper import TEST_FW, CommonDatabaseMock
@@ -18,8 +20,9 @@ class AnalysisDBMock(CommonDatabaseMock):
     @staticmethod
     def get_object(uid):
         if uid == TEST_FW.uid:
-            TEST_FW.processed_analysis = {PLUGIN: ANALYSIS_RESULT}
-            return TEST_FW
+            fw = deepcopy(TEST_FW)
+            fw.processed_analysis = {PLUGIN: ANALYSIS_RESULT}
+            return fw
         return None
 
     def exists(self, uid):

--- a/src/test/unit/web_interface/rest/test_rest_analysis.py
+++ b/src/test/unit/web_interface/rest/test_rest_analysis.py
@@ -1,24 +1,42 @@
 import pytest
 
-from test.common_helper import CommonDatabaseMock
+from test.common_helper import TEST_FW, CommonDatabaseMock
+from test.unit.conftest import CommonIntercomMock
 
 PLUGIN = 'existing_plugin'
 UID = 'existing_uid'
 ANALYSIS_RESULT = {'result_key': 'result_value'}
 
 
-class StatisticDbViewerMock(CommonDatabaseMock):
+class AnalysisDBMock(CommonDatabaseMock):
     @staticmethod
     def get_analysis(uid, plugin):
         if uid == UID and plugin == PLUGIN:
             return ANALYSIS_RESULT
         return None
 
+    @staticmethod
+    def get_object(uid):
+        if uid == TEST_FW.uid:
+            TEST_FW.processed_analysis = {PLUGIN: ANALYSIS_RESULT}
+            return TEST_FW
+        return None
+
     def exists(self, uid):
         return uid == UID
 
 
-@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=StatisticDbViewerMock)
+class AnalysisIntercomMock(CommonIntercomMock):
+    def get_available_analysis_plugins(self):
+        return [
+            PLUGIN,
+        ]
+
+    def add_single_file_task(self, file_object):
+        return file_object.uid == TEST_FW.uid
+
+
+@pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=AnalysisDBMock, intercom_mock_class=AnalysisIntercomMock)
 class TestRestAnalysis:
     def test_get_analysis(self, test_client):
         result = test_client.get(f'/rest/analysis/{UID}/{PLUGIN}').json
@@ -39,3 +57,29 @@ class TestRestAnalysis:
         assert 'analysis' not in result
         assert 'error_message' in result
         assert '"unknown_plugin" not found' in result['error_message']
+
+    def test_put_analysis(self, test_client):
+        result = test_client.put(f'/rest/analysis/{TEST_FW.uid}/{PLUGIN}').json
+
+        assert 'success' in result, 'missing field in result'
+        assert result['success'], 'put should be successful'
+
+    def test_put_analysis_unknown_file(self, test_client):
+        bad_uid = 'nosuch_uid'
+        result = test_client.put(f'/rest/analysis/{bad_uid}/{PLUGIN}').json
+
+        assert 'error_message' in result, 'missing error message'
+        assert 'No file' in result['error_message'], 'misformed error message'
+
+    def test_put_analysis_unknown_plugin(self, test_client):
+        bad_plugin = 'nosuch_plugin'
+        result = test_client.put(f'/rest/analysis/{TEST_FW.uid}/{bad_plugin}').json
+
+        assert 'error_message' in result, 'missing error message'
+        assert f'"{bad_plugin}" not found' in result['error_message'], 'misformed error message'
+
+    def test_put_analysis_force_update(self, test_client):
+        result = test_client.put(f'/rest/analysis/{TEST_FW.uid}/{PLUGIN}?force=true').json
+
+        assert 'success' in result, 'missing field in result'
+        assert result['success'], 'put should be successful'

--- a/src/web_interface/rest/rest_analysis.py
+++ b/src/web_interface/rest/rest_analysis.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from http import HTTPStatus
 
+from flask import request
 from flask_restx import Namespace
 
-from web_interface.rest.helper import error_message, success_message
+from web_interface.rest.helper import error_message, get_boolean_from_request, success_message
 from web_interface.rest.rest_resource_base import RestResourceBase
 from web_interface.security.decorator import roles_accepted
 from web_interface.security.privileges import PRIVILEGES
@@ -19,6 +20,12 @@ api = Namespace('rest/analysis', description='Request the analysis results of a 
         'params': {
             'uid': 'File UID',
             'plugin': 'The name of the analysis plugin (lower case with underscores, e.g. file_type)',
+            'force': {
+                'description': 'Force re-analysis of already analyzed files',
+                'in': 'query',
+                'type': 'boolean',
+                'default': 'false',
+            },
         },
     },
 )
@@ -50,3 +57,36 @@ class RestAnalysis(RestResourceBase):
             return error_message(message, self.URL, request_data, return_code=return_code)
 
         return success_message({'analysis': analysis}, self.URL, request_data)
+
+    @roles_accepted(*PRIVILEGES['submit_analysis'])
+    @api.doc(
+        responses={
+            HTTPStatus.OK: 'Success',
+            HTTPStatus.BAD_REQUEST: 'Unknown file object or plugin',
+        }
+    )
+    def put(self, uid: str, plugin: str) -> tuple[dict, int]:
+        """
+        Run a specific analysis on a specific file.
+        """
+        file_object = self.db.frontend.get_object(uid)
+        request_data = {'uid': uid, 'plugin': plugin}
+
+        if not file_object:
+            message = f'No file object with UID "{uid}" found'
+            return error_message(message, self.URL, request_data, return_code=HTTPStatus.BAD_REQUEST)
+
+        available_plugins = self.intercom.get_available_analysis_plugins()
+        if plugin not in available_plugins:
+            message = f'Analysis plugin "{plugin}" not found'
+            return error_message(message, self.URL, request_data, return_code=HTTPStatus.BAD_REQUEST)
+
+        file_object.scheduled_analysis = [plugin]
+        if 'force' in request.args:
+            force_flag = get_boolean_from_request(request.args, 'force')
+            file_object.force_update = force_flag
+        success = self.intercom.add_single_file_task(file_object)
+
+        if success:
+            return success_message({'success': True}, self.URL, request_data)
+        return error_message('Failed to schedule analysis', self.URL, request_data, return_code=HTTPStatus.BAD_REQUEST)


### PR DESCRIPTION
* adds a new PUT method to the existing `/rest/analysis/{uid}/{plugin}` endpoint for starting a "single file analysis" or update over REST