### PR TITLE
fix: don't keep objects after passing them to a queue

### DIFF
--- a/src/scheduler/analysis/plugin.py
+++ b/src/scheduler/analysis/plugin.py
@@ -261,6 +261,7 @@ class Worker(mp.Process):
                 entry['exception'] = (self._plugin.metadata.name, 'An unexpected exception occurred')
             finally:
                 # Don't kill another process if it uses the same PID as our dead worker
+                child_process.join(timeout=5)
                 if child_process.is_alive():
                     child = psutil.Process(pid=child_process.pid)
                     for grandchild in child.children(recursive=True):
@@ -271,6 +272,8 @@ class Worker(mp.Process):
             fw = task.scheduler_state
             self._write_result_in_file_object(entry, fw)
             self._out_queue.put(fw)
+            del fw, task, result, entry
+            result = None
 
     def _write_result_in_file_object(self, entry: dict, file_object: FileObject) -> None:
         """Takes a file_object and an entry as it is returned by :py:func:`Worker.run`

--- a/src/scheduler/analysis/scheduler.py
+++ b/src/scheduler/analysis/scheduler.py
@@ -332,6 +332,7 @@ class AnalysisScheduler:
                 pass
             else:
                 self._process_next_analysis_task(task)
+                del task
         logging.debug(f'Stopped analysis scheduling worker {index}')
 
     def _process_next_analysis_task(self, fw_object: FileObject) -> None:
@@ -535,6 +536,7 @@ class AnalysisScheduler:
                 else:
                     nop = False
                     self._handle_collected_result(fw, plugin_name)
+                    del fw
             if nop:
                 sleep(config.backend.block_delay)
         logging.debug(f'Stopped analysis result collector worker {index}')

--- a/src/scheduler/unpacking_scheduler.py
+++ b/src/scheduler/unpacking_scheduler.py
@@ -168,6 +168,7 @@ class UnpackingScheduler:
                 task_thread.start()
                 logging.debug(f'Started Worker on {task.uid} ({container.tmp_dir})')
                 self.pending_tasks[container.id_] = task_thread
+                del task
             except NoFreeWorker:
                 logging.debug('No free worker. Sleeping...')
                 sleep(0.2)


### PR DESCRIPTION
* delete objects after passing them on in endless (`while True:`) loops (so they are not kept in memory while waiting on the next task)
* try to join processes before killing them (to clean them up)