### PR TITLE
feat: detect Clash-compatible proxy configuration

### DIFF
--- a/src/plugins/analysis/software_components/signatures/network.yara
+++ b/src/plugins/analysis/software_components/signatures/network.yara
@@ -64,6 +64,36 @@ rule curl
         $a
 }
 
+rule ClashConfiguration
+{
+	meta:
+		software_name = "Clash-compatible proxy"
+		open_source = true
+		website = "https://wiki.metacubex.one/"
+		description = "Clash-compatible proxy configuration identified by its external controller and proxy settings"
+		match_text_files = true
+		// Configuration endpoints are not software versions.
+		version_regex = "(?!)"
+	strings:
+		// Mihomo v1.19.30 RawConfig field names:
+		// https://github.com/MetaCubeX/mihomo/blob/ac017cdd246ce8bd547653d927e7bf77d7ee73d5/config/config.go#L419-L450
+		// Controller syntax: https://wiki.metacubex.one/en/config/general/#external-control-restful-api
+		// RawConfig fields are top-level. Reject indentation so nested examples and
+		// block-scalar text are not mistaken for active configuration.
+		$controller = /(^([\xEF][\xBB][\xBF])?|[\r\n])("external-controller"|'external-controller'|external-controller)[ \t]*:[ \t]*(((localhost|[A-Za-z]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*|((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9]))?:([0-9]{1,4}|[0-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))|"((localhost|[A-Za-z]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*|((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])|\[(::|[0-9A-Fa-f]{1,4}:[0-9A-Fa-f:]*|[0-9A-Fa-f:]*:[0-9A-Fa-f]{1,4})\])?:([0-9]{1,4}|[0-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))"|'((localhost|[A-Za-z]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*|((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])|\[(::|[0-9A-Fa-f]{1,4}:[0-9A-Fa-f:]*|[0-9A-Fa-f:]*:[0-9A-Fa-f]{1,4})\])?:([0-9]{1,4}|[0-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5]))')([ \t]+#[^\r\n]*|[ \t]*)([\r\n]|$)/ ascii
+		$proxy_groups = /(^|[\r\n])("proxy-groups"|'proxy-groups'|proxy-groups)[ \t]*:/ ascii
+		$proxies = /(^|[\r\n])("proxies"|'proxies'|proxies)[ \t]*:/ ascii
+		$rule_providers = /(^|[\r\n])("rule-providers"|'rule-providers'|rule-providers)[ \t]*:/ ascii
+		$subsequent_document = /[\r\n]---([ \t]+#[^\r\n]*)?[ \t]*([\r\n]|$)/ ascii
+	condition:
+		$controller and 1 of ($proxy_groups, $proxies, $rule_providers) and
+		(not $subsequent_document or
+			(@controller < @subsequent_document and
+				(($proxy_groups and @proxy_groups < @subsequent_document) or
+				 ($proxies and @proxies < @subsequent_document) or
+				 ($rule_providers and @rule_providers < @subsequent_document))))
+}
+
 rule dhcp6c
 {
 	meta:

--- a/src/plugins/analysis/software_components/test/data/clash_config.yaml
+++ b/src/plugins/analysis/software_components/test/data/clash_config.yaml
@@ -1,0 +1,6 @@
+external-controller: 127.0.0.1:9090
+proxy-groups:
+  - name: Router
+    type: select
+    proxies:
+      - DIRECT

--- a/src/plugins/analysis/software_components/test/test_plugin_software_components.py
+++ b/src/plugins/analysis/software_components/test/test_plugin_software_components.py
@@ -10,6 +10,7 @@ from ..code.software_components import (
 )
 
 YARA_TEST_FILE = Path(__file__).parent / 'data' / 'yara_test_file'
+CLASH_CONFIG_TEST_FILE = Path(__file__).parent / 'data' / 'clash_config.yaml'
 RULE_TEST_FILE = Path(__file__).parent / 'data/signatures/test_signature.yara'
 
 
@@ -17,6 +18,12 @@ class MockFileTypeResult:
     def __init__(self):
         self.full = 'full type'
         self.mime = 'application/octet-stream'
+
+
+class MockTextFileTypeResult:
+    def __init__(self):
+        self.full = 'ASCII text'
+        self.mime = 'text/plain'
 
 
 @pytest.mark.AnalysisPluginTestConfig(plugin_class=AnalysisPlugin)
@@ -43,6 +50,16 @@ class TestAnalysisPluginSoftwareComponents:
         summary = analysis_plugin.summarize(results)
         assert len(summary) == 1, 'Number of summary results not correct'
         assert 'Test Software 0.1.3' in summary
+
+    def test_analyze_clash_configuration(self, analysis_plugin):
+        with CLASH_CONFIG_TEST_FILE.open('rb') as file_handle:
+            result = analysis_plugin.analyze(file_handle, {}, {'file_type': MockTextFileTypeResult()})
+
+        clash_matches = [match for match in result.software_components if match.rule == 'ClashConfiguration']
+        assert len(clash_matches) == 1
+        assert clash_matches[0].name == 'Clash-compatible proxy'
+        assert clash_matches[0].versions == []
+        assert analysis_plugin.summarize(result) == ['Clash-compatible proxy']
 
     @pytest.mark.parametrize(
         ('version', 'expected_output', 'meta_dict'),

--- a/src/plugins/analysis/software_components/test/test_plugin_software_components_signatures.py
+++ b/src/plugins/analysis/software_components/test/test_plugin_software_components_signatures.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import yara
+
 from test.yara_signature_testing import SignatureTestingMatching, SignatureTestingMeta
 
 TEST_DATA_DIR = Path(__file__).parent / 'data'
@@ -34,3 +36,66 @@ class TestAllSoftwareSignaturesMatched:
     def test_all_signatures_matched(self):
         diff = self.sig_tester.check(SIGNATURE_PATH, TEST_DATA_DIR / 'software_component_test_list.txt')
         assert diff == set(), f'Missing signature for {diff}'
+
+
+def test_clash_configuration_signature():
+    rules = yara.compile(str(SIGNATURE_PATH / 'network.yara'))
+    active_configs = (
+        b'external-controller: 127.0.0.1:9090\nproxy-groups:\n',
+        b'external-controller: :9090\nproxies: []\n',
+        b'external-controller: localhost:9090\r\nrule-providers: {}\r\n',
+        b'external-controller: "[::1]:65535" # local API\nproxies: []\n',
+        b"external-controller: '0.0.0.0:1'\nproxy-groups: []\n",
+        b'external-controller: localhost:0\nproxies: []\n',
+        b'\xef\xbb\xbfexternal-controller: 127.0.0.1:9090\nproxies: []\n',
+        b'---\nexternal-controller: 127.0.0.1:9090\nproxies: []\n',
+        b'external-controller: router.local:9090\nproxies: []\n',
+        b'external-controller: localhost:09090\nproxies: []\n',
+        b'external-controller: 127.0.0.1:9090\nproxies: []\n---\nnotes: second document\n',
+        b'"external-controller": 127.0.0.1:9090\n\'proxies\': []\n',
+        b"external-controller: '[1:2:3:4:5:6:7:8]:9090'\nproxies: []\n",
+        b'external-controller: "[1:2:3:4:5:6:7::]:9090"\nproxies: []\n',
+        b'external-controller: "[1:2:3:4:5:6::8]:9090"\nproxies: []\n',
+        b'external-controller: "[1:2:3:4:5::7:8]:9090"\nproxies: []\n',
+        b'external-controller: "[1:2:3:4::6:7:8]:9090"\nproxies: []\n',
+        b'external-controller: "[1:2:3::5:6:7:8]:9090"\nproxies: []\n',
+        b'external-controller: "[1:2::4:5:6:7:8]:9090"\nproxies: []\n',
+        b'external-controller: "[1::3:4:5:6:7:8]:9090"\nproxies: []\n',
+    )
+    inactive_configs = (
+        b'external-controller:\nproxy-groups:\n',
+        b'external-controller: # disabled\nproxy-groups:\n',
+        b'external-controller: ""\nproxy-groups:\n',
+        b"external-controller: ''\nproxy-groups:\n",
+        b'external-controller: null\nproxies: []\n',
+        b'external-controller: ~\nproxies: []\n',
+        b'external-controller: false\nproxies: []\n',
+        b'external-controller: 0\nproxies: []\n',
+        b'external-controller: localhost:65536\nproxies: []\n',
+        b'external-controller: 256.1.1.1:9090\nproxies: []\n',
+        b'external-controller: 999.999.999.999:9090\nproxies: []\n',
+        b'external-controller: 001.002.003.004:9090\nproxies: []\n',
+        b'external-controller: "[:::]:9090"\nproxies: []\n',
+        b'external-controller: "[:]:9090"\nproxies: []\n',
+        b'external-controller: "[dead.beef]:9090"\nproxies: []\n',
+        b'external-controller: -router.local:9090\nproxies: []\n',
+        b'external-controller: router..local:9090\nproxies: []\n',
+        b'external-controller: 127.0.0.1:9090#not-a-comment\nproxies: []\n',
+        b'external-controller: enabled\nproxies: documented below\n',
+        b'external-controller: "localhost:9090\nproxies: []\n',
+        b'EXTERNAL-CONTROLLER: localhost:9090\nPROXIES: []\n',
+        b'# external-controller: 127.0.0.1:9090\nproxy-groups:\n',
+        b'external-controller: 127.0.0.1:9090\n# proxy-groups:\n',
+        b'example:\n  external-controller: 127.0.0.1:9090\n  proxies: []\n',
+        b'notes: |\n  external-controller: 127.0.0.1:9090\n  proxies: []\n',
+        b'\texternal-controller: 127.0.0.1:9090\n\tproxies: []\n',
+        b'external-controller: 127.0.0.1:9090\n---\nproxies: []\n',
+        b'external-controller: 127.0.0.1:9090\n--- # next document\nproxies: []\n',
+    )
+
+    for config in active_configs:
+        matches = [match for match in rules.match(data=config) if match.rule == 'ClashConfiguration']
+        assert len(matches) == 1
+
+    for config in inactive_configs:
+        assert not any(match.rule == 'ClashConfiguration' for match in rules.match(data=config))


### PR DESCRIPTION
Adds a software-component YARA rule for Clash-compatible proxy configurations.

The rule requires a top-level `external-controller` endpoint together with `proxy-groups`, `proxies`, or `rule-providers`. This limits false positives from comments, nested examples, inactive values, and unrelated YAML documents.

Includes direct positive/negative regression coverage and an end-to-end software-components plugin test.

Validation:

- Pre-commit checks passed
- YARA bundle compiled successfully
- All 24 relevant tests passed

This identifies compatible configuration structure; it does not attribute the firmware to a particular distribution or indicate malicious use.