### PR TITLE
optional analysis type check skipping

### DIFF
--- a/src/scheduler/analysis/scheduler.py
+++ b/src/scheduler/analysis/scheduler.py
@@ -457,6 +457,8 @@ class AnalysisScheduler:
         }
 
     def _next_analysis_is_blacklisted(self, next_analysis: str, fw_object: FileObject) -> bool:
+        if self._blacklist_check_is_disabled(fw_object):
+            return False
         blacklist, whitelist = self._get_blacklist_and_whitelist(next_analysis)
         if not (blacklist or whitelist):
             return False
@@ -499,6 +501,10 @@ class AnalysisScheduler:
             whitelist = []
 
         return blacklist, whitelist
+
+    @staticmethod
+    def _blacklist_check_is_disabled(fw_object: FileObject) -> bool:
+        return bool(fw_object.temporary_data.get('skip_type_check', False))
 
     # ---- result collector functions ----
 

--- a/src/scheduler/analysis/scheduler.py
+++ b/src/scheduler/analysis/scheduler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import time
+from copy import deepcopy
 from multiprocessing import Lock, Queue, Value
 from pathlib import Path
 from queue import Empty
@@ -170,7 +171,7 @@ class AnalysisScheduler:
         self.status.add_update(fo, included_files)
         for child_fo in self.db_backend_service.get_objects_by_uid_list(included_files):
             child_fo.root_uid = fo.uid  # set the correct root_uid so that "current analysis stats" work correctly
-            child_fo.force_update = getattr(fo, 'force_update', False)  # propagate forced update to children
+            child_fo.temporary_data = deepcopy(fo.temporary_data)  # propagate temp data to children
             self.task_scheduler.schedule_analysis_tasks(child_fo, fo.scheduled_analysis, mandatory=True)
             self._check_further_process_or_complete(child_fo)
         self._check_further_process_or_complete(fo)
@@ -387,10 +388,7 @@ class AnalysisScheduler:
 
     @staticmethod
     def _is_forced_update(file_object: FileObject) -> bool:
-        try:
-            return bool(getattr(file_object, 'force_update', False))
-        except AttributeError:
-            return False
+        return bool(file_object.temporary_data.get('force_update', False))
 
     # ---- 2. Analysis present and plugin version unchanged ----
 

--- a/src/test/common_helper.py
+++ b/src/test/common_helper.py
@@ -140,6 +140,7 @@ class MockFileObject:
         self.uid = uid
         self.file_path = file_path
         self.processed_analysis = {'file_type': {'result': {'mime': 'application/x-executable'}}}
+        self.temporary_data = {}
 
 
 class CommonDatabaseMock:

--- a/src/test/integration/web_interface/rest/test_rest_analysis.py
+++ b/src/test/integration/web_interface/rest/test_rest_analysis.py
@@ -88,7 +88,7 @@ class TestRestAnalysis(RestTestBase):
         )
         monkeypatch.setattr(
             'intercom.front_end_binding.InterComFrontEndBinding.add_single_file_task',
-            lambda _, fo: fo.force_update is True,
+            lambda _, fo: fo.temporary_data['force_update'] is True,
         )
 
         response = self.test_client.put(f'/rest/analysis/{TEST_UID}/file_type?force=true')

--- a/src/test/unit/scheduler/test_analysis.py
+++ b/src/test/unit/scheduler/test_analysis.py
@@ -219,6 +219,16 @@ class TestAnalysisSchedulerBlacklist:
         blacklisted = self.sched._next_analysis_is_blacklisted(self.test_plugin, self.file_object)
         assert blacklisted is True
 
+    def test_next_analysis_is_blacklisted__skip(self):
+        self.sched.analysis_plugins[self.test_plugin] = self.PluginMock(blacklist=['blacklisted_type'])
+        self.file_object.processed_analysis['file_type']['result']['mime'] = 'blacklisted_type'
+        try:
+            self.file_object.temporary_data['skip_type_check'] = True
+            blacklisted = self.sched._next_analysis_is_blacklisted(self.test_plugin, self.file_object)
+            assert blacklisted is False
+        finally:
+            self.file_object.temporary_data = {}
+
     def test_next_analysis_is_blacklisted__not_blacklisted(self):
         self.sched.analysis_plugins[self.test_plugin] = self.PluginMock(blacklist=[])
         self.file_object.processed_analysis['file_type']['result']['mime'] = 'not_blacklisted_type'

