### PR TITLE
analysis results pruning

### DIFF
--- a/src/scheduler/analysis/scheduler.py
+++ b/src/scheduler/analysis/scheduler.py
@@ -559,6 +559,9 @@ class AnalysisScheduler:
             or fw_object.root_uid is None  # this should only be true if we are dealing with a "single file analysis"
             or self.status.fw_analysis_is_in_progress(fw_object)
         ):
+            # Check for results that are not needed as dependencies for the remaining scheduled analyses and remove them
+            # (They were already stored in the DB in _handle_collected_result, so there is no reason to keep them)
+            self.task_scheduler.prune_unneeded_results(fw_object)
             self.process_queue.put(fw_object)
         else:
             logging.debug(

--- a/src/scheduler/task_scheduler.py
+++ b/src/scheduler/task_scheduler.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import logging
 from copy import copy
 from time import time
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING
 
 from helperFunctions.merge_generators import shuffled
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from analysis.plugin import AnalysisPluginV0
     from objects.file import FileObject
     from objects.firmware import Firmware
@@ -16,10 +18,10 @@ MANDATORY_PLUGINS = ['file_type', 'file_hashes']
 
 
 class AnalysisTaskScheduler:
-    def __init__(self, plugins):
+    def __init__(self, plugins: dict[str, AnalysisPluginV0]):
         self.plugins: dict[str, AnalysisPluginV0] = plugins
 
-    def schedule_analysis_tasks(self, fo, scheduled_analysis, mandatory=False):
+    def schedule_analysis_tasks(self, fo: FileObject, scheduled_analysis: list[str], mandatory: bool = False) -> None:
         scheduled_analysis = self._add_dependencies_recursively(copy(scheduled_analysis) or [])
         fo.scheduled_analysis = self._smart_shuffle(
             scheduled_analysis + MANDATORY_PLUGINS if mandatory else scheduled_analysis
@@ -69,7 +71,7 @@ class AnalysisTaskScheduler:
             dependency for plugin in scheduled_analyses for dependency in self.plugins[plugin].metadata.dependencies
         }.difference(scheduled_analyses)
 
-    def reschedule_failed_analysis_task(self, fw_object: Firmware | FileObject):
+    def reschedule_failed_analysis_task(self, fw_object: Firmware | FileObject) -> None:
         failed_plugin, cause = fw_object.analysis_exception
         fw_object.processed_analysis[failed_plugin] = self._get_failed_analysis_result(cause, failed_plugin)
         for plugin in fw_object.scheduled_analysis[:]:

--- a/src/scheduler/task_scheduler.py
+++ b/src/scheduler/task_scheduler.py
@@ -91,3 +91,14 @@ class AnalysisTaskScheduler:
             'plugin_version': self.plugins[plugin].metadata.version,
             'analysis_date': time(),
         }
+
+    def prune_unneeded_results(self, fo: FileObject) -> None:
+        """
+        Important thing to note: We only care about direct dependencies here, because recursive ones are not needed
+        to run an analysis.
+        """
+        still_needed_deps = {
+            dep for plugin in (fo.scheduled_analysis or []) for dep in self.plugins[plugin].metadata.dependencies
+        }
+        for result_to_remove in set(fo.processed_analysis) - still_needed_deps:
+            fo.processed_analysis.pop(result_to_remove, None)

--- a/src/test/unit/scheduler/test_task_scheduler.py
+++ b/src/test/unit/scheduler/test_task_scheduler.py
@@ -15,6 +15,17 @@ class MetadataMock:
     version: Version
 
 
+class MockPlugin:
+    def __init__(self, dependencies: list[str]):
+        self.metadata = MetadataMock(dependencies, Version(1, 0, 0))
+
+
+class MockFo:
+    def __init__(self, scheduled: list[str], done: list[str]):
+        self.scheduled_analysis = scheduled
+        self.processed_analysis = {p: None for p in done}
+
+
 class TestAnalysisScheduling:
     class PluginMock:
         def __init__(self, dependencies):
@@ -129,3 +140,42 @@ class TestAnalysisScheduling:
         }
         result = self.scheduler._smart_shuffle(['p1', 'p2', 'p3'])
         assert result == []
+
+
+PLUGINS = {
+    'A': MockPlugin(dependencies=[]),
+    'B': MockPlugin(dependencies=['A']),
+    'C': MockPlugin(dependencies=['B']),
+    'D': MockPlugin(dependencies=['A', 'B']),
+    'E': MockPlugin(dependencies=[]),
+}
+
+
+@pytest.mark.parametrize(
+    ('scheduled', 'processed', 'expected_remaining'),
+    [
+        # 1. nothing planned -> everything can be removed
+        pytest.param([], ['A', 'B'], set(), id='empty'),
+        # 2. scheduled_analysis None -> like 1.
+        pytest.param(None, ['A', 'B'], set(), id='none'),
+        # 3. C needs B directly (not A) -> A removable, B stays
+        pytest.param(['C'], ['A', 'B'], {'B'}, id='A-removable'),
+        # 4. B needs A -> A stays
+        pytest.param(['B', 'C'], ['A'], {'A'}, id='keep-A'),
+        # 5. Multiple deps
+        pytest.param(['D'], ['A', 'B', 'E'], {'A', 'B'}, id='multi'),
+        # 6. overlapping deps
+        pytest.param(['C', 'D'], ['A', 'B', 'E'], {'A', 'B'}, id='overlap'),
+        # 7. no deps -> remove all
+        pytest.param(['E'], ['A', 'B'], set(), id='no-deps'),
+        # 8. dep missing (should not happen, should not cause an error)
+        pytest.param(['B'], ['E'], set(), id='dep-missing'),
+    ],
+)
+def test_prune_unneeded_results(scheduled, processed, expected_remaining):
+    fo = MockFo(scheduled, processed)
+    scheduler = AnalysisTaskScheduler(PLUGINS)
+
+    scheduler.prune_unneeded_results(fo)
+    remaining = set(fo.processed_analysis)
+    assert remaining == expected_remaining


### PR DESCRIPTION
* prune results from `FileObject.processed_analysis` if they are not needed anymore (as dependencies for the remaining planned analyses)
  * this should reduce the amount of data that is pickled/unpickled when passing the FOs through queues