### PR TITLE
feat: optional inverted summary

### DIFF
--- a/src/helperFunctions/data_conversion.py
+++ b/src/helperFunctions/data_conversion.py
@@ -24,7 +24,7 @@ def make_bytes(data: AnyStr | list[int]) -> bytes:
     return bytes(data)
 
 
-def make_unicode_string(code: Any) -> str:
+def make_unicode_string(code: Any) -> str:  # noqa: ANN401
     """
     Convert a (byte) string or some arbitrary object into a string.
     """
@@ -87,7 +87,15 @@ def none_to_none(input_data: str | None) -> str | None:
     return None if input_data == 'None' else input_data
 
 
-def convert_time_to_str(time_obj: Any) -> str:
+def boolean_string_to_boolean(boolean: str | bool) -> bool:
+    if any(boolean == a for a in [True, 'true', 'True']):
+        return True
+    if any(boolean == a for a in [False, 'false', 'False']):
+        return False
+    raise ValueError(f'{boolean} does not seem to be a boolean value')
+
+
+def convert_time_to_str(time_obj: Any) -> str:  # noqa: ANN401
     """
     Convert a time object to a string. The time object may be a datetime.date object or a string. If it is anything else,
     the output defaults to `"1970-01-01"`.

--- a/src/storage/db_interface_common.py
+++ b/src/storage/db_interface_common.py
@@ -327,7 +327,7 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             analysis_result['summary'] = self.get_summary(fo, plugin)
         return fo
 
-    def get_summary(self, fo: FileObject, selected_analysis: str, reverse: bool = False) -> Summary | None:
+    def get_summary(self, fo: FileObject, selected_analysis: str, reverse: bool | str = False) -> Summary | None:
         if selected_analysis not in fo.processed_analysis:
             logging.warning(f'Analysis {selected_analysis} not available on {fo.uid}')
             return None
@@ -337,6 +337,7 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             included_files = fo.list_of_all_included_files or self.get_list_of_all_included_files(fo)
         else:
             included_files = self.get_all_files_in_fw(fo.uid).union({fo.uid})
+        reverse = reverse == 'true' if not isinstance(reverse, bool) else reverse
         return (
             self._collect_reverse_summary_for_uid_list(included_files, selected_analysis)
             if reverse

--- a/src/storage/db_interface_common.py
+++ b/src/storage/db_interface_common.py
@@ -327,7 +327,7 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             analysis_result['summary'] = self.get_summary(fo, plugin)
         return fo
 
-    def get_summary(self, fo: FileObject, selected_analysis: str, invert: bool | str = False) -> Summary | None:
+    def get_summary(self, fo: FileObject, selected_analysis: str, invert: bool = False) -> Summary | None:
         if selected_analysis not in fo.processed_analysis:
             logging.warning(f'Analysis {selected_analysis} not available on {fo.uid}')
             return None
@@ -337,13 +337,9 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             included_files = fo.list_of_all_included_files or self.get_list_of_all_included_files(fo)
         else:
             included_files = self.get_all_files_in_fw(fo.uid).union({fo.uid})
-        return (
-            self._collect_inverted_summary_for_uid_list(included_files, selected_analysis)
-            if invert
-            else self._collect_summary_for_uid_list(included_files, selected_analysis)
-        )
+        return self._collect_summary_for_uid_list(included_files, selected_analysis, invert)
 
-    def _collect_summary_for_uid_list(self, uid_list: set[str] | list[str], plugin: str) -> Summary:
+    def _collect_summary_for_uid_list(self, uid_list: set[str] | list[str], plugin: str, invert: bool) -> Summary:
         with self.get_read_only_session() as session:
             query = select(AnalysisEntry.uid, AnalysisEntry.summary).filter(
                 AnalysisEntry.plugin == plugin, AnalysisEntry.uid.in_(uid_list)
@@ -351,18 +347,10 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             summary = {}
             for uid, summary_list in session.execute(query):  # type: str, list[str]
                 for item in set(summary_list or []):
-                    summary.setdefault(item, []).append(uid)
-        return summary
-
-    def _collect_inverted_summary_for_uid_list(self, uid_list: set[str] | list[str], plugin: str) -> Summary:
-        with self.get_read_only_session() as session:
-            query = select(AnalysisEntry.uid, AnalysisEntry.summary).filter(
-                AnalysisEntry.plugin == plugin, AnalysisEntry.uid.in_(uid_list)
-            )
-            summary = {}
-            for uid, summary_list in session.execute(query):  # type: str, list[str]
-                for item in set(summary_list or []):
-                    summary.setdefault(uid, []).append(item)
+                    if invert:
+                        summary.setdefault(uid, []).append(item)
+                    else:
+                        summary.setdefault(item, []).append(uid)
         return summary
 
     # ===== tags =====

--- a/src/storage/db_interface_common.py
+++ b/src/storage/db_interface_common.py
@@ -327,7 +327,7 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             analysis_result['summary'] = self.get_summary(fo, plugin)
         return fo
 
-    def get_summary(self, fo: FileObject, selected_analysis: str, reverse: bool | str = False) -> Summary | None:
+    def get_summary(self, fo: FileObject, selected_analysis: str, invert: bool | str = False) -> Summary | None:
         if selected_analysis not in fo.processed_analysis:
             logging.warning(f'Analysis {selected_analysis} not available on {fo.uid}')
             return None
@@ -337,10 +337,10 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             included_files = fo.list_of_all_included_files or self.get_list_of_all_included_files(fo)
         else:
             included_files = self.get_all_files_in_fw(fo.uid).union({fo.uid})
-        reverse = reverse == 'true' if not isinstance(reverse, bool) else reverse
+        invert = invert == 'true' if not isinstance(invert, bool) else invert
         return (
-            self._collect_reverse_summary_for_uid_list(included_files, selected_analysis)
-            if reverse
+            self._collect_inverted_summary_for_uid_list(included_files, selected_analysis)
+            if invert
             else self._collect_summary_for_uid_list(included_files, selected_analysis)
         )
 
@@ -355,7 +355,7 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
                     summary.setdefault(item, []).append(uid)
         return summary
 
-    def _collect_reverse_summary_for_uid_list(self, uid_list: set[str] | list[str], plugin: str) -> Summary:
+    def _collect_inverted_summary_for_uid_list(self, uid_list: set[str] | list[str], plugin: str) -> Summary:
         with self.get_read_only_session() as session:
             query = select(AnalysisEntry.uid, AnalysisEntry.summary).filter(
                 AnalysisEntry.plugin == plugin, AnalysisEntry.uid.in_(uid_list)

--- a/src/storage/db_interface_common.py
+++ b/src/storage/db_interface_common.py
@@ -337,7 +337,6 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             included_files = fo.list_of_all_included_files or self.get_list_of_all_included_files(fo)
         else:
             included_files = self.get_all_files_in_fw(fo.uid).union({fo.uid})
-        invert = invert == 'true' if not isinstance(invert, bool) else invert
         return (
             self._collect_inverted_summary_for_uid_list(included_files, selected_analysis)
             if invert

--- a/src/storage/db_interface_common.py
+++ b/src/storage/db_interface_common.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from operator import or_
-from typing import TYPE_CHECKING, Dict, Iterable, List
+from typing import TYPE_CHECKING
 
 from sqlalchemy import distinct, func, select
 from sqlalchemy.dialects.postgresql import JSONB
@@ -23,6 +23,9 @@ from storage.schema import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from sqlalchemy.orm import Session
     from sqlalchemy.sql import Select
 
     from objects.file import FileObject
@@ -35,7 +38,7 @@ PLUGINS_WITH_TAG_PROPAGATION = [  # FIXME This should be inferred in a sensible 
     'software_components',
     'users_and_passwords',
 ]
-Summary = Dict[str, List[str]]
+Summary = dict[str, list[str]]
 
 
 class DbInterfaceCommon(ReadOnlyDbInterface):
@@ -249,7 +252,7 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             return path_dict
 
     @staticmethod
-    def _remove_paths_lacking_root_uid(path_dict: dict[str, list[list[str]]], root_uid: str):
+    def _remove_paths_lacking_root_uid(path_dict: dict[str, list[list[str]]], root_uid: str) -> None:
         # remove the paths that don't start with root_uid
         for path_list in path_dict.values():
             for uid_list in path_list[:]:
@@ -299,7 +302,7 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
         with self.get_read_only_session() as session:
             return self._get_files_in_files(session, fo.files_included).union({fo.uid, *fo.files_included})
 
-    def _get_files_in_files(self, session, uid_set: set[str], recursive: bool = True) -> set[str]:
+    def _get_files_in_files(self, session: Session, uid_set: set[str], recursive: bool = True) -> set[str]:
         if not uid_set:
             return set()
         query = select(FileObjectEntry).filter(FileObjectEntry.uid.in_(uid_set))
@@ -324,7 +327,7 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             analysis_result['summary'] = self.get_summary(fo, plugin)
         return fo
 
-    def get_summary(self, fo: FileObject, selected_analysis: str) -> Summary | None:
+    def get_summary(self, fo: FileObject, selected_analysis: str, reverse: bool = False) -> Summary | None:
         if selected_analysis not in fo.processed_analysis:
             logging.warning(f'Analysis {selected_analysis} not available on {fo.uid}')
             return None
@@ -334,7 +337,11 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             included_files = fo.list_of_all_included_files or self.get_list_of_all_included_files(fo)
         else:
             included_files = self.get_all_files_in_fw(fo.uid).union({fo.uid})
-        return self._collect_summary_for_uid_list(included_files, selected_analysis)
+        return (
+            self._collect_reverse_summary_for_uid_list(included_files, selected_analysis)
+            if reverse
+            else self._collect_summary_for_uid_list(included_files, selected_analysis)
+        )
 
     def _collect_summary_for_uid_list(self, uid_list: set[str] | list[str], plugin: str) -> Summary:
         with self.get_read_only_session() as session:
@@ -345,6 +352,17 @@ class DbInterfaceCommon(ReadOnlyDbInterface):
             for uid, summary_list in session.execute(query):  # type: str, list[str]
                 for item in set(summary_list or []):
                     summary.setdefault(item, []).append(uid)
+        return summary
+
+    def _collect_reverse_summary_for_uid_list(self, uid_list: set[str] | list[str], plugin: str) -> Summary:
+        with self.get_read_only_session() as session:
+            query = select(AnalysisEntry.uid, AnalysisEntry.summary).filter(
+                AnalysisEntry.plugin == plugin, AnalysisEntry.uid.in_(uid_list)
+            )
+            summary = {}
+            for uid, summary_list in session.execute(query):  # type: str, list[str]
+                for item in set(summary_list or []):
+                    summary.setdefault(uid, []).append(item)
         return summary
 
     # ===== tags =====

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from http import HTTPStatus
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from helperFunctions.fileSystem import get_src_dir
 from helperFunctions.tag import TagColor
@@ -14,7 +14,11 @@ from objects.file import FileObject
 from objects.firmware import Firmware
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from werkzeug.test import TestResponse
+
+# ruff: noqa: ANN001, ANN201, ANN205, S101
 
 
 def get_test_data_dir() -> Path:
@@ -230,7 +234,7 @@ class CommonDatabaseMock:
             return 'test_name'
         return None
 
-    def get_summary(self, fo, selected_analysis):
+    def get_summary(self, fo, selected_analysis, invert, focus=False):
         if fo.uid == TEST_FW.uid and selected_analysis == 'foobar':
             return {'foobar': ['some_uid']}
         return None
@@ -257,7 +261,7 @@ class CommonDatabaseMock:
 
     @staticmethod
     def get_hid_dict(uid_set, root_uid):  # noqa: ARG004
-        return {uid: 'hid' for uid in uid_set}
+        return dict.fromkeys(uid_set, 'hid')
 
     @staticmethod
     def get_file_tree_path(uid: str, root_uid=None):
@@ -266,7 +270,7 @@ class CommonDatabaseMock:
         return [[uid]]
 
 
-def fake_exit(self, *args):  # noqa: ARG001
+def fake_exit(self, *args):
     pass
 
 

--- a/src/test/integration/storage/test_db_interface_common.py
+++ b/src/test/integration/storage/test_db_interface_common.py
@@ -207,11 +207,11 @@ def test_get_summary_fw(backend_db, common_db):
     assert fw.uid not in summary['file exclusive sum b'], 'parent as origin but should not be'
 
 
-def test_get_reverse_summary_fw(backend_db, common_db):
+def test_get_inverted_summary_fw(backend_db, common_db):
     fo, fw = create_fw_with_child_fo()
     backend_db.insert_multiple_objects(fw, fo)
 
-    summary = common_db.get_summary(fw, 'dummy', reverse=True)
+    summary = common_db.get_summary(fw, 'dummy', invert=True)
     assert isinstance(summary, dict), 'summary is not a dict'
 
     assert fw.uid in summary, 'parent should be in summary'

--- a/src/test/integration/storage/test_db_interface_common.py
+++ b/src/test/integration/storage/test_db_interface_common.py
@@ -207,6 +207,24 @@ def test_get_summary_fw(backend_db, common_db):
     assert fw.uid not in summary['file exclusive sum b'], 'parent as origin but should not be'
 
 
+def test_get_reverse_summary_fw(backend_db, common_db):
+    fo, fw = create_fw_with_child_fo()
+    backend_db.insert_multiple_objects(fw, fo)
+
+    summary = common_db.get_summary(fw, 'dummy', reverse=True)
+    assert isinstance(summary, dict), 'summary is not a dict'
+
+    assert fw.uid in summary, 'parent should be in summary'
+    assert fo.uid in summary, 'child should be in summary'
+    assert len(summary[fw.uid]) == len(summary[fo.uid]) == 2, 'each object should include two results'
+
+    assert 'sum a' in summary[fw.uid], 'entry should be in parent summary'
+    assert 'sum a' in summary[fo.uid], 'entry should be in child summary'
+    assert 'fw exclusive sum a' not in summary[fo.uid], 'entry should be in parent, but not child'
+    assert 'file exclusive sum b' in summary[fo.uid], 'exclusive entry of child missing'
+    assert 'file exclusive sum b' not in summary[fw.uid], 'entry should be in child, but not parent'
+
+
 def test_get_summary_fo(backend_db, common_db):
     fw, parent_fo, child_fo = create_fw_with_parent_and_child()
     backend_db.insert_multiple_objects(fw, parent_fo, child_fo)

--- a/src/test/unit/helperFunctions/test_data_conversion.py
+++ b/src/test/unit/helperFunctions/test_data_conversion.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 
 from helperFunctions.data_conversion import (
+    boolean_string_to_boolean,
     convert_compare_id_to_list,
     convert_str_to_bool,
     convert_time_to_str,
@@ -70,6 +71,25 @@ def test_get_value_of_first_key(input_data, expected):
 @pytest.mark.parametrize(('input_data', 'expected'), [(None, None), ('None', None), ('foo', 'foo')])
 def test_none_to_none(input_data, expected):
     assert none_to_none(input_data) == expected
+
+
+@pytest.mark.parametrize(
+    ('input_data', 'expected'),
+    [(True, True), ('True', True), ('true', True), (False, False), ('False', False), ('false', False)],
+)
+def test_boolean_string_to_boolean(input_data, expected):
+    assert boolean_string_to_boolean(input_data) == expected
+
+
+def test_boolean_string_to_boolean_raises():
+    with pytest.raises(ValueError, match='does not seem to be a boolean value'):
+        boolean_string_to_boolean('anything else')
+
+    with pytest.raises(ValueError, match='does not seem to be a boolean value'):
+        boolean_string_to_boolean('')
+
+    with pytest.raises(ValueError, match='does not seem to be a boolean value'):
+        boolean_string_to_boolean(None)
 
 
 @pytest.mark.parametrize(

--- a/src/test/unit/web_interface/test_app_ajax_routes.py
+++ b/src/test/unit/web_interface/test_app_ajax_routes.py
@@ -42,13 +42,19 @@ class DbMock(CommonDatabaseMock):
 @pytest.mark.WebInterfaceUnitTestConfig(database_mock_class=DbMock)
 class TestAppAjaxRoutes:
     def test_ajax_get_summary(self, test_client):
-        result = test_client.get(f'/ajax_get_summary/{TEST_FW.uid}/foobar').data
-        assert b'Summary for Included Files' in result
+        result = test_client.get(f'/ajax_get_summary/{TEST_FW.uid}/foobar/false').data
+        assert b'summary-heading' in result
+        assert b'foobar' in result
+        assert b'some_uid' in result
+
+    def test_ajax_get_inverse_summary(self, test_client):
+        result = test_client.get(f'/ajax_get_summary/{TEST_FW.uid}/foobar/true').data
+        assert b'summary-heading' in result
         assert b'foobar' in result
         assert b'some_uid' in result
 
     def test_ajax_get_summary__summary_not_found(self, test_client):
-        result = test_client.get(f'/ajax_get_summary/{TEST_FW.uid}/not_found').data
+        result = test_client.get(f'/ajax_get_summary/{TEST_FW.uid}/not_found/false').data
         assert b'No summary found' in result
 
     def test_ajax_get_common_files_for_compare(self, test_client):

--- a/src/web_interface/components/ajax_routes.py
+++ b/src/web_interface/components/ajax_routes.py
@@ -118,18 +118,18 @@ class AjaxRoutes(ComponentBase):
         return f'<pre style="white-space: pre-wrap; margin-bottom: 0;">\n{hex_dump}\n</pre>'
 
     @roles_accepted(*PRIVILEGES['view_analysis'])
-    @AppRoute('/ajax_get_summary/<uid>/<selected_analysis>/<reversed_order>', GET)
-    def ajax_get_summary(self, uid: str, selected_analysis: str, reversed_order: bool) -> str:
+    @AppRoute('/ajax_get_summary/<uid>/<selected_analysis>/<inverted>', GET)
+    def ajax_get_summary(self, uid: str, selected_analysis: str, inverted: bool) -> str:
         with get_shared_session(self.db.frontend) as frontend_db:
             firmware = frontend_db.get_object(uid, analysis_filter=selected_analysis)
-            summary_of_included_files = frontend_db.get_summary(firmware, selected_analysis, reverse=reversed_order)
+            summary_of_included_files = frontend_db.get_summary(firmware, selected_analysis, invert=inverted)
             root_uid = uid if isinstance(firmware, Firmware) else frontend_db.get_root_uid(uid)
         return render_template(
             'summary.html',
             summary_of_included_files=summary_of_included_files,
             root_uid=root_uid,
             selected_analysis=selected_analysis,
-            reverse_summary=reversed_order,
+            inverted=inverted,
         )
 
     @roles_accepted(*PRIVILEGES['status'])

--- a/src/web_interface/components/ajax_routes.py
+++ b/src/web_interface/components/ajax_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import html
 import logging
 from http import HTTPStatus
+from typing import TYPE_CHECKING
 
 from flask import jsonify, render_template
 
@@ -23,19 +24,22 @@ from web_interface.filter import (
 from web_interface.security.decorator import roles_accepted
 from web_interface.security.privileges import PRIVILEGES
 
+if TYPE_CHECKING:
+    from flask import Response
+
 
 class AjaxRoutes(ComponentBase):
     @roles_accepted(*PRIVILEGES['view_analysis'])
     @AppRoute('/ajax_tree/<uid>/<root_uid>', GET)
     @AppRoute('/compare/ajax_tree/<compare_id>/<root_uid>/<uid>', GET)
-    def ajax_get_tree_children(self, uid, root_uid=None, compare_id=None):
+    def ajax_get_tree_children(self, uid: str, root_uid: str | None = None, compare_id: str | None = None) -> Response:
         root_uid, compare_id = none_to_none(root_uid), none_to_none(compare_id)
         exclusive_files = self._get_exclusive_files(compare_id, root_uid)
         tree = self._generate_file_tree(root_uid, uid, exclusive_files)
         children = [convert_to_jstree_node(child_node) for child_node in tree.get_list_of_child_nodes()]
         return jsonify(children)
 
-    def _get_exclusive_files(self, compare_id, root_uid):
+    def _get_exclusive_files(self, compare_id: str, root_uid: str) -> list[str] | None:
         if compare_id:
             return self.db.comparison.get_exclusive_files(compare_id, root_uid)
         return None
@@ -57,7 +61,7 @@ class AjaxRoutes(ComponentBase):
 
     @roles_accepted(*PRIVILEGES['view_analysis'])
     @AppRoute('/ajax_root/<uid>/<root_uid>', GET)
-    def ajax_get_tree_root(self, uid, root_uid):
+    def ajax_get_tree_root(self, uid: str, root_uid: str) -> Response:
         root = []
         with get_shared_session(self.db.frontend) as frontend_db:
             for node in frontend_db.generate_file_tree_level(uid, root_uid):  # only a single item in this 'iterable'
@@ -67,20 +71,20 @@ class AjaxRoutes(ComponentBase):
 
     @roles_accepted(*PRIVILEGES['compare'])
     @AppRoute('/compare/ajax_common_files/<compare_id>/<feature_id>/', GET)
-    def ajax_get_common_files_for_compare(self, compare_id, feature_id):
+    def ajax_get_common_files_for_compare(self, compare_id: str, feature_id: str) -> str:
         result = self.db.comparison.get_comparison_result(compare_id)
         feature, matching_uid = feature_id.split('___')
         uid_list = result['plugins']['File_Coverage'][feature][matching_uid]
         return self._get_nice_uid_list_html(uid_list, root_uid=self._get_root_uid(matching_uid, compare_id))
 
     @staticmethod
-    def _get_root_uid(candidate, compare_id):
+    def _get_root_uid(candidate: str, compare_id: str) -> str:
         # feature_id contains an UID in individual case, in all case simply take first uid from compare
         if candidate != 'all':
             return candidate
-        return compare_id.split(';')[0]
+        return compare_id.split(';', maxsplit=1)[0]
 
-    def _get_nice_uid_list_html(self, input_data, root_uid):
+    def _get_nice_uid_list_html(self, input_data: list[str], root_uid: str) -> str:
         included_files = self.db.frontend.get_data_for_nice_list(input_data, None)
         number_of_unanalyzed_files = len(input_data) - len(included_files)
         return render_template(
@@ -93,7 +97,7 @@ class AjaxRoutes(ComponentBase):
 
     @roles_accepted(*PRIVILEGES['view_analysis'])
     @AppRoute('/ajax_get_binary/<mime_type>/<uid>', GET)
-    def ajax_get_binary(self, mime_type, uid):
+    def ajax_get_binary(self, mime_type: str, uid: str) -> str | None:
         mime_type = mime_type.replace('_', '/')
         binary = self.intercom.get_binary_and_filename(uid)[0]
         if is_text_file(mime_type):
@@ -114,27 +118,28 @@ class AjaxRoutes(ComponentBase):
         return f'<pre style="white-space: pre-wrap; margin-bottom: 0;">\n{hex_dump}\n</pre>'
 
     @roles_accepted(*PRIVILEGES['view_analysis'])
-    @AppRoute('/ajax_get_summary/<uid>/<selected_analysis>', GET)
-    def ajax_get_summary(self, uid, selected_analysis):
+    @AppRoute('/ajax_get_summary/<uid>/<selected_analysis>/<reversed_order>', GET)
+    def ajax_get_summary(self, uid: str, selected_analysis: str, reversed_order: bool) -> str:
         with get_shared_session(self.db.frontend) as frontend_db:
             firmware = frontend_db.get_object(uid, analysis_filter=selected_analysis)
-            summary_of_included_files = frontend_db.get_summary(firmware, selected_analysis)
+            summary_of_included_files = frontend_db.get_summary(firmware, selected_analysis, reverse=reversed_order)
             root_uid = uid if isinstance(firmware, Firmware) else frontend_db.get_root_uid(uid)
         return render_template(
             'summary.html',
             summary_of_included_files=summary_of_included_files,
             root_uid=root_uid,
             selected_analysis=selected_analysis,
+            reverse_summary=reversed_order,
         )
 
     @roles_accepted(*PRIVILEGES['status'])
     @AppRoute('/ajax/stats/system', GET)
-    def get_system_stats(self):
+    def get_system_stats(self) -> dict[str, str | int]:
         backend_data = self.db.stats_viewer.get_statistic('backend')
         analysis_status = self.status.get_analysis_status()
         try:
             return {
-                'backend_cpu_percentage': f"{backend_data['system']['cpu_percentage']}%",
+                'backend_cpu_percentage': f'{backend_data["system"]["cpu_percentage"]}%',
                 'number_of_running_analyses': len(analysis_status['current_analyses']),
             }
         except (KeyError, TypeError):
@@ -142,7 +147,7 @@ class AjaxRoutes(ComponentBase):
 
     @roles_accepted(*PRIVILEGES['status'])
     @AppRoute('/ajax/system_health', GET)
-    def get_system_health_update(self):
+    def get_system_health_update(self) -> dict[str, list[dict] | dict]:
         return {
             'systemHealth': self.db.stats_viewer.get_stats_list('backend', 'frontend', 'database'),
             'analysisStatus': self.status.get_analysis_status(),
@@ -150,7 +155,7 @@ class AjaxRoutes(ComponentBase):
 
     @roles_accepted(*PRIVILEGES['cancel_analysis'])
     @AppRoute('/ajax/cancel_analysis/<root_uid>', GET)
-    def cancel_analysis(self, root_uid: str):
+    def cancel_analysis(self, root_uid: str) -> tuple[dict, int]:
         logging.info(f'Received analysis cancel request for {root_uid}')
         self.intercom.cancel_analysis(root_uid=root_uid)
         return {}, HTTPStatus.OK

--- a/src/web_interface/components/ajax_routes.py
+++ b/src/web_interface/components/ajax_routes.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 from flask import jsonify, render_template
 
-from helperFunctions.data_conversion import none_to_none
+from helperFunctions.data_conversion import boolean_string_to_boolean, none_to_none
 from helperFunctions.database import get_shared_session
 from objects.firmware import Firmware
 from web_interface.components.component_base import GET, AppRoute, ComponentBase
@@ -120,10 +120,13 @@ class AjaxRoutes(ComponentBase):
     @roles_accepted(*PRIVILEGES['view_analysis'])
     @AppRoute('/ajax_get_summary/<uid>/<selected_analysis>/<inverted>', GET)
     def ajax_get_summary(self, uid: str, selected_analysis: str, inverted: bool) -> str:
+        inverted = boolean_string_to_boolean(inverted)
+
         with get_shared_session(self.db.frontend) as frontend_db:
             firmware = frontend_db.get_object(uid, analysis_filter=selected_analysis)
             summary_of_included_files = frontend_db.get_summary(firmware, selected_analysis, invert=inverted)
             root_uid = uid if isinstance(firmware, Firmware) else frontend_db.get_root_uid(uid)
+
         return render_template(
             'summary.html',
             summary_of_included_files=summary_of_included_files,

--- a/src/web_interface/static/js/show_analysis_summary.js
+++ b/src/web_interface/static/js/show_analysis_summary.js
@@ -1,9 +1,9 @@
-function load_summary(uid, selected_analysis, focus=false){
+function load_summary(uid, selected_analysis, focus=false, reversed_order=false){
     $("#summary-button").css("display", "none");
     let summary_gif = $("#loading-summary-gif");
     summary_gif.css("display", "block");
     $("#summary-div").load(
-        `/ajax_get_summary/${uid}/${selected_analysis}`,
+        `/ajax_get_summary/${uid}/${selected_analysis}/${reversed_order}`,
         () => {
             summary_gif.css("display", "none");
             if (focus === true) {

--- a/src/web_interface/static/js/show_analysis_summary.js
+++ b/src/web_interface/static/js/show_analysis_summary.js
@@ -1,4 +1,4 @@
-function load_summary(uid, selected_analysis, inverted, focus=false){
+function load_summary(uid, selected_analysis, inverted){
     $("#summary-button").css("display", "none");
     let summary_gif = $("#loading-summary-gif");
     summary_gif.css("display", "block");
@@ -6,9 +6,6 @@ function load_summary(uid, selected_analysis, inverted, focus=false){
         `/ajax_get_summary/${uid}/${selected_analysis}/${inverted}`,
         () => {
             summary_gif.css("display", "none");
-            if (focus === true) {
-                location.href = "#summary-heading";
-            }
         }
     );
 }

--- a/src/web_interface/static/js/show_analysis_summary.js
+++ b/src/web_interface/static/js/show_analysis_summary.js
@@ -1,4 +1,4 @@
-function load_summary(uid, selected_analysis, focus=false, reversed_order=false){
+function load_summary(uid, selected_analysis, reversed_order, focus=false){
     $("#summary-button").css("display", "none");
     let summary_gif = $("#loading-summary-gif");
     summary_gif.css("display", "block");

--- a/src/web_interface/static/js/show_analysis_summary.js
+++ b/src/web_interface/static/js/show_analysis_summary.js
@@ -1,9 +1,9 @@
-function load_summary(uid, selected_analysis, reversed_order, focus=false){
+function load_summary(uid, selected_analysis, inverted, focus=false){
     $("#summary-button").css("display", "none");
     let summary_gif = $("#loading-summary-gif");
     summary_gif.css("display", "block");
     $("#summary-div").load(
-        `/ajax_get_summary/${uid}/${selected_analysis}/${reversed_order}`,
+        `/ajax_get_summary/${uid}/${selected_analysis}/${inverted}`,
         () => {
             summary_gif.css("display", "none");
             if (focus === true) {

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -113,8 +113,24 @@
 
                 {# summary of included files #}
                 {%- if selected_analysis and firmware.files_included -%}
+                    <table class="table table-bordered pb-0 mb-0">
+                        <thead class="thead-light">
+                            <tr>
+                                <th>
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        Summary for Included Files
+                                        <div class="custom-control custom-switch">
+                                            <input type="checkbox" class="custom-control-input" id="summaryOrderSwitch" onchange="reverseSummaryOrder()">
+                                            <label class="custom-control-label" for="summaryOrderSwitch" style="font-weight: normal;">Show inverted summary</label>
+                                        </div>
+                                    </div>
+                                </th>
+                            </tr>
+                        </thead>
+                    </table>
+
                     <button id="summary-button" class="btn list-group-item list-group-item-primary p-2 w-100 mb-3"
-                            onclick="load_summary(uid, selected_analysis);">
+                            onclick="load_summary(uid, selected_analysis, reversed_order=document.getElementById('summaryOrderSwitch').checked);">
                         Load Summary for Included Files
                     </button>
 

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -130,7 +130,7 @@
                     </table>
 
                     <button id="summary-button" class="btn list-group-item list-group-item-primary p-2 w-100 mb-3"
-                            onclick="load_summary(uid, selected_analysis, reversed_order=document.getElementById('summaryOrderSwitch').checked);">
+                            onclick="load_summary(uid, selected_analysis, false);">
                         Load Summary for Included Files
                     </button>
 

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -120,7 +120,7 @@
                                     <div class="d-flex justify-content-between align-items-center">
                                         Summary for Included Files
                                         <div class="custom-control custom-switch">
-                                            <input type="checkbox" class="custom-control-input" id="summaryOrderSwitch" onchange="reverseSummaryOrder()">
+                                            <input type="checkbox" class="custom-control-input" id="summaryOrderSwitch" onchange="load_summary(uid, selected_analysis, document.getElementById('summaryOrderSwitch').checked);">
                                             <label class="custom-control-label" for="summaryOrderSwitch" style="font-weight: normal;">Show inverted summary</label>
                                         </div>
                                     </div>
@@ -173,7 +173,7 @@
             const has_children = {{ "true" if firmware.files_included | length > 0  else "false" }};
             if (summary === "true" && has_children && selected_analysis !== "None") {
                 // automatically load summary if URL parameter "load_summary=true" is set
-                load_summary(uid, selected_analysis, focus=true);
+                load_summary(uid, selected_analysis, false, focus=true);
             } else if (preview !== false) {
                 // automatically load preview at address xyz if URL parameter "load_preview=xyz" is set
                 loadPreview(preview, true);

--- a/src/web_interface/templates/show_analysis.html
+++ b/src/web_interface/templates/show_analysis.html
@@ -120,7 +120,7 @@
                                     <div class="d-flex justify-content-between align-items-center">
                                         Summary for Included Files
                                         <div class="custom-control custom-switch">
-                                            <input type="checkbox" class="custom-control-input" id="summaryOrderSwitch" onchange="load_summary(uid, selected_analysis, document.getElementById('summaryOrderSwitch').checked);">
+                                            <input type="checkbox" class="custom-control-input" id="summaryOrderSwitch" onchange="create_summary_view();">
                                             <label class="custom-control-label" for="summaryOrderSwitch" style="font-weight: normal;">Show inverted summary</label>
                                         </div>
                                     </div>
@@ -130,18 +130,17 @@
                     </table>
 
                     <button id="summary-button" class="btn list-group-item list-group-item-primary p-2 w-100 mb-3"
-                            onclick="load_summary(uid, selected_analysis, false);">
+                            onclick="create_summary_view();">
                         Load Summary for Included Files
                     </button>
 
-                    <div id="summary-div">
-                        <div class="mb-3 border" id="loading-summary-gif" style="display: none; padding: 5px; text-align: center">
+                    <div class="mb-0 border" id="loading-summary-gif" style="display: none; padding: 5px; text-align: center">
                             <p>Loading summary for included files...</p>
-                        </div>
-                        <script>
-                            loadLoadingAnimation('loading-summary-gif');
-                        </script>
                     </div>
+                    <div id="summary-div"></div>
+                    <script>
+                        loadLoadingAnimation('loading-summary-gif');
+                    </script>
                     <script type="text/javascript" src="{{ url_for('static', filename='js/show_analysis_summary.js') }}"></script>
 
                 {%- endif -%}
@@ -166,6 +165,12 @@
             document.body.append(radare_form);
             radare_form.submit();
         }
+        function create_summary_view(focus=false){
+            load_summary(uid, selected_analysis, document.getElementById('summaryOrderSwitch').checked);
+            if (focus === true) {
+                location.href = "#summary-heading";
+            }
+        }
         document.addEventListener("DOMContentLoaded", function() {
             const urlParams = new URLSearchParams(window.location.search);
             const summary = urlParams.get('load_summary');
@@ -173,7 +178,7 @@
             const has_children = {{ "true" if firmware.files_included | length > 0  else "false" }};
             if (summary === "true" && has_children && selected_analysis !== "None") {
                 // automatically load summary if URL parameter "load_summary=true" is set
-                load_summary(uid, selected_analysis, false, focus=true);
+                create_summary_view(focus=true);
             } else if (preview !== false) {
                 // automatically load preview at address xyz if URL parameter "load_preview=xyz" is set
                 loadPreview(preview, true);

--- a/src/web_interface/templates/summary.html
+++ b/src/web_interface/templates/summary.html
@@ -23,7 +23,7 @@
                 {% else %}
                     <td>{{ item | replace_uid_with_hid_link | safe }}</td>
                     <td>
-                        {{ summary_of_included_files[item] | nice_generic | safe }}
+                        {{ summary_of_included_files[item] | list_group_collapse | safe }}
                     </td>
                 {% endif %}
             </tr>

--- a/src/web_interface/templates/summary.html
+++ b/src/web_interface/templates/summary.html
@@ -15,7 +15,7 @@
     </tr>
         {% for item in summary_of_included_files | sort %}
             <tr>
-                {% if not reverse_summary %}
+                {% if not inverted %}
                     <td>{{ item | wordwrap(width=60, break_long_words=True) }}</td>
                     <td>
                         {{ summary_of_included_files[item] | nice_uid_list(root_uid=root_uid, selected_analysis=selected_analysis) | safe }}

--- a/src/web_interface/templates/summary.html
+++ b/src/web_interface/templates/summary.html
@@ -21,7 +21,7 @@
                         {{ summary_of_included_files[item] | nice_uid_list(root_uid=root_uid, selected_analysis=selected_analysis) | safe }}
                     </td>
                 {% else %}
-                    <td>{{ item | replace_uid_with_hid_link | safe }}</td>
+                    <td style="word-break: break-all;">{{ item | replace_uid_with_hid_link | safe }}</td>
                     <td>
                         {{ summary_of_included_files[item] | list_group_collapse | safe }}
                     </td>

--- a/src/web_interface/templates/summary.html
+++ b/src/web_interface/templates/summary.html
@@ -5,7 +5,7 @@
     </colgroup>
     <thead class="thead-light">
         <tr>
-            <th id="summary-heading" colspan=2>Summary for Included Files</th>
+            <th class="p-0" id="summary-heading" colspan=2></th>
         </tr>
     </thead>
     {% if summary_of_included_files %}
@@ -15,10 +15,17 @@
     </tr>
         {% for item in summary_of_included_files | sort %}
             <tr>
-                <td>{{ item | wordwrap(width=60, break_long_words=True) }}</td>
-                <td>
-                    {{ summary_of_included_files[item] | nice_uid_list(root_uid=root_uid, selected_analysis=selected_analysis) | safe }}
-                </td>
+                {% if not reverse_summary %}
+                    <td>{{ item | wordwrap(width=60, break_long_words=True) }}</td>
+                    <td>
+                        {{ summary_of_included_files[item] | nice_uid_list(root_uid=root_uid, selected_analysis=selected_analysis) | safe }}
+                    </td>
+                {% else %}
+                    <td>{{ item | replace_uid_with_hid_link | safe }}</td>
+                    <td>
+                        {{ summary_of_included_files[item] | nice_generic | safe }}
+                    </td>
+                {% endif %}
             </tr>
         {% endfor %}
     {% else %}


### PR DESCRIPTION
* Added checkbox to analysis view summary block to allow inverting summary
  * Summary is displayed `1-n` where `1` is item and `n` is matched files.
  * Inversion shows `1` as matched file and `n` as matched items.
* Added parameter to database function to invert summary dict after query of database
* Created hand-over chain for checkbox to make "inverted" parameter accessible where needed
* Added helper function to fix "boolean string problem" to make future code duplication unnecessary
* Added tests for new functionalities