--- a/src/test/unit/scheduler/test_analysis.py
+++ b/src/test/unit/scheduler/test_analysis.py
@@ -346,9 +346,9 @@ class TestAnalysisSkipping:
     def test_is_forced_update(self):
         fo = MockFileObject()
         assert self.scheduler._is_forced_update(fo) is False
-        fo.force_update = False
+        fo.temporary_data['force_update'] = False
         assert self.scheduler._is_forced_update(fo) is False
-        fo.force_update = True
+        fo.temporary_data['force_update'] = True
         assert self.scheduler._is_forced_update(fo) is True
 
 

--- a/src/test/unit/web_interface/rest/test_rest_analysis.py
+++ b/src/test/unit/web_interface/rest/test_rest_analysis.py
@@ -86,3 +86,9 @@ class TestRestAnalysis:
 
         assert 'success' in result, 'missing field in result'
         assert result['success'], 'put should be successful'
+
+    def test_put_analysis_skip_type_check(self, test_client):
+        result = test_client.put(f'/rest/analysis/{TEST_FW.uid}/{PLUGIN}?skip_type_check=true').json
+
+        assert 'success' in result, 'missing field in result'
+        assert result['success'], 'put should be successful'

--- a/src/unpacker/unpack.py
+++ b/src/unpacker/unpack.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from copy import deepcopy
 from pathlib import Path
 from time import time
 from typing import TYPE_CHECKING
@@ -99,6 +100,7 @@ class Unpacker(UnpackBase):
                 uid = create_uid_from_path(path)
             current_file = FileObject.from_uid(uid, file_name=path.name)
             current_virtual_path = get_relative_object_path(path, extraction_dir)
+            current_file.temporary_data = deepcopy(parent.temporary_data)
             current_file.temporary_data['parent_fo_type'] = magic.from_file(parent.file_path, mime=True)
 
             if current_file.uid not in extracted_files:

--- a/src/web_interface/components/analysis_routes.py
+++ b/src/web_interface/components/analysis_routes.py
@@ -121,6 +121,7 @@ class AnalysisRoutes(ComponentBase):
         else:
             file_object.scheduled_analysis = request.form.getlist('analysis_systems')
         file_object.temporary_data['force_update'] = request.form.get('force_update') == 'true'
+        file_object.temporary_data['skip_type_check'] = request.form.get('skip_type_check') == 'true'
         success = self.intercom.add_single_file_task(file_object)
         return {'success': success}
 
@@ -178,11 +179,12 @@ class AnalysisRoutes(ComponentBase):
             logging.warning(f'Received invalid update analysis request: Key {KeyError.__str__(error)} is missing!')
             raise
         force_reanalysis = request.form.get('force_reanalysis') == 'true'
-        self._schedule_re_analysis_task(uid, analysis_task, re_do, force_reanalysis)
+        skip_type_check = request.form.get('skip_type_check') == 'true'
+        self._schedule_re_analysis_task(uid, analysis_task, re_do, force_reanalysis, skip_type_check)
         return render_template('upload/upload_successful.html', uid=uid)
 
     def _schedule_re_analysis_task(
-        self, uid: str, analysis_task: dict, re_do: bool, force_reanalysis: bool = False
+        self, uid: str, analysis_task: dict, re_do: bool, force_reanalysis: bool = False, skip_type_check: bool = False
     ) -> None:
         if re_do:
             analysis_task['binary'] = self.intercom.get_file_contents(uid)
@@ -191,7 +193,8 @@ class AnalysisRoutes(ComponentBase):
             # FixMe? do we need to wait for cascade/event listener to finish?
         else:
             base_fw = self.db.frontend.get_object(uid)
-            base_fw.temporary_data['force_update'] = force_reanalysis
+        base_fw.temporary_data['force_update'] = force_reanalysis
+        base_fw.temporary_data['skip_type_check'] = skip_type_check
         fw = convert_analysis_task_to_fw_obj(analysis_task, base_fw=base_fw)
         self.intercom.add_re_analyze_task(fw, unpack=re_do)
 

--- a/src/web_interface/components/analysis_routes.py
+++ b/src/web_interface/components/analysis_routes.py
@@ -120,7 +120,7 @@ class AnalysisRoutes(ComponentBase):
             file_object.scheduled_analysis = [plugin]
         else:
             file_object.scheduled_analysis = request.form.getlist('analysis_systems')
