### PR TITLE
PoC: escape null bytes and surrogates in DB serialization

### DIFF
--- a/src/storage/db_interface_backend.py
+++ b/src/storage/db_interface_backend.py
@@ -22,7 +22,7 @@ from storage.entry_conversion import (
 from storage.schema import AnalysisEntry, FileObjectEntry, FirmwareEntry, VirtualFilePath, included_files_table
 
 if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
+    from sqlalchemy.orm import Relationship, Session
 
     from objects.file import FileObject
 
@@ -30,24 +30,24 @@ if TYPE_CHECKING:
 class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
     # ===== Create / INSERT =====
 
-    def add_object(self, fw_object: FileObject):
+    def add_object(self, fw_object: FileObject) -> None:
         if self.exists(fw_object.uid):
             self.update_object(fw_object)
         else:
             self.insert_object(fw_object)
 
-    def insert_multiple_objects(self, *objects: FileObject):
+    def insert_multiple_objects(self, *objects: FileObject) -> None:
         """Convenience method mostly for tests. Careful: order does matter!"""
         for obj in objects:
             self.insert_object(obj)
 
-    def insert_object(self, fw_object: FileObject):
+    def insert_object(self, fw_object: FileObject) -> None:
         if isinstance(fw_object, Firmware):
             self.insert_firmware(fw_object)
         else:
             self.insert_file_object(fw_object)
 
-    def insert_file_object(self, file_object: FileObject):
+    def insert_file_object(self, file_object: FileObject) -> None:
         with self.get_read_write_session() as session:
             fo_entry = create_file_object_entry(file_object)
             self._update_parents(file_object.parent_firmware_uids, file_object.parents, fo_entry, session)
@@ -57,12 +57,12 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
 
     def _update_parents(
         self, root_fw_uids: list[str], parent_uids: list[str], fo_entry: FileObjectEntry, session: Session
-    ):
+    ) -> None:
         self._update_entries(session, fo_entry.root_firmware, root_fw_uids, 'root')
         self._update_entries(session, fo_entry.parent_files, parent_uids, 'parent')
 
     @staticmethod
-    def _update_entries(session: Session, db_column, uid_list: list[str], label: str):
+    def _update_entries(session: Session, db_column: Relationship, uid_list: list[str], label: str) -> None:
         entry_list = [session.get(FileObjectEntry, uid) for uid in uid_list]
         if entry_list and not any(entry_list):  # => all None
             raise DbInterfaceError(f'Trying to add object but no {label} object was found in DB: {uid_list}')
@@ -72,7 +72,7 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
             elif fo_entry and fo_entry not in db_column:
                 db_column.append(fo_entry)
 
-    def insert_firmware(self, firmware: Firmware):
+    def insert_firmware(self, firmware: Firmware) -> None:
         with self.get_read_write_session() as session:
             fo_entry = create_file_object_entry(firmware)
             # references in fo_entry (e.g. analysis or included files) are populated automatically
@@ -80,7 +80,7 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
             analyses = create_analysis_entries(firmware, fo_entry)
             session.add_all([fo_entry, firmware_entry, *analyses])
 
-    def add_analysis(self, uid: str, plugin: str, analysis_dict: dict):
+    def add_analysis(self, uid: str, plugin: str, analysis_dict: dict) -> None:
         try:
             if self.analysis_exists(uid, plugin):
                 self.update_analysis(uid, plugin, analysis_dict)
@@ -102,7 +102,7 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
             query = select(AnalysisEntry.uid).filter_by(uid=uid, plugin=plugin)
             return bool(session.execute(query).scalar())
 
-    def insert_analysis(self, uid: str, plugin: str, analysis_dict: dict):
+    def insert_analysis(self, uid: str, plugin: str, analysis_dict: dict) -> None:
         with self.get_read_write_session() as session:
             fo_backref = session.get(FileObjectEntry, uid)
             if fo_backref is None:
@@ -139,7 +139,7 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
             return str(plugin_version)
         return plugin_version
 
