### PR TITLE
fix: current analysis duration fix for distributed setups

### DIFF
--- a/src/scheduler/analysis_status.py
+++ b/src/scheduler/analysis_status.py
@@ -242,6 +242,7 @@ class AnalysisStatusWorker:
                 'unpacked_count': status.unpacked_files_count,
                 'analyzed_count': status.analyzed_files_count,
                 'start_time': status.start_time,
+                'duration': time() - status.start_time,
                 'total_count': status.total_files_count,
                 'total_count_with_duplicates': status.total_files_with_duplicates,
                 'hid': status.hid,

--- a/src/web_interface/static/js/system_health.js
+++ b/src/web_interface/static/js/system_health.js
@@ -150,7 +150,7 @@ function updateCurrentAnalyses(analysisData) {
 }
 
 function createCurrentAnalysisItem(data, uid, isFinished = false, isCancelled = false) {
-    const timeString = isFinished ? `Finished in ${getDuration(null, data.duration)}` : `${getDuration(data.start_time)}`;
+    const timeString = isFinished ? `Finished in ${getDuration(data.duration)}` : `${getDuration(data.duration)}`;
     const total = isFinished ? data.total_files_count : data.total_count;
     const showDetails = Boolean(document.getElementById("ca-show-details").checked);
     const width = isFinished || isCancelled || !showDetails ? "30px" : "50%";
@@ -260,8 +260,7 @@ function createIconCell(icon, tooltip, width) {
     `;
 }
 
-function getDuration(start = null, duration = null) {
-    duration = duration != null ? duration : Date.now() / 1000 - start;
+function getDuration(duration) {
     const date = new Date(duration * 1000);
     if (date.getUTCHours() > 0) {
         return date.toUTCString().slice(-12, -4);  // returns something like '01:23:45'


### PR DESCRIPTION
* current analysis duration fix for distributed setups
  * duration was calculated as a different of the system times of backend and frontend which resulted in erroneous values if the time is not synchronized correctly (only relevant for distributed setups)
  * this fix moves the duration calculation to the backend
  * as a side effect the displayed duration time is more accurate