-        file_object.force_update = request.form.get('force_update') == 'true'
+        file_object.temporary_data['force_update'] = request.form.get('force_update') == 'true'
         success = self.intercom.add_single_file_task(file_object)
         return {'success': success}
 
@@ -191,7 +191,7 @@ class AnalysisRoutes(ComponentBase):
             # FixMe? do we need to wait for cascade/event listener to finish?
         else:
             base_fw = self.db.frontend.get_object(uid)
-            base_fw.force_update = force_reanalysis
+            base_fw.temporary_data['force_update'] = force_reanalysis
         fw = convert_analysis_task_to_fw_obj(analysis_task, base_fw=base_fw)
         self.intercom.add_re_analyze_task(fw, unpack=re_do)
 

--- a/src/web_interface/rest/rest_analysis.py
+++ b/src/web_interface/rest/rest_analysis.py
@@ -84,7 +84,7 @@ class RestAnalysis(RestResourceBase):
         file_object.scheduled_analysis = [plugin]
         if 'force' in request.args:
             force_flag = get_boolean_from_request(request.args, 'force')
-            file_object.force_update = force_flag
+            file_object.temporary_data['force_update'] = force_flag
         success = self.intercom.add_single_file_task(file_object)
 
         if success:

--- a/src/web_interface/rest/rest_analysis.py
+++ b/src/web_interface/rest/rest_analysis.py
@@ -26,6 +26,12 @@ api = Namespace('rest/analysis', description='Request the analysis results of a 
                 'type': 'boolean',
                 'default': 'false',
             },
+            'skip_type_check': {
+                'description': 'Disable type checking (plugin blacklists and whitelists).',
+                'in': 'query',
+                'type': 'boolean',
+                'default': 'false',
+            },
         },
     },
 )
@@ -85,6 +91,8 @@ class RestAnalysis(RestResourceBase):
         if 'force' in request.args:
             force_flag = get_boolean_from_request(request.args, 'force')
             file_object.temporary_data['force_update'] = force_flag
+        if 'skip_type_check' in request.args:
+            file_object.temporary_data['skip_type_check'] = get_boolean_from_request(request.args, 'skip_type_check')
         success = self.intercom.add_single_file_task(file_object)
 
         if success:

--- a/src/web_interface/templates/show_analysis/select_analysis.j2
+++ b/src/web_interface/templates/show_analysis/select_analysis.j2
@@ -51,6 +51,9 @@
                     <label class="checkbox-inline" data-toggle="tooltip" title="disable smart analysis skipping" style="display: block;">
                         <input type=checkbox name="force_update" value="true" unchecked>&nbsp;force analysis update<br />
                     </label>
+                    <label class="checkbox-inline" data-toggle="tooltip" title="disable type checking (plugin blacklists and whitelists)" style="display: block;">
+                        <input type=checkbox name="skip_type_check" value="true" unchecked>&nbsp;disable type checking<br />
+                    </label>
                     <button class="btn btn-primary" type="submit" id="add_single_file_analysis" value=submit>
                         <i class="fas fa-play-circle"></i> Add
                     </button>

--- a/src/web_interface/templates/upload/upload.html
+++ b/src/web_interface/templates/upload/upload.html
@@ -169,9 +169,18 @@
                             <label style="padding: 2px">
                                 <input
                                         type="checkbox" value="true" id="force_reanalysis" style="margin-top: 2px;"
-                                        data-toggle="tooltip" title="deactivate smart scheduling"
+                                        data-toggle="tooltip" title="run analyses even if they are already in the database"
                                         name="force_reanalysis"
-                                > Force Analysis Update
+                                > force analysis update
+                            </label>
+                        </div>
+                        <div class="checkbox m-0 pl-2" style="display: inline;">
+                            <label style="padding: 2px">
+                                <input
+                                        type="checkbox" value="true" id="skip_type_check" style="margin-top: 2px;"
+                                        data-toggle="tooltip" title="disable type checking (plugin blacklists and whitelists)"
+                                        name="skip_type_check"
+                                > disable type checking
                             </label>
                         </div>
                     {%- endif %}


### PR DESCRIPTION
* "force_update" was using a field of `FileObject` that does not "officially" exist -> move field to `FileObject.temporary_data`
* add an option for skipping the analysis type check (plugin blacklist/whitelist)
  * can be useful if the file type was detected wrongly and the analysis can't be run otherwise
  * also uses `FileObject.temporary_data`
  * makes sure `FileObject.temporary_data` is propagated to included files
  * available for FW update, single file update, and REST analysis PUT