### PR TITLE
feat: improved the ThreadX rule to be more robust

### DIFF
--- a/src/plugins/analysis/software_components/signatures/os.yara
+++ b/src/plugins/analysis/software_components/signatures/os.yara
@@ -76,7 +76,7 @@ rule LinuxKernel
 	condition:
 		$safe_condition
 
-/* tmporarly removed due to too many false positives */
+/* temporarily removed due to too many false positives */
 /*
         $a = /[2-4]\.\d\d?\.\d\d?-[a-z_][a-z\-_]+/ nocase ascii wide
         $b = /gcc-[2-4]\.\d\d?\.\d\d?-[a-z_][a-z\-_]+/ nocase ascii wide
@@ -107,8 +107,9 @@ rule ThreadX
 		open_source = false
 		website = "https://rtos.com/solutions/threadx/real-time-operating-system/"
 		description = "Real Time Operating System"
+		version_regex = "\\d(\\.\\d){1,3}"
 	strings:
-		$a = /ThreadX [a-z\/ 1-9_]+ [a-z]?\d+\.\d+(\.\d+)?(\.\d+)?/ nocase ascii wide
+		$a = /ThreadX [A-Za-z\/ 0-9_-]+ [A-Z]?\d+(\.[\da-z]{1,3}){1,3}( SN: [\d-]+)?/
 	condition:
 		$a
 }

--- a/src/plugins/analysis/software_components/test/data/software_component_test_list.txt
+++ b/src/plugins/analysis/software_components/test/data/software_component_test_list.txt
@@ -35,7 +35,9 @@ Redis needs to enable the AOF
 SSLeay 0.8.2b
 This is perl
 ThreadX ARM11/Green Hills Version G5.0.5.0
+ThreadX Cortex-M3/RVDS Version G5.3.5.2 SN: 12345-123-1234
 ThreadX MIPS32_M14K/GNU Version G5.5.5.0
+ThreadX R3900/Green Hills Version G3.0f.3.0b
 U-Boot 1.1.4
 UPnP/1.0, Portable SDK for UPnP devices/1.3.1
 VxWorks 6.5


### PR DESCRIPTION
* fixes false negatives like "ThreadX R3900/Green Hills Version G3.0f.3.0b" or "ThreadX Cortex-M3/RVDS Version G5.3.5.2"
* adds a version_regex meta field to prevent the version from being detected from the arch/compiler part of the string
* also adds optional rule part to pick up the SN if it is present