### PR TITLE
chore: switch to hadolint-docker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
   - repo: https://github.com/hadolint/hadolint
     rev: v2.14.0
     hooks:
-      - id: hadolint
+      - id: hadolint-docker
 
   - repo: https://github.com/pre-commit/mirrors-jshint
     rev: v2.13.6


### PR DESCRIPTION
* hadolint-docker does not need to be manually installed (unlike the version without docker)
* this fixes the pre-commit CI action