-    def add_vfp(self, parent_uid: str, child_uid: str, paths: list[str]):
+    def add_vfp(self, parent_uid: str, child_uid: str, paths: list[str]) -> None:
         """Adds a new "virtual file path" for file `child_uid` with path `path` in `parent_uid`"""
         with self.get_read_write_session() as session:
             vfp_list = [
@@ -153,7 +153,7 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
             for vfp in vfp_list:
                 session.merge(vfp)  # use merge in case paths exist already
 
-    def add_child_to_parent(self, parent_uid: str, child_uid: str):
+    def add_child_to_parent(self, parent_uid: str, child_uid: str) -> None:
         with self.get_read_write_session() as session:
             statement = included_files_table.insert().values(parent_uid=parent_uid, child_uid=child_uid)
             with suppress(IntegrityError):
@@ -162,7 +162,7 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
 
     # ===== Update / UPDATE =====
 
-    def update_object(self, fw_object: FileObject):
+    def update_object(self, fw_object: FileObject) -> None:
         if isinstance(fw_object, Firmware):
             if not self.is_firmware(fw_object.uid):
                 # special case: Trying to upload a file as firmware that is already in the DB as part of another
@@ -175,7 +175,7 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
             self.update_firmware(fw_object)
         self.update_file_object(fw_object)
 
-    def update_firmware(self, firmware: Firmware):
+    def update_firmware(self, firmware: Firmware) -> None:
         with self.get_read_write_session() as session:
             entry: FirmwareEntry = session.get(FirmwareEntry, firmware.uid)
             entry.release_date = firmware.release_date
@@ -186,7 +186,7 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
             entry.device_part = firmware.part
             entry.firmware_tags = firmware.tags
 
-    def update_file_object(self, file_object: FileObject):
+    def update_file_object(self, file_object: FileObject) -> None:
         with self.get_read_write_session() as session:
             entry = session.get(FileObjectEntry, file_object.uid)
             if entry is None:
@@ -203,11 +203,11 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
                 self._update_virtual_file_path(file_object, session)
 
     @staticmethod
-    def _update_virtual_file_path(file_object: FileObject, session: Session):
+    def _update_virtual_file_path(file_object: FileObject, session: Session) -> None:
         for vfp in create_vfp_entries(file_object):
             session.merge(vfp)  # session.merge will insert or update (if it is already in the DB)
 
-    def update_analysis(self, uid: str, plugin: str, analysis_data: dict):
+    def update_analysis(self, uid: str, plugin: str, analysis_data: dict) -> None:
         with self.get_read_write_session() as session:
             entry = session.get(AnalysisEntry, (uid, plugin))
             entry.plugin_version = self._sanitize_plugin_version(analysis_data['plugin_version'])
@@ -224,7 +224,7 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
                 sanitize(result)
             entry.result = result
 
-    def update_file_object_parents(self, file_uid: str, root_uid: str, parent_uid):
+    def update_file_object_parents(self, file_uid: str, root_uid: str, parent_uid: str) -> None:
         with self.get_read_write_session() as session:
             fo_entry = session.get(FileObjectEntry, file_uid)
             self._update_parents([root_uid], [parent_uid], fo_entry, session)

--- a/src/storage/db_interface_backend.py
+++ b/src/storage/db_interface_backend.py
@@ -17,6 +17,7 @@ from storage.entry_conversion import (
     create_firmware_entry,
     create_vfp_entries,
     sanitize,
+    sanitize_list,
 )
 from storage.schema import AnalysisEntry, FileObjectEntry, FirmwareEntry, VirtualFilePath, included_files_table
 
@@ -112,6 +113,12 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
             result = analysis_dict.get('result', {})
             if result is not None:
                 sanitize(result)
+            summary = analysis_dict.get('summary')
+            if summary is not None:
+                sanitize_list(summary)
+            tags = analysis_dict.get('tags')
+            if tags is not None:
+                sanitize(tags)
 
             analysis = AnalysisEntry(
                 uid=uid,
@@ -119,8 +126,8 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
                 plugin_version=self._sanitize_plugin_version(analysis_dict['plugin_version']),
                 system_version=analysis_dict.get('system_version'),
                 analysis_date=analysis_dict['analysis_date'],
-                summary=analysis_dict.get('summary'),
-                tags=analysis_dict.get('tags'),
+                summary=summary,
+                tags=tags,
                 result=result,
                 file_object=fo_backref,
             )
@@ -207,7 +214,11 @@ class BackendDbInterface(DbInterfaceCommon, ReadWriteDbInterface):
             entry.system_version = analysis_data.get('system_version')
             entry.analysis_date = analysis_data['analysis_date']
             entry.summary = analysis_data.get('summary')
+            if entry.summary is not None:
+                sanitize_list(entry.summary)
             entry.tags = analysis_data.get('tags')
+            if entry.tags is not None:
+                sanitize(entry.tags)
             result = analysis_data.get('result', {})
             if result is not None:
                 sanitize(result)

--- a/src/storage/db_interface_base.py
+++ b/src/storage/db_interface_base.py
@@ -55,7 +55,7 @@ class ReadWriteDbInterface(ReadOnlyDbInterface):
             session.commit()
         except (SQLAlchemyError, DbInterfaceError) as err:
             session.rollback()
-            if 'not JSON serializable' in str(err):
+            if isinstance(err, DbSerializationError) or 'not JSON serializable' in str(err):
                 raise DbSerializationError() from err
             message = 'Database error when trying to write to the database'
             logging.exception(f'{message}: {err}')

--- a/src/storage/db_interface_frontend.py
+++ b/src/storage/db_interface_frontend.py
@@ -13,6 +13,7 @@ from helperFunctions.virtual_file_path import get_some_vfp
 from objects.firmware import Firmware
 from storage.db_interface_common import DbInterfaceCommon
 from storage.query_conversion import build_generic_search_query, build_query_from_dict, query_parent_firmware
+from storage.safe_types import _unescape_string
 from storage.schema import (
     AnalysisEntry,
     FileObjectEntry,
@@ -143,7 +144,7 @@ class FrontEndDbInterface(DbInterfaceCommon):
     def get_tag_list(self) -> list[str]:
         with self.get_read_only_session() as session:
             query = select(func.unnest(FirmwareEntry.firmware_tags)).distinct()
-            return sorted(session.execute(query).scalars())
+            return sorted(_unescape_string(tag) for tag in session.execute(query).scalars())
 
     def get_device_name_dict(self) -> dict[str, dict[str, list[str]]]:
         device_name_dict = {}

--- a/src/storage/db_interface_stats.py
+++ b/src/storage/db_interface_stats.py
@@ -2,20 +2,22 @@ from __future__ import annotations
 
 import logging
 from collections import Counter
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, List, Tuple
+from collections.abc import Callable, Iterable, Iterator
+from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import column, func, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import InstrumentedAttribute, aliased
 
 from storage.db_interface_base import ReadOnlyDbInterface, ReadWriteDbInterface
+from storage.safe_types import _unescape_json, _unescape_string
 from storage.schema import AnalysisEntry, FileObjectEntry, FirmwareEntry, StatsEntry
 
 if TYPE_CHECKING:
     from sqlalchemy.sql import Select
 
-Stats = List[Tuple[str, int]]
-RelativeStats = List[Tuple[str, int, float]]  # stats with relative share as third element
+Stats = list[tuple[str, int]]
+RelativeStats = list[tuple[str, int, float]]  # stats with relative share as third element
 
 
 class StatsUpdateDbInterface(ReadWriteDbInterface):
@@ -143,7 +145,7 @@ class StatsUpdateDbInterface(ReadWriteDbInterface):
             if self._filter_is_not_empty(q_filter):
                 query = self._join_fw_or_fo(query, is_firmware=False)
                 query = query.filter_by(**q_filter)
-            return _sort_tuples(session.execute(query))
+            return _sort_tuples((_unescape_json(value), count) for value, count in session.execute(query))
 
     def count_values_in_summary(self, plugin: str, q_filter: dict | None = None, firmware: bool = False) -> Stats:
         """
@@ -158,7 +160,7 @@ class StatsUpdateDbInterface(ReadWriteDbInterface):
             query = self._join_fw_or_fo(query, firmware)
             if self._filter_is_not_empty(q_filter):
                 query = query.filter_by(**q_filter)
-            return count_occurrences(session.execute(query).scalars())
+            return count_occurrences([_unescape_string(s) for s in session.execute(query).scalars()])
 
     def get_arch_stats(self, q_filter: dict | None = None) -> list[tuple[str, int, str]]:
         """
@@ -182,7 +184,7 @@ class StatsUpdateDbInterface(ReadWriteDbInterface):
             )
             if self._filter_is_not_empty(q_filter):
                 query = query.filter_by(**q_filter)
-            return list(session.execute(query))
+            return [(_unescape_string(arch), count, uid) for arch, count, uid in session.execute(query)]
 
     def get_unpacking_file_types(self, summary_key: str, q_filter: dict | None = None) -> Stats:
         with self.get_read_only_session() as session:
@@ -265,8 +267,9 @@ class StatsUpdateDbInterface(ReadWriteDbInterface):
 
             result = {}
             for software_dict, count in session.execute(query):
-                result.setdefault(software_dict['name'], 0)
-                result[software_dict['name']] += count
+                software = _unescape_json(software_dict)
+                result.setdefault(software['name'], 0)
+                result[software['name']] += count
             return _sort_tuples(result.items())
 
     @staticmethod
@@ -297,7 +300,7 @@ def count_occurrences(result_list: list[str]) -> Stats:
     return _sort_tuples(Counter(result_list).items())
 
 
-def _sort_tuples(query_result: Iterable[Tuple[str, int]]) -> Stats:
+def _sort_tuples(query_result: Iterable[tuple[str, int]]) -> Stats:
     # Sort stats tuples by count in ascending order
     return sorted(
         _convert_to_tuples(query_result), key=lambda e: (e[1], e[0]) if not isinstance(e[0], dict) else (e[1],)

--- a/src/storage/db_interface_stats.py
+++ b/src/storage/db_interface_stats.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from collections import Counter
-from collections.abc import Callable, Iterable, Iterator
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import column, func, select
@@ -14,6 +13,8 @@ from storage.safe_types import _unescape_json, _unescape_string
 from storage.schema import AnalysisEntry, FileObjectEntry, FirmwareEntry, StatsEntry
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Iterator
+
     from sqlalchemy.sql import Select
 
 Stats = list[tuple[str, int]]
@@ -25,11 +26,11 @@ class StatsUpdateDbInterface(ReadWriteDbInterface):
     Statistic module backend interface
     """
 
-    def update_statistic(self, identifier: str, content_dict: dict):
+    def update_statistic(self, identifier: str, content_dict: dict) -> None:
         logging.debug(f'Updating {identifier} statistics')
         try:
             with self.get_read_write_session() as session:
-                entry: StatsEntry = session.get(StatsEntry, identifier)
+                entry: StatsEntry | None = session.get(StatsEntry, identifier)
                 if entry is None:  # no old entry in DB -> create new one
                     entry = StatsEntry(name=identifier, data=content_dict)
                     session.add(entry)
@@ -55,7 +56,7 @@ class StatsUpdateDbInterface(ReadWriteDbInterface):
         aggregation_function: Callable,
         q_filter: dict | None = None,
         firmware: bool = False,
-    ) -> Any:
+    ) -> Any:  # noqa: ANN401
         """
         :param field: The field that is aggregated (e.g. `FileObjectEntry.size`)
         :param aggregation_function: The aggregation function (e.g. `func.sum`)
@@ -85,7 +86,7 @@ class StatsUpdateDbInterface(ReadWriteDbInterface):
             sum_ = session.execute(query).scalar()
             return int(sum_) if sum_ is not None else 0
 
-    def count_distinct_values(self, key: InstrumentedAttribute, q_filter=None) -> Stats:
+    def count_distinct_values(self, key: InstrumentedAttribute, q_filter: dict | None = None) -> Stats:
         """
         Get a sorted list of tuples with all unique values of a column `key` and the count of occurrences.
         E.g. key=FileObjectEntry.file_name, result: [('some.other.file', 1), ('some.file', 2)]
@@ -101,7 +102,7 @@ class StatsUpdateDbInterface(ReadWriteDbInterface):
             return _sort_tuples(session.execute(query))
 
     def count_distinct_in_analysis(
-        self, key: InstrumentedAttribute, plugin: str, firmware: bool = False, q_filter=None
+        self, key: InstrumentedAttribute, plugin: str, firmware: bool = False, q_filter: dict | None = None
     ) -> Stats:
         """
         Count distinct values in analysis results: Get a list of tuples with all unique values of a key `key`
@@ -126,7 +127,9 @@ class StatsUpdateDbInterface(ReadWriteDbInterface):
                 query = query.filter_by(**q_filter)
             return _sort_tuples(session.execute(query))
 
-    def count_distinct_values_in_array(self, key: InstrumentedAttribute, plugin: str, q_filter=None) -> Stats:
+    def count_distinct_values_in_array(
+        self, key: InstrumentedAttribute, plugin: str, q_filter: dict | None = None
+    ) -> Stats:
         """
         Get a list of tuples with all unique values of an array stored under `key` and the count of occurrences.
 
@@ -282,7 +285,7 @@ class StatsUpdateDbInterface(ReadWriteDbInterface):
         return query
 
     @staticmethod
-    def _join_all(query):
+    def _join_all(query: Select) -> Select:
         # join all FOs (root fw objects and included objects)
         query = query.join(FileObjectEntry, AnalysisEntry.uid == FileObjectEntry.uid)
         return query.join(
@@ -307,7 +310,7 @@ def _sort_tuples(query_result: Iterable[tuple[str, int]]) -> Stats:
     )
 
 
-def _convert_to_tuples(query_result) -> Iterator[tuple[str, int]]:
+def _convert_to_tuples(query_result: Iterable[tuple[str, int]]) -> Iterator[tuple[str, int]]:
     # results from the DB query will be of type `Row` and not actual tuples -> convert
     # (otherwise they cannot be serialized as JSON and not be saved in the stats DB)
     return (tuple(item) if not isinstance(item, tuple) else item for item in query_result)
@@ -324,9 +327,9 @@ class StatsDbViewer(ReadOnlyDbInterface):
     Statistic module frontend interface
     """
 
-    def get_statistic(self, identifier) -> dict | None:
+    def get_statistic(self, identifier: str) -> dict | None:
         with self.get_read_only_session() as session:
-            entry: StatsEntry = session.get(StatsEntry, identifier)
+            entry: StatsEntry | None = session.get(StatsEntry, identifier)
             if entry is None:
                 return None
             return self._stats_entry_to_dict(entry)

--- a/src/storage/entry_conversion.py
+++ b/src/storage/entry_conversion.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import logging
+import json
 from datetime import datetime
 from time import time
 from typing import Any
@@ -8,6 +8,7 @@ from typing import Any
 from helperFunctions.data_conversion import convert_time_to_str
 from objects.file import FileObject
 from objects.firmware import Firmware
+from storage.db_interface_base import DbSerializationError
 from storage.schema import AnalysisEntry, FileObjectEntry, FirmwareEntry, VirtualFilePath
 
 
@@ -35,13 +36,6 @@ def file_object_from_entry(
     file_object = FileObject.from_uid(uid=fo_entry.uid, file_name=fo_entry.file_name)
     _populate_fo_data(fo_entry, file_object, analysis_filter, included_files, parents, virtual_file_paths, parent_fw)
     return file_object
-
-
-def _convert_vfp_entries_to_dict(vfp_list: list[VirtualFilePath]) -> dict[str, list[str]]:
-    result = {}
-    for vfp_entry in vfp_list or []:
-        result.setdefault(vfp_entry.parent_uid, []).append(vfp_entry.file_path)
-    return result
 
 
 def _populate_fo_data(
@@ -99,7 +93,6 @@ def create_vfp_entries(file_object: FileObject) -> list[VirtualFilePath]:
 
 
 def create_file_object_entry(file_object: FileObject) -> FileObjectEntry:
-    sanitize(file_object.virtual_file_path)
     return FileObjectEntry(
         uid=file_object.uid,
         sha256=file_object.sha256,
@@ -116,60 +109,66 @@ def create_file_object_entry(file_object: FileObject) -> FileObjectEntry:
     )
 
 
+_JSON_SCALAR_TYPES = (str, int, float, bool, type(None))
+_JSON_CONVERTIBLE_TYPES = (tuple, set, frozenset)
+
+
 def sanitize(analysis_data: dict) -> dict:
     """
     Makes a Python dict JSON compatible so that it can be stored in the database.
-    Null bytes are not legal in PostgreSQL JSON columns, so we remove them.
-    Tuples are not JSON compatible and immutable (i.e. the values cannot be sanitized), so they are converted to lists.
+    Keys that are JSON scalar types (int, float, bool, None) are coerced to strings using the same representation that
+    json.dumps uses. Tuples, sets and frozensets are not JSON compatible and immutable (i.e. the values cannot be
+    sanitized), so they are converted to lists.
+    Any other non-JSON-compatible value or key is rejected with a DbSerializationError.
+    Null bytes and lone surrogates in strings are handled reversibly by the DB types (SafeJSONB/SafeString), so they
+    are not sanitized here.
     """
     for key, value in list(analysis_data.items()):
-        _sanitize_value(analysis_data, key, value)
-        _sanitize_key(analysis_data, key)
+        new_key = _sanitize_key(analysis_data, key)
+        _sanitize_value(analysis_data, new_key, value)
 
     return analysis_data
 
 
+def _sanitize_key(analysis_data: dict, key: Any) -> str:  # noqa: ANN401
+    if not isinstance(key, _JSON_SCALAR_TYPES):
+        raise DbSerializationError(f'key of type {type(key).__name__} is not JSON serializable: {key!r}')
+    if isinstance(key, str):
+        return key
+    str_key = json.dumps(key)  # int/float/bool/None -> '1', '1.5', 'true', 'false', 'null', 'Infinity', 'NaN'
+    analysis_data[str_key] = analysis_data.pop(key)
+    return str_key
+
+
 def _sanitize_value(analysis_data: dict, key: str, value: Any) -> None:  # noqa: ANN401
-    if isinstance(value, tuple):
+    if isinstance(value, _JSON_CONVERTIBLE_TYPES):
         analysis_data[key] = value = list(value)
     if isinstance(value, dict):
         sanitize(value)
-    elif isinstance(value, str):
-        analysis_data[key] = _sanitize_string(value)
     elif isinstance(value, list):
-        _sanitize_list(value)
-    elif isinstance(value, bytes):
-        logging.warning(
-            f'Plugin result contains bytes entry. '
-            f'Plugin results should only contain JSON compatible data structures!:\n\t{value!r}'
+        sanitize_list(value)
+    elif isinstance(value, _JSON_SCALAR_TYPES):
+        pass
+    else:
+        raise DbSerializationError(
+            f'value of type {type(value).__name__} for key {key!r} is not JSON serializable: {value!r}'
         )
-        analysis_data[key] = value.decode(errors='replace')
 
 
-def _sanitize_string(string: str) -> str:
-    string = string.replace('\0', '')
-    try:
-        string.encode()
-    except UnicodeEncodeError:
-        string = string.encode(errors='replace').decode()
-    return string
-
-
-def _sanitize_key(analysis_data: dict, key: str) -> None:
-    if '\0' in key:
-        analysis_data[key.replace('\0', '')] = analysis_data.pop(key)
-
-
-def _sanitize_list(value: list) -> list:
+def sanitize_list(value: list) -> list:
     for index, element in enumerate(list(value)):
-        if isinstance(element, tuple):
+        if isinstance(element, _JSON_CONVERTIBLE_TYPES):
             value[index] = element = list(element)  # noqa: PLW2901
         if isinstance(element, dict):
             sanitize(element)
         elif isinstance(element, list):
-            _sanitize_list(element)
-        elif isinstance(element, str):
-            value[index] = _sanitize_string(element)
+            sanitize_list(element)
+        elif isinstance(element, _JSON_SCALAR_TYPES):
+            pass
+        else:
+            raise DbSerializationError(
+                f'value of type {type(element).__name__} in list is not JSON serializable: {element!r}'
+            )
     return value
 
 
@@ -181,8 +180,8 @@ def create_analysis_entries(file_object: FileObject, fo_backref: FileObjectEntry
             plugin_version=analysis_data.get('plugin_version'),
             system_version=analysis_data.get('system_version'),
             analysis_date=analysis_data.get('analysis_date'),
-            summary=_sanitize_list(analysis_data.get('summary', [])),
-            tags=analysis_data.get('tags'),
+            summary=sanitize_list(analysis_data.get('summary', [])),
+            tags=sanitize(analysis_data.get('tags') or {}),
             result=sanitize(analysis_data.get('result', {})),
             file_object=fo_backref,
         )

--- a/src/storage/migration/versions/c20903c88b30_escape_null_bytes_and_surrogates.py
+++ b/src/storage/migration/versions/c20903c88b30_escape_null_bytes_and_surrogates.py
@@ -1,0 +1,208 @@
+"""Escape null bytes and surrogates in existing data
+
+Revision ID: c20903c88b30
+Revises: 6a1c50ade0f3
+Create Date: 2026-08-27 17:20:36
+
+"""
+
+from __future__ import annotations
+
+import logging
+
+from alembic import op
+from sqlalchemy import Column, ForeignKey, orm, select
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, VARCHAR
+from sqlalchemy.orm import declarative_base
+
+from storage.safe_types import _escape_json, _escape_string, _strip_unsafe_chars, _unescape_json, _unescape_string
+
+# revision identifiers, used by Alembic.
+revision = 'c20903c88b30'
+down_revision = '6a1c50ade0f3'
+branch_labels = None
+depends_on = None
+
+Base = declarative_base()
+UID = VARCHAR(78)
+
+# Plain (non-Safe) models: the escape function is applied manually so that existing data is not escaped twice.
+
+
+class AnalysisEntry(Base):
+    __tablename__ = 'analysis'
+
+    uid = Column(UID, ForeignKey('file_object.uid'), primary_key=True)
+    plugin = Column(VARCHAR(64), primary_key=True)
+    summary = Column(ARRAY(VARCHAR))
+    tags = Column(JSONB)
+    result = Column(JSONB)
+
+
+class FirmwareEntry(Base):
+    __tablename__ = 'firmware'
+
+    uid = Column(UID, ForeignKey('file_object.uid'), primary_key=True)
+    firmware_tags = Column(ARRAY(VARCHAR))
+
+
+class ComparisonEntry(Base):
+    __tablename__ = 'comparison'
+
+    comparison_id = Column(VARCHAR, primary_key=True)
+    data = Column(JSONB)
+
+
+class StatsEntry(Base):
+    __tablename__ = 'stats'
+
+    name = Column(VARCHAR, primary_key=True)
+    data = Column(JSONB, nullable=False)
+
+
+class SearchCacheEntry(Base):
+    __tablename__ = 'search_cache'
+
+    uid = Column(UID, primary_key=True)
+    match_data = Column(JSONB)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    _escape_analysis_entries(session)
+    _escape_firmware_tags(session)
+    _escape_comparison_data(session)
+    _escape_stats_data(session)
+    _escape_search_cache(session)
+
+    session.commit()
+
+
+def _escape_analysis_entries(session: orm.Session) -> None:
+    query = select(AnalysisEntry)
+    for entry in session.execute(query.execution_options(yield_per=1000)).scalars():
+        if entry.result is not None:
+            _escape_json_field(entry, 'result')
+        if entry.tags is not None:
+            _escape_json_field(entry, 'tags')
+        if entry.summary is not None:
+            _escape_list_field(entry, 'summary')
+        _flush_and_release(session, entry)
+
+
+def _escape_firmware_tags(session: orm.Session) -> None:
+    for entry in session.execute(select(FirmwareEntry).execution_options(yield_per=1000)).scalars():
+        if entry.firmware_tags is not None:
+            _escape_list_field(entry, 'firmware_tags')
+        _flush_and_release(session, entry)
+
+
+def _escape_comparison_data(session: orm.Session) -> None:
+    for entry in session.execute(select(ComparisonEntry).execution_options(yield_per=1000)).scalars():
+        if entry.data is not None:
+            _escape_json_field(entry, 'data')
+        _flush_and_release(session, entry)
+
+
+def _escape_stats_data(session: orm.Session) -> None:
+    for entry in session.execute(select(StatsEntry).execution_options(yield_per=1000)).scalars():
+        _escape_json_field(entry, 'data')
+        _flush_and_release(session, entry)
+
+
+def _escape_search_cache(session: orm.Session) -> None:
+    for entry in session.execute(select(SearchCacheEntry).execution_options(yield_per=1000)).scalars():
+        if entry.match_data is not None:
+            _escape_json_field(entry, 'match_data')
+        _flush_and_release(session, entry)
+
+
+def _escape_json_field(entry: object, attribute: str) -> None:
+    value = getattr(entry, attribute)
+    if _unescape_json(value) != value:
+        setattr(entry, attribute, _escape_json(value))
+
+
+def _escape_list_field(entry: object, attribute: str) -> None:
+    value = getattr(entry, attribute)
+    escaped = [_escape_string(s) for s in value]
+    if escaped != value:
+        setattr(entry, attribute, escaped)
+
+
+def _flush_and_release(session: orm.Session, entry: object) -> None:
+    session.flush()
+    session.expunge(entry)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+
+    _unescape_analysis_entries(session)
+    _unescape_firmware_tags(session)
+    _unescape_comparison_data(session)
+    _unescape_stats_data(session)
+    _unescape_search_cache(session)
+
+    session.commit()
+
+
+def _unescape_analysis_entries(session: orm.Session) -> None:
+    for entry in session.execute(select(AnalysisEntry).execution_options(yield_per=1000)).scalars():
+        if entry.result is not None:
+            _unescape_json_field(entry, 'result')
+        if entry.tags is not None:
+            _unescape_json_field(entry, 'tags')
+        if entry.summary is not None:
+            _unescape_list_field(entry, 'summary')
+        _flush_and_release(session, entry)
+
+
+def _unescape_firmware_tags(session: orm.Session) -> None:
+    for entry in session.execute(select(FirmwareEntry).execution_options(yield_per=1000)).scalars():
+        if entry.firmware_tags is not None:
+            _unescape_list_field(entry, 'firmware_tags')
+        _flush_and_release(session, entry)
+
+
+def _unescape_comparison_data(session: orm.Session) -> None:
+    for entry in session.execute(select(ComparisonEntry).execution_options(yield_per=1000)).scalars():
+        if entry.data is not None:
+            _unescape_json_field(entry, 'data')
+        _flush_and_release(session, entry)
+
+
+def _unescape_stats_data(session: orm.Session) -> None:
+    for entry in session.execute(select(StatsEntry).execution_options(yield_per=1000)).scalars():
+        _unescape_json_field(entry, 'data')
+        _flush_and_release(session, entry)
+
+
+def _unescape_search_cache(session: orm.Session) -> None:
+    for entry in session.execute(select(SearchCacheEntry).execution_options(yield_per=1000)).scalars():
+        if entry.match_data is not None:
+            _unescape_json_field(entry, 'match_data')
+        _flush_and_release(session, entry)
+
+
+def _unescape_json_field(entry: object, attribute: str) -> None:
+    value = getattr(entry, attribute)
+    unescaped = _unescape_json(value)
+    stripped = _strip_unsafe_chars(unescaped)
+    if stripped != unescaped:
+        logging.warning(f'Stripped null bytes/surrogates from {type(entry).__name__}.{attribute} during downgrade')
+    if stripped != value:
+        setattr(entry, attribute, stripped)
+
+
+def _unescape_list_field(entry: object, attribute: str) -> None:
+    value = getattr(entry, attribute)
+    unescaped = [_unescape_string(s) for s in value]
+    stripped = [_strip_unsafe_chars(s) for s in unescaped]
+    if stripped != unescaped:
+        logging.warning(f'Stripped null bytes/surrogates from {type(entry).__name__}.{attribute} during downgrade')
+    if stripped != value:
+        setattr(entry, attribute, stripped)

--- a/src/storage/safe_types.py
+++ b/src/storage/safe_types.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.types import String, TypeDecorator
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine import Dialect
+
+_SURROGATE_RANGE = range(0xD800, 0xDFFF + 1)
+_MARKER_PATTERN = re.compile(r'\\\\|\\u([0-9A-Fa-f]{4})')
+_STRIP_PATTERN = re.compile(r'[\0\ud800-\udfff]')
+
+
+def _escape_string(value: str) -> str:
+    escaped = value.replace('\\', '\\\\')
+    escaped = escaped.replace('\0', '\\u0000')
+    return re.sub(r'[\ud800-\udfff]', lambda match: f'\\u{ord(match.group()):04x}', escaped)
+
+
+def _unescape_string(value: str) -> str:
+    def replace(match: re.Match) -> str:
+        if match.group(1) is None:
+            return '\\'
+        code = int(match.group(1), 16)
+        if code == 0 or code in _SURROGATE_RANGE:
+            return chr(code)
+        return match.group(0)
+
+    return _MARKER_PATTERN.sub(replace, value)
+
+
+def _escape_json(value: Any) -> Any:  # noqa: ANN401
+    if isinstance(value, dict):
+        return {_escape_string(k) if isinstance(k, str) else k: _escape_json(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_escape_json(v) for v in value]
+    if isinstance(value, str):
+        return _escape_string(value)
+    return value
+
+
+def _unescape_json(value: Any) -> Any:  # noqa: ANN401
+    if isinstance(value, dict):
+        return {_unescape_string(k) if isinstance(k, str) else k: _unescape_json(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_unescape_json(v) for v in value]
+    if isinstance(value, str):
+        return _unescape_string(value)
+    return value
+
+
+def _strip_unsafe_chars(value: Any) -> Any:  # noqa: ANN401
+    if isinstance(value, dict):
+        return {_strip_unsafe_chars(k) if isinstance(k, str) else k: _strip_unsafe_chars(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_strip_unsafe_chars(v) for v in value]
+    if isinstance(value, str):
+        return _STRIP_PATTERN.sub('', value)
+    return value
+
+
+class SafeString(TypeDecorator):
+    """VARCHAR storing null bytes and lone surrogates in a reversible escaped form."""
+
+    impl = String
+    cache_ok = True
+
+    def coerce_compared_value(self, op, value) -> Any:  # noqa: ANN001, ANN401
+        return self.impl_instance.coerce_compared_value(op, value)
+
+    def process_bind_param(self, value: str | None, dialect: Dialect) -> str | None:  # noqa: ARG002
+        if value is None:
+            return None
+        return _escape_string(value)
+
+    def process_result_value(self, value: str | None, dialect: Dialect) -> str | None:  # noqa: ARG002
+        if value is None:
+            return None
+        return _unescape_string(value)
+
+
+class SafeJSONB(TypeDecorator):
+    """JSONB storing null bytes and lone surrogates in a reversible escaped form."""
+
+    impl = JSONB
+    cache_ok = True
+
+    def coerce_compared_value(self, op, value) -> Any:  # noqa: ANN001, ANN401
+        return self.impl_instance.coerce_compared_value(op, value)
+
+    def process_bind_param(self, value: Any, dialect: Dialect) -> Any:  # noqa: ARG002, ANN401
+        if value is None:
+            return None
+        return _escape_json(value)
+
+    def process_result_value(self, value: Any, dialect: Dialect) -> Any:  # noqa: ARG002, ANN401
+        if value is None:
+            return None
+        return _unescape_json(value)

--- a/src/storage/schema.py
+++ b/src/storage/schema.py
@@ -19,6 +19,8 @@ from sqlalchemy.dialects.postgresql import ARRAY, CHAR, JSONB, VARCHAR
 from sqlalchemy.ext.mutable import MutableDict, MutableList
 from sqlalchemy.orm import Session, backref, declarative_base, mapped_column, relationship
 
+from storage.safe_types import SafeJSONB, SafeString
+
 Base = declarative_base()
 UID = VARCHAR(78)
 
@@ -58,7 +60,7 @@ class AnalysisEntry(Base):
         comment='The date the analysis was performed.',
     )
     summary = mapped_column(
-        ARRAY(VARCHAR, dimensions=1),
+        ARRAY(SafeString, dimensions=1),
         nullable=True,
         comment=(
             'The summary of the analysis. This is an array of strings which represent important results to be'
@@ -66,7 +68,7 @@ class AnalysisEntry(Base):
         ),
     )
     tags = mapped_column(
-        MutableDict.as_mutable(JSONB),
+        MutableDict.as_mutable(SafeJSONB),
         nullable=True,
         comment=(
             'A JSON object containing all tags set by the plugin during analysis. Tags can be propagated, meaning they '
@@ -75,7 +77,7 @@ class AnalysisEntry(Base):
         ),
     )
     result = mapped_column(
-        MutableDict.as_mutable(JSONB),
+        MutableDict.as_mutable(SafeJSONB),
         nullable=True,
         comment='The result of the analysis in JSON format.',
     )
@@ -339,7 +341,7 @@ class FirmwareEntry(Base):
         comment='Which part of the firmware this entry represents (complete, kernel, bootloader, or root FS).',
     )
     firmware_tags = mapped_column(
-        ARRAY(VARCHAR, dimensions=1),
+        ARRAY(SafeString, dimensions=1),
         comment='Tags that were set by the user during upload.',
     )
 
@@ -351,14 +353,14 @@ class ComparisonEntry(Base):
 
     comparison_id = mapped_column(VARCHAR, primary_key=True)
     submission_date = mapped_column(Float, nullable=False)
-    data = mapped_column(MutableDict.as_mutable(JSONB))
+    data = mapped_column(MutableDict.as_mutable(SafeJSONB))
 
 
 class StatsEntry(Base):
     __tablename__ = 'stats'
 
     name = mapped_column(VARCHAR, primary_key=True)
-    data = mapped_column(MutableDict.as_mutable(JSONB), nullable=False)
+    data = mapped_column(MutableDict.as_mutable(SafeJSONB), nullable=False)
 
 
 class SearchCacheEntry(Base):
@@ -367,7 +369,7 @@ class SearchCacheEntry(Base):
     uid = mapped_column(UID, primary_key=True)
     query = mapped_column(VARCHAR, nullable=False)  # the query that searches for the files that the YARA rule matched
     yara_rule = mapped_column(VARCHAR, nullable=False)
-    match_data = mapped_column(MutableDict.as_mutable(JSONB), nullable=True)
+    match_data = mapped_column(MutableDict.as_mutable(SafeJSONB), nullable=True)
 
 
 class WebInterfaceTemplateEntry(Base):

--- a/src/storage/schema.py
+++ b/src/storage/schema.py
@@ -439,7 +439,7 @@ class VirtualFilePath(Base):
 
 
 @event.listens_for(Session, 'persistent_to_deleted')
-def delete_file_orphans(session, deleted_object):
+def delete_file_orphans(session: Session, deleted_object: Base) -> None:
     """
     If a firmware is deleted, delete all "orphaned" files: files that do not belong to any firmware anymore (and also
     are not a firmware themselves).

--- a/src/test/integration/statistic/test_update.py
+++ b/src/test/integration/statistic/test_update.py
@@ -29,10 +29,8 @@ def test_get_mitigation_stats(stats_updater, backend_db):
     assert stats_updater.get_exploit_mitigations_stats() == {'exploit_mitigations': []}
 
     mitigation_plugin_summaries = [
-        [
-            ['RELRO disabled', 'NX disabled', 'CANARY disabled', 'PIE disabled', 'FORTIFY_SOURCE disabled'],
-            ['RELRO disabled', 'NX enabled', 'CANARY enabled', 'PIE disabled', 'FORTIFY_SOURCE disabled'],
-        ]
+        ['RELRO disabled', 'NX disabled', 'CANARY disabled', 'PIE disabled', 'FORTIFY_SOURCE disabled'],
+        ['RELRO disabled', 'NX enabled', 'CANARY enabled', 'PIE disabled', 'FORTIFY_SOURCE disabled'],
     ]
     _add_objects_with_summary('exploit_mitigations', mitigation_plugin_summaries, backend_db)
 
@@ -63,7 +61,7 @@ def test_get_vulnerability_stats(stats_updater, backend_db):
     assert sorted(stats) == [('Heartbleed', 2), ('WPA_Key_Hardcoded', 1)]
 
 
-def _add_objects_with_summary(plugin, summary_list, backend_db):
+def _add_objects_with_summary(plugin, summary_list: list[list[str]], backend_db):
     root_fw = create_test_firmware()
     root_fw.vendor = 'test_vendor'
     root_fw.uid = 'root_fw'
@@ -246,7 +244,9 @@ def test_get_executable_stats(backend_db, stats_updater):
         ('statically linked', 1, 0.25),
         ('section info missing', 1, 0.25),
     ]
-    for (expected_label, expected_count, expected_percentage), (label, count, percentage, _) in zip(expected, stats):
+    for (expected_label, expected_count, expected_percentage), (label, count, percentage, _) in zip(
+        expected, stats, strict=True
+    ):
         assert label == expected_label
         assert count == expected_count
         assert percentage == expected_percentage

--- a/src/test/integration/storage/test_db_interface_backend.py
+++ b/src/test/integration/storage/test_db_interface_backend.py
@@ -217,7 +217,23 @@ def test_insert_analysis(backend_db, common_db):
     assert db_fo.processed_analysis[plugin] == new_analysis_data
 
 
-def test_insert_analysis_error(backend_db, common_db):
+def test_insert_analysis_roundtrip(backend_db, common_db):
+    backend_db.insert_file_object(TEST_FO)
+    analysis = {
+        'analysis_date': 1.0,
+        'plugin_version': '0.1.0',
+        'system_version': '0.1.0',
+        'summary': [],
+        'tags': {},
+        'result': {'key': ('a', 'b\0'), 'foo': 'bar\0', 'surrogate': '\udcc4'},
+    }
+    plugin = 'foo'
+    backend_db.add_analysis(TEST_FO.uid, plugin, analysis)
+    db_fo = common_db.get_object(TEST_FO.uid)
+    assert db_fo.processed_analysis[plugin]['result'] == {'foo': 'bar\0', 'key': ['a', 'b\0'], 'surrogate': '\udcc4'}
+
+
+def test_insert_analysis_bytes_error(backend_db, common_db):
     backend_db.insert_file_object(TEST_FO)
     illegal_analysis = {
         'analysis_date': 1.0,
@@ -225,12 +241,11 @@ def test_insert_analysis_error(backend_db, common_db):
         'system_version': '0.1.0',
         'summary': [],
         'tags': {},
-        'result': {'key': ('a', 'b\0'), 'foo': 'bar\0'},
+        'result': {'key': b'bytes'},
     }
     plugin = 'foo'
     backend_db.add_analysis(TEST_FO.uid, plugin, illegal_analysis)
-    db_fo = common_db.get_object(TEST_FO.uid)
-    assert db_fo.processed_analysis[plugin]['result'] == {'foo': 'bar', 'key': ['a', 'b']}
+    assert plugin not in common_db.get_object(TEST_FO.uid).processed_analysis
 
 
 def test_update_analysis(backend_db, common_db):

--- a/src/test/unit/storage/test_entry_conversion.py
+++ b/src/test/unit/storage/test_entry_conversion.py
@@ -1,6 +1,10 @@
+from datetime import datetime
+from decimal import Decimal
+
 import pytest
 
-from storage.entry_conversion import sanitize
+from storage.db_interface_base import DbSerializationError
+from storage.entry_conversion import sanitize, sanitize_list
 
 
 @pytest.mark.parametrize(
@@ -8,25 +12,100 @@ from storage.entry_conversion import sanitize
     [
         ({}, {}),
         ({'a': 1, 'b': '2'}, {'a': 1, 'b': '2'}),
-        ({'illegal': 'a\0b\0c'}, {'illegal': 'abc'}),
-        ({'nested': {'key': 'a\0b\0c'}}, {'nested': {'key': 'abc'}}),
-        ({'ille\0gal': 'abc'}, {'illegal': 'abc'}),
-        ({'nested': {'key\0': 'abc'}}, {'nested': {'key': 'abc'}}),
-        (
-            {'list': ['item\x001', {'list_in_dict': ['item2\0']}], 'list_in_list': [['a\0b']]},
-            {'list': ['item1', {'list_in_dict': ['item2']}], 'list_in_list': [['ab']]},
-        ),
-        ({'vfp': {'123': ['123|/\udcc4\udcd6\udcdc\udce4\udcf6\udcfc\udcdf']}}, {'vfp': {'123': ['123|/???????']}}),
+        # null bytes and lone surrogates in strings are left untouched (handled by the DB types)
+        ({'illegal': 'a\0b\0c'}, {'illegal': 'a\0b\0c'}),
+        ({'nested': {'key': '\udcc4'}}, {'nested': {'key': '\udcc4'}}),
         (
             {'tuple': ('a', 'b'), 'nested': {'tuple': ('c', 'd')}, 'tuple_in_list': [('e', 'f')]},
             {'tuple': ['a', 'b'], 'nested': {'tuple': ['c', 'd']}, 'tuple_in_list': [['e', 'f']]},
         ),
         (
-            {'tuple_w0': ('a\0', 'b'), 'tuple_in_list_w0': [('a', 'b\0')]},
-            {'tuple_w0': ['a', 'b'], 'tuple_in_list_w0': [['a', 'b']]},
+            {'tuple_in_list': [('a', 'b'), {'t': ('c',)}]},
+            {'tuple_in_list': [['a', 'b'], {'t': ['c']}]},
         ),
+        # scalars are passed through untouched
+        ({'int': 1, 'float': 1.5, 'bool': True, 'none': None}, {'int': 1, 'float': 1.5, 'bool': True, 'none': None}),
     ],
 )
 def test_sanitize(input_dict, expected):
     sanitize(input_dict)
     assert input_dict == expected
+
+
+def test_sanitize_converts_sets():
+    input_dict = {'set': {'a', 'b'}, 'nested': {'set': {'c', 'd'}}}
+    sanitize(input_dict)
+    assert set(input_dict['set']) == {'a', 'b'}
+    assert set(input_dict['nested']['set']) == {'c', 'd'}
+
+
+def test_sanitize_converts_sets_in_lists():
+    input_dict = {'set_in_list': [{'a', 'b'}], 'frozenset_in_list': [frozenset({'c'})]}
+    sanitize(input_dict)
+    assert set(input_dict['set_in_list'][0]) == {'a', 'b'}
+    assert input_dict['frozenset_in_list'] == [['c']]
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected_message'),
+    [
+        (b'bytes', "key 'a'"),
+        ([b'bytes'], 'in list'),
+        ({'nested': b'bytes'}, "key 'nested'"),
+        (datetime(2020, 1, 1), "key 'a'"),
+        ([datetime(2020, 1, 1)], 'in list'),
+        (Decimal('1.5'), "key 'a'"),
+        (object(), "key 'a'"),
+    ],
+)
+def test_sanitize_rejects_non_json_types(value, expected_message):
+    with pytest.raises(DbSerializationError, match=expected_message):
+        sanitize({'a': value})
+
+
+def test_sanitize_list_rejects_non_json_types():
+    with pytest.raises(DbSerializationError, match='in list'):
+        sanitize_list(['a', object()])
+
+
+def test_sanitize_list_converts_containers():
+    value = [('a', 'b'), {'c', 'd'}, frozenset({'e'}), 'g']
+    sanitize_list(value)
+    assert value[0] == ['a', 'b']
+    assert set(value[1]) == {'c', 'd'}
+    assert value[2] == ['e']
+    assert value[3] == 'g'
+
+
+@pytest.mark.parametrize(
+    ('input_dict', 'expected'),
+    [
+        ({1: 'a'}, {'1': 'a'}),
+        ({1.5: 'b'}, {'1.5': 'b'}),
+        ({True: 'c'}, {'true': 'c'}),
+        ({None: 'd'}, {'null': 'd'}),
+        ({'outer': {2: 'x'}}, {'outer': {'2': 'x'}}),
+    ],
+)
+def test_sanitize_coerces_scalar_keys(input_dict, expected):
+    sanitize(input_dict)
+    assert input_dict == expected
+
+
+@pytest.mark.parametrize(
+    'key',
+    [(1, 2), b'k', datetime(2020, 1, 1), object()],
+)
+def test_sanitize_rejects_non_scalar_keys(key):
+    with pytest.raises(DbSerializationError, match='key of type'):
+        sanitize({key: 'a'})
+
+
+def test_sanitize_rejects_non_scalar_keys_nested():
+    with pytest.raises(DbSerializationError, match='key of type'):
+        sanitize({'outer': {(1, 2): 'x'}})
+
+
+def test_sanitize_rejects_non_scalar_keys_in_list():
+    with pytest.raises(DbSerializationError, match='key of type'):
+        sanitize_list([{'k': {(1, 2): 'x'}}])

--- a/src/test/unit/storage/test_safe_types.py
+++ b/src/test/unit/storage/test_safe_types.py
@@ -1,0 +1,102 @@
+import pytest
+
+from storage.safe_types import _escape_json, _escape_string, _strip_unsafe_chars, _unescape_json, _unescape_string
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected_escaped'),
+    [
+        ('plain', 'plain'),
+        ('a\0b', 'a\\u0000b'),
+        ('\\u0000', '\\\\u0000'),
+        ('\\u0041', '\\\\u0041'),
+        ('\\\0', '\\\\\\u0000'),  # backslash + null byte -> doubled backslash + null-byte marker
+        ('\udcc4\udcd6\udcdc', '\\udcc4\\udcd6\\udcdc'),
+        ('a\0\\\0\udcc4\u0041\\\\', 'a\\u0000\\\\\\u0000\\udcc4A\\\\\\\\'),
+        ('back\\slash\\u0000', 'back\\\\slash\\\\u0000'),
+    ],
+)
+def test_escape_string_roundtrip(value, expected_escaped):
+    escaped = _escape_string(value)
+    assert escaped == expected_escaped
+    assert _unescape_string(escaped) == value
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected_unescaped'),
+    [
+        ('\\u0000', '\0'),
+        ('\\udcc4', '\udcc4'),
+        ('\\u0041', '\\u0041'),  # non-marker escape stays as-is
+        ('\\\\', '\\'),
+        ('a\\\\b', 'a\\b'),
+    ],
+)
+def test_unescape_string(value, expected_unescaped):
+    assert _unescape_string(value) == expected_unescaped
+
+
+@pytest.mark.parametrize(
+    'value',
+    [
+        {},
+        {'a': 1, 'b': 'x\0y'},
+        {'nested': {'k': 'v\udcc4'}, 'list': ['a\0', {'x': 'y'}]},
+        {'\0key': 'val', 'key': ['\udcc4', 1, True, None]},
+        [1, 'a\0', {'k': '\udcc4'}],
+        'string\0with\udcc4surrogate',
+        None,
+    ],
+)
+def test_escape_json_roundtrip(value):
+    escaped = _escape_json(value)
+    if isinstance(value, (dict, list)):
+        assert _unescape_json(escaped) == value
+    elif isinstance(value, str):
+        assert _unescape_string(escaped) == value
+    else:
+        assert escaped == value
+
+
+def test_escape_json_preserves_other_types():
+    value = {'int': 1, 'float': 1.5, 'bool': True, 'none': None, 'bytes': b'data'}
+    escaped = _escape_json(value)
+    assert escaped['int'] == 1
+    assert escaped['float'] == 1.5
+    assert escaped['bool'] is True
+    assert escaped['none'] is None
+    assert escaped['bytes'] == b'data'
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        ('plain', 'plain'),
+        ('a\0b', 'ab'),
+        ('\0', ''),
+        ('\ud800\udfff', ''),
+        ('a\0b\udcc4c', 'abc'),
+        ('\u0041\0', 'A'),
+        (None, None),
+        (1, 1),
+        (True, True),
+        (b'data\0', b'data\0'),
+    ],
+)
+def test_strip_unsafe_chars_scalar(value, expected):
+    assert _strip_unsafe_chars(value) == expected
+
+
+def test_strip_unsafe_chars_dict():
+    value = {'key\0name': 'val\0ue', 'nested': {'k': 'v\udcc4'}, 'ok': 'fine'}
+    assert _strip_unsafe_chars(value) == {'keyname': 'value', 'nested': {'k': 'v'}, 'ok': 'fine'}
+
+
+def test_strip_unsafe_chars_list():
+    value = [{'k': '\ud800'}, 'a\0', 'plain']
+    assert _strip_unsafe_chars(value) == [{'k': ''}, 'a', 'plain']
+
+
+def test_strip_unsafe_chars_after_unescape():
+    escaped = _escape_json({'key': 'a\0b\udcc4c'})
+    assert _strip_unsafe_chars(_unescape_json(escaped)) == {'key': 'abc'}


### PR DESCRIPTION
Replace the lossy sanitize (which stripped null bytes and replaced lone surrogates) with reversible escaping via new custom SQLAlchemy types, and switch sanitize to a deny-by-default allowlist that fails early and informatively on any non-JSON-compatible value or key.

- Add SafeString (VARCHAR) and SafeJSONB (JSONB) TypeDecorators that  escape null bytes (\u0000) and lone surrogates on write and unescape  on read, so data round-trips losslessly
- Rework sanitize to allow only JSON scalar types (str, int, float,  bool, None) and convert tuple/set/frozenset to lists (recursively,  including in lists)
- reject any other value type with DbSerializationError naming the  key/type, so failures surface in add_analysis with context instead of  at session.commit() via a generic json.dumps TypeError
- Validate dict keys: coerce int/float/bool/None keys to str via  json.dumps (matching the stored representation) and reject non-scalar  keys (tuple, bytes, datetime, object, ...)
- Add Alembic data migration (c20903c88b30) escaping existing data
- also fixes the exception occurring when trying to use YARA to search for byte strings containing null bytes